### PR TITLE
fix(settings): resolve console errors and warnings

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -10,6 +10,8 @@
     "shell:default",
     "shell:allow-open",
     "http:default",
-    "deep-link:default"
+    "deep-link:default",
+    "notification:allow-is-permission-granted",
+    "notification:default"
   ]
 }

--- a/src/components/home/mod.rs
+++ b/src/components/home/mod.rs
@@ -37,8 +37,9 @@ fn handle_sync_result_notifications(
     set_new_badges_event: WriteSignal<Vec<NewBadgeInfo>>,
 ) {
     // Show notification if XP gained (check notification settings)
+    // Use get_untracked() since this is called from event handlers (non-reactive context)
     if sync_result.xp_gained > 0 {
-        let should_show_app_notification = notification_settings.get()
+        let should_show_app_notification = notification_settings.get_untracked()
             .map(|s| {
                 let method = NotificationMethod::from_str(&s.notification_method);
                 method != NotificationMethod::None && method != NotificationMethod::OsOnly
@@ -58,7 +59,7 @@ fn handle_sync_result_notifications(
             
             if sync_result.level_up {
                 // Check if level up notifications are enabled
-                let should_show_level_up = notification_settings.get()
+                let should_show_level_up = notification_settings.get_untracked()
                     .map(|s| s.notify_level_up)
                     .unwrap_or(true);
                 
@@ -67,7 +68,7 @@ fn handle_sync_result_notifications(
                 }
             } else {
                 // Check if XP gain notifications are enabled
-                let should_show_xp = notification_settings.get()
+                let should_show_xp = notification_settings.get_untracked()
                     .map(|s| s.notify_xp_gain)
                     .unwrap_or(true);
                 
@@ -92,7 +93,7 @@ fn handle_sync_result_notifications(
     
     // Show badge notifications if any (check notification settings)
     if !sync_result.new_badges.is_empty() {
-        let should_show_badge_notification = notification_settings.get()
+        let should_show_badge_notification = notification_settings.get_untracked()
             .map(|s| {
                 let method = NotificationMethod::from_str(&s.notification_method);
                 (method != NotificationMethod::None && method != NotificationMethod::OsOnly) && s.notify_badge_earned

--- a/src/components/settings/account_settings.rs
+++ b/src/components/settings/account_settings.rs
@@ -108,10 +108,10 @@ pub fn AccountSettings(
             <div class="flex gap-3">
                 <button
                     class="flex-1 px-4 py-2 rounded-lg bg-gm-accent-cyan/20 hover:bg-gm-accent-cyan/30 text-gm-accent-cyan transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                    disabled=loading.get()
+                    disabled=move || loading.get()
                     on:click=move |_| handle_validate_token()
                 >
-                    {if loading.get() {
+                    {move || if loading.get() {
                         "確認中..."
                     } else {
                         "🔄 トークンを確認"
@@ -119,7 +119,7 @@ pub fn AccountSettings(
                 </button>
                 <button
                     class="flex-1 px-4 py-2 rounded-lg bg-gm-error/20 hover:bg-gm-error/30 text-gm-error transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                    disabled=loading.get()
+                    disabled=move || loading.get()
                     on:click=move |_| set_show_logout_dialog.set(true)
                 >
                     "🚪 ログアウト"

--- a/src/tauri_api.rs
+++ b/src/tauri_api.rs
@@ -376,7 +376,12 @@ pub async fn get_sync_intervals() -> Result<Vec<SyncIntervalOption>, String> {
 
 /// ユーザー設定を更新
 pub async fn update_settings(settings: &UpdateSettingsRequest) -> Result<UserSettings, String> {
-    let args = serde_wasm_bindgen::to_value(settings).unwrap();
+    #[derive(serde::Serialize)]
+    struct Args<'a> {
+        settings: &'a UpdateSettingsRequest,
+    }
+    
+    let args = serde_wasm_bindgen::to_value(&Args { settings }).unwrap();
     let result = invoke("update_settings", args).await;
     
     serde_wasm_bindgen::from_value(result)


### PR DESCRIPTION
## 概要

アプリケーション実行時に発生していたコンソールエラーと警告を修正しました。

## 修正内容

### 🔴 エラー1: `update_settings` コマンドの引数エラー

**問題**: フロントエンドとバックエンドで `update_settings` の引数形式が一致していなかった

**修正**: `src/tauri_api.rs` でsettingsを `settings` キーでラップするように修正

```rust
// Before
let args = serde_wasm_bindgen::to_value(settings).unwrap();

// After
#[derive(serde::Serialize)]
struct Args<'a> {
    settings: &'a UpdateSettingsRequest,
}
let args = serde_wasm_bindgen::to_value(&Args { settings }).unwrap();
```

### 🟡 警告2: Reactive tracking context の外でのシグナルアクセス

**問題**: `view!` マクロ内で `signal.get()` を直接使用していた

**修正**:
- `src/components/home/mod.rs`: イベントハンドラー内の `notification_settings.get()` を `get_untracked()` に変更
- `src/components/settings/account_settings.rs`: `disabled=loading.get()` を `disabled=move || loading.get()` に変更

### 🟠 警告3: 通知権限エラー

**問題**: Tauri の capabilities 設定で通知権限が許可されていなかった

**修正**: `src-tauri/capabilities/default.json` に以下を追加
```json
"notification:allow-is-permission-granted",
"notification:default"
```

## 変更ファイル

- `src/tauri_api.rs` - update_settings関数の引数形式修正
- `src/components/home/mod.rs` - シグナルアクセスの修正
- `src/components/settings/account_settings.rs` - シグナルアクセスの修正
- `src-tauri/capabilities/default.json` - 通知権限追加

## テスト

- [x] `cargo check` (フロントエンド) - 成功
- [x] `cargo check` (バックエンド) - 成功

Fixes #28