### PR TITLE
deps(npm): bump @types/node to ^25.0.2 and tailwindcss to 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,11 +31,11 @@
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2",
-    "@types/node": "^24.10.1",
+    "@types/node": "^25.0.2",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.0",
-    "tailwindcss": "3",
+    "tailwindcss": "4",
     "typescript": "^5.9.3",
     "vite": "^7.2.6"
   }


### PR DESCRIPTION
Manually resolve conflicting dependabot PRs #156 and #157.
- @types/node: ^24.10.1 → ^25.0.2
- tailwindcss: 3 → 4

https://claude.ai/code/session_01QbhwKtin3ajKZu5UEo86Bt
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/development-tools/pull/163" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores（保守）**
  * 開発環境用の依存パッケージをアップデートしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->