### PR TITLE
Implement auth-expired event flow for token revocation detection

### DIFF
--- a/docs/api/AUTH_LIFECYCLE.md
+++ b/docs/api/AUTH_LIFECYCLE.md
@@ -1,0 +1,190 @@
+# 認証ライフサイクル仕様
+
+GitHub Device Flow による認証〜失効検知〜再ログイン誘導までの状態遷移とイ
+ベント設計をまとめたドキュメント。Issue #181 の対応で追加。
+
+## 関連ファイル
+
+| 役割 | パス |
+|------|------|
+| バックエンド: トークン保管 | `src-tauri/src/auth/token.rs` |
+| バックエンド: Device Flow | `src-tauri/src/auth/oauth.rs` |
+| バックエンド: 401 共通ハンドラ | `src-tauri/src/auth/session.rs` |
+| バックエンド: 認証コマンド | `src-tauri/src/commands/auth.rs` |
+| バックエンド: Tauri 起動セットアップ | `src-tauri/src/lib.rs` |
+| バックエンド: 同期スケジューラ | `src-tauri/src/sync_scheduler/runner.rs` |
+| フロント: 認証ストア | `src/stores/authStore.ts` |
+| フロント: イベント購読 | `src/lib/tauri/events.ts` |
+| フロント: 再ログインバナー | `src/components/features/auth/SessionExpiredBanner.tsx` |
+
+## 状態遷移
+
+```
+                         ┌──────────────────────┐
+                         │  LoggedOut           │
+                         │  (token なし)         │
+                         └────────────┬─────────┘
+                                      │
+                          ユーザー操作 │  start_device_flow
+                                      ▼
+                         ┌──────────────────────┐
+                         │  DeviceFlowPending   │
+                         │  (認可待ち / poll)    │
+                         └────────────┬─────────┘
+                                      │
+                       Polling 成功    │  poll_device_token Success
+                                      ▼
+                         ┌──────────────────────┐
+                  ┌──────│  LoggedIn            │◀─────┐
+                  │      │  (token 保持中)        │      │
+                  │      └────────────┬─────────┘      │
+                  │                   │                │
+       手動ログアウト│       401 検出   │ auth-expired   │
+        (logout)   │                   │                │
+                  │                   ▼                │
+                  │      ┌──────────────────────┐      │
+                  │      │  SessionExpired      │      │
+                  │      │  (token 失効済み・     │      │
+                  │      │   バナー表示中)         │      │
+                  │      └────────────┬─────────┘      │
+                  │                   │                │
+                  ▼                   │  再ログイン     │
+       ┌──────────────────────┐      │   完了          │
+       │  LoggedOut           │◀─────┘                 │
+       └──────────┬───────────┘                        │
+                  │                                    │
+                  └────────────────────────────────────┘
+                              再認証成功
+```
+
+## バックエンド側の責務
+
+### トークン検証 (`TokenManager::validate_token`)
+
+`GET /user` を Bearer 付きで叩いて以下を返す:
+
+| GitHub レスポンス | 戻り値 | ハンドラ動作 |
+|--------------------|--------|--------------|
+| 2xx | `Ok(true)` | なにもしない（正常） |
+| 401 Unauthorized | `Ok(false)` | 呼び出し側で `handle_unauthorized` を起動 |
+| 5xx / 通信エラー | `Err(_)` | **強制ログアウトしない**（ネットワーク不調と区別） |
+
+ネットワーク不調で勝手にログアウトされると UX が破壊されるため、`Err` を
+受け取った呼び出し側はセッションをそのまま温存する。
+
+### 共通 401 ハンドラ (`auth::session::handle_unauthorized`)
+
+役割:
+
+1. `TokenManager::logout` で DB のトークンを破棄
+2. `auth-expired` イベントを `app.emit` で発火
+
+冪等で、複数回呼ばれても害はない（保管済みトークンが既に空なら no-op、フロ
+ント側のリスナーは重複イベントを無視する）。
+
+### 401 検出ポイント
+
+| 場所 | きっかけ | reason 値 |
+|------|----------|-----------|
+| GitHub コマンド全般 | `map_github_result` ヘルパー経由 | `github_unauthorized` |
+| 起動時セッション検証 | `lib.rs::setup` → `run_startup_token_validation` | `startup_validation_failed` |
+| 手動 `validate_token` コマンド | UI からの明示的検証 | `manual_validation_failed` |
+| バックグラウンド同期 | `sync_scheduler::runner` の失敗時に `classify_unauthorized` 真 | `scheduler_unauthorized` |
+
+`map_github_result` の使い方:
+
+```rust
+let github_stats =
+    map_github_result(&app, state.inner(), client.get_user_stats(&user.username).await).await?;
+```
+
+これだけで「401 → トークン破棄 + イベント emit」までの導線が共通化される。
+新しい GitHub API コマンドを追加するときも同じパターンで包む。
+
+### 起動時検証 (`run_startup_token_validation`)
+
+`lib.rs` の `setup` フック内で `tauri::async_runtime::spawn` から非同期で
+呼ぶ。スプラッシュ表示や初回描画をブロックしない。
+
+判定ロジック:
+
+```
+if no current user → no-op
+if validate_token == Ok(true)  → no-op
+if validate_token == Ok(false) → handle_unauthorized(STARTUP_VALIDATION_FAILED)
+if validate_token == Err(_)    → no-op (ネットワーク不調)
+```
+
+### スケジューラとの統合
+
+`sync_scheduler::runner::run_loop` は `run_github_sync` の戻り値文字列を
+`classify_unauthorized` で判定する。マッチしたら:
+
+1. `handle_unauthorized` を発火（`SCHEDULER_UNAUTHORIZED`）
+2. 即座に `wait_for_change_or_timeout` でループのトップへ戻る
+3. 次の反復で `get_current_user` が `None` を返すので「未ログイン」分岐に
+   入り、ユーザーが再ログインするまで同期を停止する
+
+## フロント側の責務
+
+### `auth-expired` イベントの購読
+
+`src/stores/authStore.ts` のモジュールロード時に
+`events.onAuthExpired` を購読する。受信時:
+
+```ts
+useAuth.setState({
+  state: { isLoggedIn: false, user: null },
+  authExpired: event,
+  isLoading: false,
+});
+```
+
+これで:
+
+- `isLoggedIn` が `false` になるため、各ページの「ログイン済みなら API を
+  叩く」分岐が自動で停止する → 401 受信後の API 呼び出し抑止が実現する
+- `Home` ページなどは自動的に `LoginCard` を再表示する
+- グローバルバナー (`SessionExpiredBanner`) が表示され、ユーザーへ再ログイン
+  を促す
+
+### 再ログインフロー
+
+1. `SessionExpiredBanner` の「再ログイン」ボタンをクリック
+2. `dismiss()` でバナーを閉じ、`/` (Home) へルーティング
+3. `Home` が `LoginCard` を表示
+4. 通常の Device Flow → 成功 → `fetchAuthState` → `state.isLoggedIn = true`
+5. `fetchAuthState` 内で `authExpired` を自動的に `null` にクリア
+
+### キャッシュ読み取りの扱い
+
+GitHub API 呼び出しは `isLoggedIn === false` で抑止される。ローカル DB の
+キャッシュ (`get_github_stats_with_cache` 等) も同じく抑止対象だが、ユーザ
+ーが再ログインすれば即座に最新化される。
+
+## イベントペイロード
+
+```ts
+interface AuthExpiredEvent {
+  /** マシン可読な理由コード */
+  reason: string;
+  /** UI に表示する日本語メッセージ */
+  message: string;
+}
+```
+
+`reason` は `src-tauri/src/auth/session.rs::reasons` モジュールに定数化さ
+れている。新しい検出ポイントを追加する際は、まず定数を追加してから emit
+する。
+
+## 既知の制約
+
+- GitHub Device Flow のアクセストークンは原則として失効しない。明示的に
+  `https://github.com/settings/applications` から取り消されたケースが主な
+  401 原因。
+- 401 検出は呼び出しが行われるたびに評価されるため、長時間 API を叩かない
+  ユーザーは「失効を検知できる契機がない」可能性がある。本実装では起動時
+  の `run_startup_token_validation` と、バックグラウンド同期スケジューラ
+  の周期実行でカバーしている。
+- 通信障害（タイムアウト・5xx）は強制ログアウトの対象外。ネットワーク復
+  旧後に自動で API が再開する。

--- a/src-tauri/src/auth/mod.rs
+++ b/src-tauri/src/auth/mod.rs
@@ -5,9 +5,14 @@
 
 pub mod crypto;
 pub mod oauth;
+pub mod session;
 pub mod token;
 
 pub use oauth::{
     AuthToken, DeviceCodeResponse, DeviceFlow, DeviceFlowConfig, DeviceTokenStatus, OAuthError,
+};
+pub use session::{
+    classify_unauthorized, handle_unauthorized, map_github_result, reasons, AuthExpiredEvent,
+    AUTH_EXPIRED_EVENT,
 };
 pub use token::{AuthState, TokenManager, UserInfo};

--- a/src-tauri/src/auth/session.rs
+++ b/src-tauri/src/auth/session.rs
@@ -1,0 +1,180 @@
+//! Session lifecycle helpers
+//!
+//! Centralizes the response to GitHub `401 Unauthorized` errors so every
+//! command — both frontend-invoked and scheduler-driven — converges on the
+//! same behavior:
+//!
+//! 1. Clear the stored access token (`TokenManager::logout`) so subsequent
+//!    calls don't keep retrying with a known-bad credential.
+//! 2. Emit `auth-expired` so the frontend can surface a re-login banner /
+//!    modal and stop firing API requests until the user re-authenticates.
+//!
+//! See Issue #181.
+
+use tauri::{AppHandle, Emitter};
+
+use crate::commands::auth::AppState;
+use crate::github::client::GitHubError;
+
+/// Tauri event name emitted whenever the backend detects that the current
+/// GitHub token is no longer valid (revoked, expired, or otherwise rejected).
+pub const AUTH_EXPIRED_EVENT: &str = "auth-expired";
+
+/// Reason codes carried in [`AuthExpiredEvent::reason`].
+///
+/// Kept as `&'static str` rather than an enum so additional sources (sync
+/// scheduler, startup validation, individual commands) can attach their own
+/// context without forcing a breaking change in the frontend payload.
+pub mod reasons {
+    /// A GitHub REST/GraphQL call returned `401 Unauthorized`.
+    pub const GITHUB_UNAUTHORIZED: &str = "github_unauthorized";
+    /// The startup `validate_token` probe failed.
+    pub const STARTUP_VALIDATION_FAILED: &str = "startup_validation_failed";
+    /// The user explicitly invoked `validate_token` and it returned false.
+    pub const MANUAL_VALIDATION_FAILED: &str = "manual_validation_failed";
+    /// The background sync scheduler observed a 401 from `run_github_sync`.
+    pub const SCHEDULER_UNAUTHORIZED: &str = "scheduler_unauthorized";
+}
+
+/// Payload for the `auth-expired` event consumed by the frontend.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct AuthExpiredEvent {
+    /// Machine-readable reason code (see [`reasons`]).
+    pub reason: String,
+    /// Human-readable Japanese message safe to show in the UI verbatim.
+    pub message: String,
+}
+
+impl AuthExpiredEvent {
+    /// Build the default Japanese message paired with a reason code.
+    pub fn new(reason: &str) -> Self {
+        Self {
+            reason: reason.to_string(),
+            message:
+                "GitHub の認証が切れました。再度ログインして連携をやり直してください。"
+                    .to_string(),
+        }
+    }
+}
+
+/// Clear the stored credential and notify the frontend that the session is
+/// no longer valid.
+///
+/// Idempotent: callers that hit multiple 401s in a row (e.g. parallel API
+/// fan-out inside a single sync) can invoke this repeatedly without ill
+/// effect — `TokenManager::logout` is a no-op once the user has been cleared,
+/// and the frontend listener tolerates duplicate events.
+pub async fn handle_unauthorized(app: &AppHandle, state: &AppState, reason: &str) {
+    if let Err(e) = state.token_manager.logout().await {
+        // Token cleanup is best-effort: we still want to emit the event so
+        // the UI surfaces the re-login prompt even if the DB write failed.
+        // TODO: [INFRA] logクレートに置換（ログ基盤整備時に一括対応）
+        eprintln!(
+            "Auth: failed to clear stored tokens during 401 handling ({}): {}",
+            reason, e
+        );
+    }
+
+    let payload = AuthExpiredEvent::new(reason);
+    if let Err(e) = app.emit(AUTH_EXPIRED_EVENT, &payload) {
+        // TODO: [INFRA] logクレートに置換（ログ基盤整備時に一括対応）
+        eprintln!(
+            "Auth: failed to emit '{}' event ({}): {}",
+            AUTH_EXPIRED_EVENT, reason, e
+        );
+    }
+}
+
+/// Bridge a typed [`GitHubError`] result into the `Result<T, String>` that
+/// Tauri commands return, while transparently triggering the auth-expired
+/// flow whenever the GitHub API responded with `401 Unauthorized`.
+///
+/// Use this at every call-site that previously did `.map_err(|e| e.to_string())`
+/// on a `GitHubResult<T>`. Non-auth errors are stringified unchanged so the
+/// existing scheduler / UI error-classification logic keeps working.
+pub async fn map_github_result<T>(
+    app: &AppHandle,
+    state: &AppState,
+    result: Result<T, GitHubError>,
+) -> Result<T, String> {
+    match result {
+        Ok(v) => Ok(v),
+        Err(GitHubError::Unauthorized) => {
+            handle_unauthorized(app, state, reasons::GITHUB_UNAUTHORIZED).await;
+            Err(GitHubError::Unauthorized.to_string())
+        }
+        Err(e) => Err(e.to_string()),
+    }
+}
+
+/// Detect whether a stringified error originated from a GitHub 401 response.
+///
+/// `run_github_sync` (and other helpers used by the scheduler) flatten typed
+/// errors into `String`, so the scheduler has to match on the formatted
+/// message. We anchor on the canonical [`GitHubError::Unauthorized`] Display
+/// output ("Authentication failed") and also accept the explicit
+/// "Unauthorized" tag emitted by [`map_github_result`].
+pub fn classify_unauthorized(err_msg: &str) -> bool {
+    let lower = err_msg.to_lowercase();
+    lower.contains("authentication failed") || lower.contains("unauthorized")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn auth_expired_event_carries_reason() {
+        let event = AuthExpiredEvent::new(reasons::GITHUB_UNAUTHORIZED);
+        assert_eq!(event.reason, "github_unauthorized");
+        assert!(event.message.contains("再"));
+    }
+
+    #[test]
+    fn auth_expired_event_serializes_camel_case() {
+        let event = AuthExpiredEvent::new(reasons::SCHEDULER_UNAUTHORIZED);
+        let json = serde_json::to_string(&event).expect("serialize");
+        // camelCase rename means the field stays "reason" (already lowercase)
+        // and "message" stays "message"; the assertion checks the payload
+        // shape the frontend listener expects.
+        assert!(json.contains("\"reason\":\"scheduler_unauthorized\""));
+        assert!(json.contains("\"message\":"));
+    }
+
+    #[test]
+    fn classify_unauthorized_recognizes_github_error_display() {
+        let msg = format!("{}", GitHubError::Unauthorized);
+        assert!(classify_unauthorized(&msg));
+    }
+
+    #[test]
+    fn classify_unauthorized_recognizes_explicit_tag() {
+        assert!(classify_unauthorized(
+            "Unauthorized: GitHub token is invalid or revoked"
+        ));
+        assert!(classify_unauthorized("UNAUTHORIZED"));
+    }
+
+    #[test]
+    fn classify_unauthorized_rejects_unrelated() {
+        assert!(!classify_unauthorized("rate limit exceeded. resets at 123"));
+        assert!(!classify_unauthorized("network error"));
+        assert!(!classify_unauthorized("Resource not found: /user"));
+    }
+
+    #[test]
+    fn auth_expired_event_constants_are_distinct() {
+        // Defensive: prevent accidental shadowing if reasons are renamed.
+        let names = [
+            reasons::GITHUB_UNAUTHORIZED,
+            reasons::STARTUP_VALIDATION_FAILED,
+            reasons::MANUAL_VALIDATION_FAILED,
+            reasons::SCHEDULER_UNAUTHORIZED,
+        ];
+        let mut seen = std::collections::HashSet::new();
+        for n in names {
+            assert!(seen.insert(n), "duplicate reason code: {}", n);
+        }
+    }
+}

--- a/src-tauri/src/auth/session.rs
+++ b/src-tauri/src/auth/session.rs
@@ -111,12 +111,20 @@ pub async fn map_github_result<T>(
 ///
 /// `run_github_sync` (and other helpers used by the scheduler) flatten typed
 /// errors into `String`, so the scheduler has to match on the formatted
-/// message. We anchor on the canonical [`GitHubError::Unauthorized`] Display
-/// output ("Authentication failed") and also accept the explicit
-/// "Unauthorized" tag emitted by [`map_github_result`].
+/// message. We anchor on:
+///
+/// - `"authentication failed"` — canonical [`GitHubError::Unauthorized`]
+///   Display output (REST 401, and after PR #199 GraphQL 401 too).
+/// - `"unauthorized"` — explicit tag emitted by [`map_github_result`].
+/// - `"bad credentials"` — defense in depth for any code path that still
+///   surfaces a GitHub error body verbatim (e.g. a future endpoint that
+///   doesn't go through the typed mapping). GitHub uses this exact phrase
+///   in its 401 response payloads on both REST and GraphQL.
 pub fn classify_unauthorized(err_msg: &str) -> bool {
     let lower = err_msg.to_lowercase();
-    lower.contains("authentication failed") || lower.contains("unauthorized")
+    lower.contains("authentication failed")
+        || lower.contains("unauthorized")
+        || lower.contains("bad credentials")
 }
 
 #[cfg(test)]
@@ -153,6 +161,18 @@ mod tests {
             "Unauthorized: GitHub token is invalid or revoked"
         ));
         assert!(classify_unauthorized("UNAUTHORIZED"));
+    }
+
+    #[test]
+    fn classify_unauthorized_recognizes_github_bad_credentials_body() {
+        // Defense in depth: if any code path ever surfaces a raw GitHub 401
+        // response body (REST or GraphQL) without going through the typed
+        // GitHubError::Unauthorized mapping, the scheduler classifier must
+        // still detect it. Regression for PR #199 review (Devin).
+        assert!(classify_unauthorized(
+            "API error: {\"message\":\"Bad credentials\",\"documentation_url\":\"https://docs.github.com/...\"}"
+        ));
+        assert!(classify_unauthorized("BAD CREDENTIALS"));
     }
 
     #[test]

--- a/src-tauri/src/auth/session.rs
+++ b/src-tauri/src/auth/session.rs
@@ -51,9 +51,8 @@ impl AuthExpiredEvent {
     pub fn new(reason: &str) -> Self {
         Self {
             reason: reason.to_string(),
-            message:
-                "GitHub の認証が切れました。再度ログインして連携をやり直してください。"
-                    .to_string(),
+            message: "GitHub の認証が切れました。再度ログインして連携をやり直してください。"
+                .to_string(),
         }
     }
 }

--- a/src-tauri/src/auth/token.rs
+++ b/src-tauri/src/auth/token.rs
@@ -124,7 +124,14 @@ impl TokenManager {
         Ok(())
     }
 
-    /// Validate that a token is working by making a test API call
+    /// Validate that a token is working by making a test API call.
+    ///
+    /// Returns:
+    /// - `Ok(true)` when the API call succeeded (token is currently accepted)
+    /// - `Ok(false)` when GitHub responded with 401 (token revoked / invalid)
+    /// - `Err(_)` for transport / non-401 HTTP failures so callers can
+    ///   distinguish "definitely revoked" from "couldn't reach GitHub" — the
+    ///   latter must NOT trigger a forced logout.
     pub async fn validate_token(&self, access_token: &str) -> TokenResult<bool> {
         let client = reqwest::Client::new();
         let response = client
@@ -135,6 +142,9 @@ impl TokenManager {
             .await
             .map_err(OAuthError::from)?;
 
+        if response.status() == reqwest::StatusCode::UNAUTHORIZED {
+            return Ok(false);
+        }
         Ok(response.status().is_success())
     }
 }

--- a/src-tauri/src/auth/token.rs
+++ b/src-tauri/src/auth/token.rs
@@ -142,10 +142,23 @@ impl TokenManager {
             .await
             .map_err(OAuthError::from)?;
 
-        if response.status() == reqwest::StatusCode::UNAUTHORIZED {
+        let status = response.status();
+        if status == reqwest::StatusCode::UNAUTHORIZED {
             return Ok(false);
         }
-        Ok(response.status().is_success())
+        if status.is_success() {
+            return Ok(true);
+        }
+        // Non-401, non-success status (403 rate-limited / abuse-blocked, 5xx
+        // server error, etc.). Surface as Err so callers can distinguish
+        // "definitely revoked" from "GitHub is having issues" and avoid a
+        // forced logout — see the lifecycle contract documented above and in
+        // docs/api/AUTH_LIFECYCLE.md.
+        Err(OAuthError::TokenExchange(format!(
+            "Unexpected status from GitHub /user during token validation: {}",
+            status
+        ))
+        .into())
     }
 }
 
@@ -186,4 +199,35 @@ mod tests {
 
     // Integration tests would require a running database
     // Unit tests for the crypto layer are in crypto.rs
+
+    /// Compile-time regression for the `validate_token` three-way contract.
+    ///
+    /// The body of `validate_token` itself can't be unit-tested without an
+    /// HTTP mock, but we can at least lock in the documented mapping at the
+    /// type / status-code level so a future refactor doesn't silently
+    /// re-introduce the "Ok(false) for any non-success status" bug
+    /// (Issue #181 review feedback) that would force-logout users on
+    /// transient 5xx / 403 responses.
+    #[test]
+    fn validate_token_status_mapping_contract() {
+        // 2xx → Ok(true)
+        assert!(reqwest::StatusCode::OK.is_success());
+        // 401 → Ok(false) — only this status maps to the auth-expired flow.
+        assert_eq!(
+            reqwest::StatusCode::UNAUTHORIZED,
+            reqwest::StatusCode::from_u16(401).unwrap()
+        );
+        // 403 / 5xx must NOT be is_success() AND must not equal UNAUTHORIZED,
+        // so they take the Err branch in the implementation.
+        for code in [403u16, 500, 502, 503, 504] {
+            let status = reqwest::StatusCode::from_u16(code).unwrap();
+            assert!(!status.is_success(), "{} should not be success", code);
+            assert_ne!(
+                status,
+                reqwest::StatusCode::UNAUTHORIZED,
+                "{} should not equal 401",
+                code
+            );
+        }
+    }
 }

--- a/src-tauri/src/auth/token.rs
+++ b/src-tauri/src/auth/token.rs
@@ -30,13 +30,22 @@ pub type TokenResult<T> = Result<T, TokenError>;
 pub struct TokenManager {
     crypto: Crypto,
     db: Database,
+    /// Shared HTTP client so the periodic / startup `validate_token` probes
+    /// reuse the underlying connection pool instead of spinning up a fresh
+    /// TCP+TLS handshake per call. `reqwest::Client` is internally `Arc`-wrapped
+    /// so cloning is cheap and the manager itself stays trivially `Send + Sync`.
+    http_client: reqwest::Client,
 }
 
 impl TokenManager {
     /// Create a new token manager
     pub fn new(db: Database) -> TokenResult<Self> {
         let crypto = Crypto::from_app_key()?;
-        Ok(Self { crypto, db })
+        Ok(Self {
+            crypto,
+            db,
+            http_client: reqwest::Client::new(),
+        })
     }
 
     /// Save tokens for a user
@@ -133,8 +142,8 @@ impl TokenManager {
     ///   distinguish "definitely revoked" from "couldn't reach GitHub" — the
     ///   latter must NOT trigger a forced logout.
     pub async fn validate_token(&self, access_token: &str) -> TokenResult<bool> {
-        let client = reqwest::Client::new();
-        let response = client
+        let response = self
+            .http_client
             .get("https://api.github.com/user")
             .header("Authorization", format!("Bearer {}", access_token))
             .header("User-Agent", "development-tools")
@@ -142,23 +151,16 @@ impl TokenManager {
             .await
             .map_err(OAuthError::from)?;
 
-        let status = response.status();
-        if status == reqwest::StatusCode::UNAUTHORIZED {
+        if response.status() == reqwest::StatusCode::UNAUTHORIZED {
             return Ok(false);
         }
-        if status.is_success() {
-            return Ok(true);
-        }
         // Non-401, non-success status (403 rate-limited / abuse-blocked, 5xx
-        // server error, etc.). Surface as Err so callers can distinguish
-        // "definitely revoked" from "GitHub is having issues" and avoid a
-        // forced logout — see the lifecycle contract documented above and in
-        // docs/api/AUTH_LIFECYCLE.md.
-        Err(OAuthError::TokenExchange(format!(
-            "Unexpected status from GitHub /user during token validation: {}",
-            status
-        ))
-        .into())
+        // server error, etc.) becomes an `Err` via `error_for_status` so
+        // callers can distinguish "definitely revoked" from "GitHub is having
+        // issues" and avoid a forced logout — see the lifecycle contract
+        // documented above and in docs/api/AUTH_LIFECYCLE.md.
+        response.error_for_status().map_err(OAuthError::from)?;
+        Ok(true)
     }
 }
 

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -168,7 +168,10 @@ pub async fn run_startup_token_validation(app: AppHandle, state: &AppState) {
     let access_token = match state.token_manager.get_access_token().await {
         Ok(t) => t,
         Err(e) => {
-            eprintln!("Startup auth check: failed to load token for {}: {}", user.id, e);
+            eprintln!(
+                "Startup auth check: failed to load token for {}: {}",
+                user.id, e
+            );
             return;
         }
     };

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -4,12 +4,12 @@
 //! Device Flow is recommended for desktop apps as it doesn't require client_secret.
 
 use std::sync::Arc;
-use tauri::{command, State};
+use tauri::{command, AppHandle, State};
 use tokio::sync::Mutex;
 
 use crate::auth::{
-    AuthState, AuthToken, DeviceCodeResponse, DeviceFlow, DeviceFlowConfig, DeviceTokenStatus,
-    OAuthError, TokenManager, UserInfo,
+    handle_unauthorized, reasons, AuthState, AuthToken, DeviceCodeResponse, DeviceFlow,
+    DeviceFlowConfig, DeviceTokenStatus, OAuthError, TokenManager, UserInfo,
 };
 use crate::database::Database;
 use crate::github::GitHubClient;
@@ -104,8 +104,12 @@ pub async fn get_current_user(state: State<'_, AppState>) -> Result<Option<UserI
 /// Note: GitHub Device Flow tokens don't expire, but users can revoke them manually.
 /// This command checks if the current token is still valid by making a test API call.
 /// Returns `Ok(false)` if the user is not logged in.
+///
+/// Side effect: when GitHub responds with 401 (token revoked), the stored
+/// credential is cleared and the `auth-expired` event is emitted so the
+/// frontend can surface a re-login prompt without polling.
 #[command]
-pub async fn validate_token(state: State<'_, AppState>) -> Result<bool, String> {
+pub async fn validate_token(app: AppHandle, state: State<'_, AppState>) -> Result<bool, String> {
     // Check if user is logged in first
     let user = state
         .token_manager
@@ -129,7 +133,66 @@ pub async fn validate_token(state: State<'_, AppState>) -> Result<bool, String> 
         .await
         .map_err(|e| e.to_string())?;
 
+    if !is_valid {
+        // Token is definitively rejected by GitHub — clear it and notify the
+        // UI. Transport / network errors take the `Err` branch above and
+        // intentionally do NOT trigger a forced logout (see
+        // `TokenManager::validate_token`'s contract).
+        handle_unauthorized(&app, state.inner(), reasons::MANUAL_VALIDATION_FAILED).await;
+    }
+
     Ok(is_valid)
+}
+
+/// Best-effort startup probe of the persisted token.
+///
+/// Called from `lib.rs` setup *after* the Tauri runtime is ready so the
+/// `auth-expired` emit has a working app handle. Runs in a background task
+/// so it never delays splash → first paint, and silently no-ops when:
+/// - no user is logged in, or
+/// - GitHub is unreachable (transport error) — we don't want a flaky network
+///   on launch to log the user out.
+///
+/// Only a confirmed 401 from GitHub clears the token.
+pub async fn run_startup_token_validation(app: AppHandle, state: &AppState) {
+    let user = match state.token_manager.get_current_user().await {
+        Ok(Some(u)) => u,
+        Ok(None) => return,
+        Err(e) => {
+            // TODO: [INFRA] logクレートに置換（ログ基盤整備時に一括対応）
+            eprintln!("Startup auth check: failed to read current user: {}", e);
+            return;
+        }
+    };
+
+    let access_token = match state.token_manager.get_access_token().await {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("Startup auth check: failed to load token for {}: {}", user.id, e);
+            return;
+        }
+    };
+
+    match state.token_manager.validate_token(&access_token).await {
+        Ok(true) => {
+            // Token still works — nothing to do.
+        }
+        Ok(false) => {
+            eprintln!(
+                "Startup auth check: GitHub rejected the stored token for user {}; clearing session",
+                user.id
+            );
+            handle_unauthorized(&app, state, reasons::STARTUP_VALIDATION_FAILED).await;
+        }
+        Err(e) => {
+            // Transport failure — leave the session alone so a flaky
+            // network on launch doesn't sign the user out.
+            eprintln!(
+                "Startup auth check: validate_token failed for user {} ({}); leaving session intact",
+                user.id, e
+            );
+        }
+    }
 }
 
 // ============================================

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -181,6 +181,30 @@ pub async fn run_startup_token_validation(app: AppHandle, state: &AppState) {
             // Token still works — nothing to do.
         }
         Ok(false) => {
+            // Re-check the active credential before clearing it. The user
+            // could have re-authenticated (or logged out, then back in as a
+            // different account) while the GitHub probe was in flight; the
+            // 401 we just observed applies to a token that's already been
+            // replaced. Forcing a logout here would wipe the freshly saved
+            // session and immediately undo the user's re-login.
+            //
+            // Compare the decrypted token rather than just the user id so an
+            // account-swap to the *same* GitHub user (rare, but possible
+            // after a manual revoke + re-grant) is also caught.
+            let still_same = match state.token_manager.get_access_token().await {
+                Ok(current) => current == access_token,
+                // NotLoggedIn / decrypt failure → user state changed under
+                // us; either way, don't clobber it.
+                Err(_) => false,
+            };
+            if !still_same {
+                eprintln!(
+                    "Startup auth check: stored token for user {} changed during validation; skipping logout",
+                    user.id
+                );
+                return;
+            }
+
             eprintln!(
                 "Startup auth check: GitHub rejected the stored token for user {}; clearing session",
                 user.id

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -2,9 +2,10 @@
 //!
 //! These commands handle fetching data from the GitHub API.
 
-use tauri::{command, Emitter, State};
+use tauri::{command, AppHandle, Emitter, State};
 
 use super::auth::AppState;
+use crate::auth::map_github_result;
 use crate::database::{
     badge, challenge, level, streak, xp, GitHubStatsSnapshot, UserStats, XpActionType,
 };
@@ -13,7 +14,10 @@ use crate::utils::notifications::send_notification;
 
 /// Get GitHub user profile
 #[command]
-pub async fn get_github_user(state: State<'_, AppState>) -> Result<GitHubUser, String> {
+pub async fn get_github_user(
+    app: AppHandle,
+    state: State<'_, AppState>,
+) -> Result<GitHubUser, String> {
     let token = state
         .token_manager
         .get_access_token()
@@ -21,12 +25,15 @@ pub async fn get_github_user(state: State<'_, AppState>) -> Result<GitHubUser, S
         .map_err(|e| e.to_string())?;
 
     let client = GitHubClient::new(token);
-    client.get_user().await.map_err(|e| e.to_string())
+    map_github_result(&app, state.inner(), client.get_user().await).await
 }
 
 /// Get GitHub stats for the current user
 #[command]
-pub async fn get_github_stats(state: State<'_, AppState>) -> Result<GitHubStats, String> {
+pub async fn get_github_stats(
+    app: AppHandle,
+    state: State<'_, AppState>,
+) -> Result<GitHubStats, String> {
     let token = state
         .token_manager
         .get_access_token()
@@ -41,10 +48,7 @@ pub async fn get_github_stats(state: State<'_, AppState>) -> Result<GitHubStats,
         .ok_or("Not logged in")?;
 
     let client = GitHubClient::new(token);
-    client
-        .get_user_stats(&user.username)
-        .await
-        .map_err(|e| e.to_string())
+    map_github_result(&app, state.inner(), client.get_user_stats(&user.username).await).await
 }
 
 /// Get local user stats (gamification data)
@@ -232,10 +236,8 @@ pub async fn run_github_sync(
         .ok_or("Not logged in")?;
 
     let client = GitHubClient::new(token);
-    let github_stats = client
-        .get_user_stats(&user.username)
-        .await
-        .map_err(|e| e.to_string())?;
+    let github_stats =
+        map_github_result(app, state, client.get_user_stats(&user.username).await).await?;
 
     // Get previous stats for diff calculation
     let previous_stats_json = state
@@ -891,6 +893,7 @@ async fn persist_sync_success(state: &AppState, user_id: i64) {
 /// Get contribution calendar
 #[command]
 pub async fn get_contribution_calendar(
+    app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<serde_json::Value, String> {
     let token = state
@@ -907,10 +910,12 @@ pub async fn get_contribution_calendar(
         .ok_or("Not logged in")?;
 
     let client = GitHubClient::new(token);
-    let contributions = client
-        .get_contribution_calendar(&user.username)
-        .await
-        .map_err(|e| e.to_string())?;
+    let contributions = map_github_result(
+        &app,
+        state.inner(),
+        client.get_contribution_calendar(&user.username).await,
+    )
+    .await?;
 
     serde_json::to_value(contributions.contribution_calendar).map_err(|e| e.to_string())
 }
@@ -920,6 +925,7 @@ pub async fn get_contribution_calendar(
 /// Consolidates the common logic for building BadgeEvalContext used by
 /// both `get_badges_with_progress` and `get_near_completion_badges`.
 async fn build_badge_context(
+    app: &AppHandle,
     state: &State<'_, AppState>,
 ) -> Result<(badge::BadgeEvalContext, crate::database::models::User), String> {
     let user = state
@@ -945,10 +951,12 @@ async fn build_badge_context(
         .map_err(|e| e.to_string())?;
 
     let client = GitHubClient::new(token);
-    let github_stats = client
-        .get_user_stats(&user.username)
-        .await
-        .map_err(|e| e.to_string())?;
+    let github_stats = map_github_result(
+        app,
+        state.inner(),
+        client.get_user_stats(&user.username).await,
+    )
+    .await?;
 
     // Calculate level
     let current_level = level::level_from_xp(user_stats.total_xp);
@@ -975,9 +983,10 @@ async fn build_badge_context(
 /// Get badges with progress information
 #[command]
 pub async fn get_badges_with_progress(
+    app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<Vec<badge::BadgeWithProgress>, String> {
-    let (badge_context, user) = build_badge_context(&state).await?;
+    let (badge_context, user) = build_badge_context(&app, &state).await?;
 
     // Get earned badges
     let earned_badges = state
@@ -1002,11 +1011,12 @@ pub async fn get_badges_with_progress(
 /// Get badges that are close to being earned
 #[command]
 pub async fn get_near_completion_badges(
+    app: AppHandle,
     state: State<'_, AppState>,
     threshold_percent: Option<f32>,
 ) -> Result<Vec<badge::BadgeWithProgress>, String> {
     let threshold = threshold_percent.unwrap_or(50.0);
-    let (badge_context, user) = build_badge_context(&state).await?;
+    let (badge_context, user) = build_badge_context(&app, &state).await?;
 
     // Get earned badge IDs
     let earned_badges = state
@@ -1052,6 +1062,7 @@ pub struct CodeStatsSyncResult {
 /// Uses incremental sync to minimize API calls.
 #[command]
 pub async fn sync_code_stats(
+    app: AppHandle,
     state: State<'_, AppState>,
     force_full_sync: Option<bool>,
 ) -> Result<CodeStatsSyncResult, String> {
@@ -1110,10 +1121,12 @@ pub async fn sync_code_stats(
     let since = format!("{}T00:00:00Z", sync_from);
 
     // Fetch code stats from GitHub
-    let code_stats = client
-        .get_code_stats(&user.username, &since, 100)
-        .await
-        .map_err(|e| e.to_string())?;
+    let code_stats = map_github_result(
+        &app,
+        state.inner(),
+        client.get_code_stats(&user.username, &since, 100).await,
+    )
+    .await?;
 
     // Store each day's stats
     let mut total_additions = 0;
@@ -1224,7 +1237,10 @@ pub async fn get_code_stats_summary(
 
 /// Get detailed rate limit information
 #[command]
-pub async fn get_rate_limit_info(state: State<'_, AppState>) -> Result<RateLimitDetailed, String> {
+pub async fn get_rate_limit_info(
+    app: AppHandle,
+    state: State<'_, AppState>,
+) -> Result<RateLimitDetailed, String> {
     let token = state
         .token_manager
         .get_access_token()
@@ -1232,16 +1248,14 @@ pub async fn get_rate_limit_info(state: State<'_, AppState>) -> Result<RateLimit
         .map_err(|e| e.to_string())?;
 
     let client = GitHubClient::new(token);
-    client
-        .get_detailed_rate_limit()
-        .await
-        .map_err(|e| e.to_string())
+    map_github_result(&app, state.inner(), client.get_detailed_rate_limit().await).await
 }
 
 // ============================================================================
 // Cache Fallback Commands
 // ============================================================================
 
+use crate::auth::{handle_unauthorized, reasons};
 use crate::database::cache_types;
 use crate::github::client::GitHubError;
 
@@ -1271,9 +1285,11 @@ pub struct CachedResponse<T> {
 ///
 /// Attempts to fetch fresh data from GitHub API. If that fails due to network error,
 /// falls back to cached data if available.
-/// Note: Authentication errors do NOT trigger cache fallback for security reasons.
+/// Note: Authentication errors do NOT trigger cache fallback for security reasons —
+/// instead they trigger the auth-expired flow (clear token + emit event).
 #[command]
 pub async fn get_github_stats_with_cache(
+    app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<CachedResponse<GitHubStats>, String> {
     let user = state
@@ -1321,7 +1337,12 @@ pub async fn get_github_stats_with_cache(
         Err(api_error) => {
             // Check if this is a network error (should fallback) or auth error (should not)
             if !is_network_error(&api_error) {
-                // Authentication or other API error - do not fallback to cache
+                // Authentication errors get the centralized 401 treatment so
+                // the UI surfaces a re-login prompt; other API errors bubble
+                // up unchanged.
+                if matches!(api_error, GitHubError::Unauthorized) {
+                    handle_unauthorized(&app, state.inner(), reasons::GITHUB_UNAUTHORIZED).await;
+                }
                 return Err(format!("GitHub API error: {}", api_error));
             }
 

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -48,7 +48,12 @@ pub async fn get_github_stats(
         .ok_or("Not logged in")?;
 
     let client = GitHubClient::new(token);
-    map_github_result(&app, state.inner(), client.get_user_stats(&user.username).await).await
+    map_github_result(
+        &app,
+        state.inner(),
+        client.get_user_stats(&user.username).await,
+    )
+    .await
 }
 
 /// Get local user stats (gamification data)

--- a/src-tauri/src/commands/issues.rs
+++ b/src-tauri/src/commands/issues.rs
@@ -14,8 +14,9 @@
 
 use chrono::Utc;
 use sqlx::Row;
-use tauri::State;
+use tauri::{AppHandle, State};
 
+use crate::auth::map_github_result;
 use crate::commands::AppState;
 use crate::database::models::project::{
     CachedIssue, IssueStatus, KanbanBoard, Project, ProjectWithStats, RepositoryInfo,
@@ -177,15 +178,13 @@ pub async fn delete_project(state: State<'_, AppState>, project_id: i64) -> Resu
 /// Get user's repositories for linking
 #[tauri::command]
 pub async fn get_user_repositories(
+    app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<Vec<RepositoryInfo>, String> {
     let access_token = get_access_token(&state).await?;
     let client = IssuesClient::new(access_token);
 
-    let repos = client
-        .get_user_repositories()
-        .await
-        .map_err(|e| format!("Failed to fetch repositories: {:?}", e))?;
+    let repos = map_github_result(&app, state.inner(), client.get_user_repositories().await).await?;
 
     Ok(repos
         .into_iter()
@@ -205,6 +204,7 @@ pub async fn get_user_repositories(
 /// Link a repository to a project
 #[tauri::command]
 pub async fn link_repository(
+    app: AppHandle,
     state: State<'_, AppState>,
     project_id: i64,
     owner: String,
@@ -215,10 +215,12 @@ pub async fn link_repository(
     let client = IssuesClient::new(access_token);
 
     // Get repository info from GitHub
-    let repo_info = client
-        .get_repository(&owner, &repo)
-        .await
-        .map_err(|e| format!("Failed to fetch repository: {:?}", e))?;
+    let repo_info = map_github_result(
+        &app,
+        state.inner(),
+        client.get_repository(&owner, &repo).await,
+    )
+    .await?;
 
     let now = Utc::now().to_rfc3339();
     let full_name = format!("{}/{}", owner, repo);
@@ -286,6 +288,7 @@ Repository: {}/{}
 /// Sync issues from GitHub to local cache
 #[tauri::command]
 pub async fn sync_project_issues(
+    app: AppHandle,
     state: State<'_, AppState>,
     project_id: i64,
 ) -> Result<Vec<CachedIssue>, String> {
@@ -302,10 +305,12 @@ pub async fn sync_project_issues(
     let mut page = 1;
 
     loop {
-        let issues = client
-            .get_issues(&owner, &repo, "all", 100, page)
-            .await
-            .map_err(|e| format!("Failed to fetch issues: {:?}", e))?;
+        let issues = map_github_result(
+            &app,
+            state.inner(),
+            client.get_issues(&owner, &repo, "all", 100, page).await,
+        )
+        .await?;
 
         if issues.is_empty() {
             break;
@@ -451,6 +456,7 @@ pub async fn get_kanban_board(
 /// Update issue status (also updates on GitHub)
 #[tauri::command]
 pub async fn update_issue_status(
+    app: AppHandle,
     state: State<'_, AppState>,
     project_id: i64,
     issue_number: i32,
@@ -469,10 +475,14 @@ pub async fn update_issue_status(
     let client = IssuesClient::new(access_token);
 
     // Update status on GitHub
-    let updated_issue = client
-        .update_issue_status(&owner, &repo, issue_number, status)
-        .await
-        .map_err(|e| format!("Failed to update issue status: {:?}", e))?;
+    let updated_issue = map_github_result(
+        &app,
+        state.inner(),
+        client
+            .update_issue_status(&owner, &repo, issue_number, status)
+            .await,
+    )
+    .await?;
 
     // Update local cache
     let now = Utc::now().to_rfc3339();
@@ -509,6 +519,7 @@ pub async fn update_issue_status(
 /// Create a new issue (on GitHub and cache locally)
 #[tauri::command]
 pub async fn create_github_issue(
+    app: AppHandle,
     state: State<'_, AppState>,
     project_id: i64,
     title: String,
@@ -539,10 +550,14 @@ pub async fn create_github_issue(
     let client = IssuesClient::new(access_token);
 
     // Create issue on GitHub
-    let github_issue = client
-        .create_issue(&owner, &repo, &title, body.as_deref(), labels)
-        .await
-        .map_err(|e| format!("Failed to create issue: {:?}", e))?;
+    let github_issue = map_github_result(
+        &app,
+        state.inner(),
+        client
+            .create_issue(&owner, &repo, &title, body.as_deref(), labels)
+            .await,
+    )
+    .await?;
 
     // Cache the new issue
     let now = Utc::now().to_rfc3339();

--- a/src-tauri/src/commands/issues.rs
+++ b/src-tauri/src/commands/issues.rs
@@ -184,7 +184,8 @@ pub async fn get_user_repositories(
     let access_token = get_access_token(&state).await?;
     let client = IssuesClient::new(access_token);
 
-    let repos = map_github_result(&app, state.inner(), client.get_user_repositories().await).await?;
+    let repos =
+        map_github_result(&app, state.inner(), client.get_user_repositories().await).await?;
 
     Ok(repos
         .into_iter()

--- a/src-tauri/src/github/client.rs
+++ b/src-tauri/src/github/client.rs
@@ -141,7 +141,18 @@ impl GitHubClient {
 
         self.check_rate_limit(&response).await?;
 
-        if !response.status().is_success() {
+        let status = response.status();
+        if !status.is_success() {
+            // 401 must surface as the typed `Unauthorized` variant so the
+            // shared `auth::session::map_github_result` helper can detect a
+            // revoked token and trigger the auth-expired flow. Without this
+            // mapping a GraphQL 401 (e.g. `get_contribution_calendar`) gets
+            // flattened to `ApiError("...Bad credentials...")` and slips past
+            // both `map_github_result` and the scheduler's classifier — see
+            // PR #199 review (Devin) for the original report.
+            if status == reqwest::StatusCode::UNAUTHORIZED {
+                return Err(GitHubError::Unauthorized);
+            }
             let error_text = response.text().await.unwrap_or_default();
             return Err(GitHubError::ApiError(error_text));
         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ mod utils;
 
 use tauri::Manager;
 
+use commands::auth::run_startup_token_validation;
 use commands::{
     // Gamification commands
     add_xp,
@@ -143,6 +144,20 @@ pub fn run() {
             });
 
             app.manage(app_state);
+
+            // Probe the persisted GitHub token in the background so we can
+            // surface a re-login prompt if the user revoked it externally
+            // between launches. Runs after `app.manage(app_state)` because the
+            // helper resolves AppState via the app handle.
+            //
+            // Issue #181 — see `commands::auth::run_startup_token_validation`
+            // for the policy: only a confirmed 401 clears the session;
+            // transport errors leave it intact.
+            let app_for_auth_check = app.handle().clone();
+            tauri::async_runtime::spawn(async move {
+                let state = app_for_auth_check.state::<AppState>();
+                run_startup_token_validation(app_for_auth_check.clone(), state.inner()).await;
+            });
 
             // Start the background sync scheduler. Must run *after* AppState is
             // managed because the scheduler resolves it via app.state::<AppState>().

--- a/src-tauri/src/sync_scheduler/runner.rs
+++ b/src-tauri/src/sync_scheduler/runner.rs
@@ -11,6 +11,7 @@ use chrono::{DateTime, Utc};
 use tauri::{AppHandle, Manager};
 use tokio::sync::{Notify, RwLock};
 
+use crate::auth::{classify_unauthorized, handle_unauthorized, reasons};
 use crate::commands::auth::AppState;
 use crate::commands::github::run_github_sync;
 use crate::database::models::code_stats::SyncMetadata;
@@ -155,6 +156,28 @@ async fn run_loop(app: AppHandle, notify: Arc<Notify>, status: Arc<RwLock<Schedu
                         eprintln!("Scheduler: scheduled sync failed: {}", err_msg);
                         let now = Utc::now();
                         let mut sleep_secs = MIN_FAILURE_SLEEP_SECONDS;
+
+                        // 401 detection: a revoked / invalidated token would
+                        // otherwise loop forever in MIN_FAILURE_SLEEP_SECONDS
+                        // increments because the failure isn't classified as
+                        // rate-limit. `run_github_sync` may have already
+                        // emitted `auth-expired` from inside the user-facing
+                        // command path, but the scheduler runs independently
+                        // (no `app` was wired through `map_github_result` for
+                        // every internal call), so re-trigger here. The
+                        // emitter is idempotent on the frontend side.
+                        if classify_unauthorized(&err_msg) {
+                            handle_unauthorized(
+                                &app,
+                                state.inner(),
+                                reasons::SCHEDULER_UNAUTHORIZED,
+                            )
+                            .await;
+                            // Skip straight to the logged-out wait branch on
+                            // the next iteration — the user is now signed out.
+                            wait_for_change_or_timeout(&notify, MIN_FAILURE_SLEEP_SECONDS).await;
+                            continue;
+                        }
 
                         if let Some(reset_at) = parse_rate_limit_reset(&err_msg) {
                             // Persist the reset time so subsequent decisions

--- a/src/components/features/auth/SessionExpiredBanner.tsx
+++ b/src/components/features/auth/SessionExpiredBanner.tsx
@@ -1,0 +1,61 @@
+/**
+ * Session Expired Banner
+ *
+ * Persistent banner shown across all routes whenever the backend has
+ * detected that the stored GitHub token is no longer valid (revoked,
+ * expired, or otherwise rejected). Mounted from `MainLayout` so it surfaces
+ * regardless of which page the user is on when the 401 is observed.
+ *
+ * Behavior:
+ * - Visible only while `useAuth.authExpired` is set.
+ * - "再ログイン" routes the user to home where `LoginCard` lives.
+ * - "閉じる" hides the banner for the current session; the next 401 will
+ *   re-emit the event and re-show it.
+ *
+ * Related: src-tauri/src/auth/session.rs, Issue #181.
+ */
+
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../../../stores/authStore';
+import { Icon } from '../../icons';
+
+export const SessionExpiredBanner = () => {
+  const authExpired = useAuth((s) => s.authExpired);
+  const dismiss = useAuth((s) => s.dismissAuthExpired);
+  const navigate = useNavigate();
+
+  if (!authExpired) return null;
+
+  const handleRelogin = () => {
+    dismiss();
+    // LoginCard lives on the home page; routing there guarantees the user
+    // sees the device-flow CTA even if they were deep in another tab.
+    navigate('/');
+  };
+
+  return (
+    <div
+      role="alert"
+      aria-live="assertive"
+      className="bg-red-500/90 text-red-50 px-4 py-2 text-sm flex items-center justify-center gap-3 flex-wrap"
+    >
+      <Icon name="alert-triangle" className="w-4 h-4 flex-shrink-0" />
+      <span className="font-medium">{authExpired.message}</span>
+      <button
+        type="button"
+        onClick={handleRelogin}
+        className="px-3 py-1 rounded-md bg-white/20 hover:bg-white/30 active:bg-white/40 transition-colors text-white text-xs font-semibold"
+      >
+        再ログイン
+      </button>
+      <button
+        type="button"
+        onClick={dismiss}
+        aria-label="閉じる"
+        className="px-2 py-1 rounded-md hover:bg-white/10 active:bg-white/20 transition-colors text-white/80 hover:text-white text-xs"
+      >
+        閉じる
+      </button>
+    </div>
+  );
+};

--- a/src/components/features/auth/index.ts
+++ b/src/components/features/auth/index.ts
@@ -8,3 +8,4 @@
  */
 
 export { LoginCard } from './LoginCard';
+export { SessionExpiredBanner } from './SessionExpiredBanner';

--- a/src/components/layouts/MainLayout/MainLayout.tsx
+++ b/src/components/layouts/MainLayout/MainLayout.tsx
@@ -13,6 +13,7 @@
 import type { ReactNode } from 'react';
 import { Sidebar } from '../Sidebar';
 import { OfflineBanner } from '../OfflineBanner';
+import { SessionExpiredBanner } from '../../features/auth';
 
 /**
  * MainLayout Component
@@ -20,6 +21,7 @@ import { OfflineBanner } from '../OfflineBanner';
  * Wraps the entire application with:
  * - Sidebar (navigation)
  * - OfflineBanner (network status)
+ * - SessionExpiredBanner (GitHub auth-expired prompt — Issue #181)
  * - Main content area (children)
  *
  * Responsive design will be implemented in a later phase.
@@ -30,6 +32,7 @@ export const MainLayout = ({ children }: { children: ReactNode }) => {
       <Sidebar />
       <main className="flex-1 flex flex-col overflow-hidden">
         <OfflineBanner />
+        <SessionExpiredBanner />
         {children}
       </main>
     </div>

--- a/src/lib/tauri/events.ts
+++ b/src/lib/tauri/events.ts
@@ -12,6 +12,7 @@
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import type {
   AuthState,
+  AuthExpiredEvent,
   XpGainedEvent,
   StreakMilestoneEvent,
   BadgeEarnedEvent,
@@ -27,6 +28,20 @@ export const events = {
    */
   onAuthStateChange: (callback: (state: AuthState) => void): Promise<UnlistenFn> =>
     listen<AuthState>('auth-state-change', (event) => callback(event.payload)),
+
+  /**
+   * Listen for authentication-expired events.
+   *
+   * Emitted by the backend whenever the stored GitHub token is rejected (401)
+   * — for example, the user revoked it on github.com between launches, or the
+   * background sync scheduler observed a 401. The backend has already cleared
+   * the credential by the time this fires; the frontend's job is to surface
+   * the re-login prompt and stop firing API requests.
+   *
+   * See `src-tauri/src/auth/session.rs` for the emitter and reason codes.
+   */
+  onAuthExpired: (callback: (event: AuthExpiredEvent) => void): Promise<UnlistenFn> =>
+    listen<AuthExpiredEvent>('auth-expired', (event) => callback(event.payload)),
 
   // ============================================================================
   // Gamification Events

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -6,35 +6,50 @@
  *
  * Related Documentation:
  *   - Issue: https://github.com/otomatty/development-tools/issues/134
+ *   - Issue (auth-expired flow): https://github.com/otomatty/development-tools/issues/181
  *   - Types: src/types/auth.ts
  *   - Tauri API: src/lib/tauri/commands.ts
  */
 
 import { create } from 'zustand';
-import type { AuthState } from '@/types';
+import type { AuthState, AuthExpiredEvent } from '@/types';
 import { auth as authApi } from '@/lib/tauri/commands';
+import { events } from '@/lib/tauri/events';
 
 interface AuthStore {
   state: AuthState;
   isLoading: boolean;
   error: string | null;
+  /**
+   * Set when the backend reports the stored GitHub token is no longer valid
+   * (revoked / expired). The UI uses this to show a re-login prompt and
+   * suppress API calls until the user re-authenticates.
+   *
+   * Cleared automatically when `fetchAuthState()` confirms the user is logged
+   * in again, or manually via `dismissAuthExpired()`.
+   */
+  authExpired: AuthExpiredEvent | null;
   fetchAuthState: () => Promise<void>;
   logout: () => Promise<void>;
+  dismissAuthExpired: () => void;
 }
 
 let authRequestSeq = 0;
 
-export const useAuth = create<AuthStore>((set) => ({
+export const useAuth = create<AuthStore>((set, get) => ({
   state: { isLoggedIn: false, user: null },
   isLoading: true,
   error: null,
+  authExpired: null,
   fetchAuthState: async () => {
     const seq = ++authRequestSeq;
     try {
       set({ isLoading: true, error: null });
       const state = await authApi.getState();
       if (seq !== authRequestSeq) return;
-      set({ state, isLoading: false });
+      // A successful re-login clears any stale "session expired" banner.
+      const cleared = state.isLoggedIn ? { authExpired: null } : {};
+      set({ state, isLoading: false, ...cleared });
     } catch (e) {
       if (seq !== authRequestSeq) return;
       set({ error: String(e), isLoading: false });
@@ -46,14 +61,46 @@ export const useAuth = create<AuthStore>((set) => ({
       set({ isLoading: true, error: null });
       await authApi.logout();
       if (seq !== authRequestSeq) return;
-      set({ state: { isLoggedIn: false, user: null }, isLoading: false });
+      set({
+        state: { isLoggedIn: false, user: null },
+        isLoading: false,
+        // Manual logout — no need to keep nagging the user about the expired
+        // session they just resolved.
+        authExpired: null,
+      });
     } catch (e) {
       if (seq !== authRequestSeq) return;
       set({ error: String(e), isLoading: false });
       throw e;
     }
   },
+  dismissAuthExpired: () => {
+    if (get().authExpired !== null) {
+      set({ authExpired: null });
+    }
+  },
 }));
+
+// Subscribe to backend auth-expired events so the UI surfaces a re-login
+// prompt without polling. The backend has already cleared the credential by
+// the time this fires; we only need to flip local state so the dashboard
+// stops issuing API requests and the LoginCard reappears.
+//
+// Listener registration is fire-and-forget: if it fails (e.g. Tauri not
+// initialised yet during tests), the dashboard still works — the user just
+// won't see the auto-prompt until they next reload.
+events
+  .onAuthExpired((event) => {
+    useAuth.setState({
+      state: { isLoggedIn: false, user: null },
+      authExpired: event,
+      isLoading: false,
+    });
+  })
+  .catch((e) => {
+    // eslint-disable-next-line no-console
+    console.error('Failed to subscribe to auth-expired events:', e);
+  });
 
 // Fetch auth state on module load
 useAuth.getState().fetchAuthState();

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -91,6 +91,15 @@ export const useAuth = create<AuthStore>((set, get) => ({
 // won't see the auto-prompt until they next reload.
 events
   .onAuthExpired((event) => {
+    // Cancel any in-flight `fetchAuthState` / `logout` so a stale success
+    // response can't sneak in after the event and overwrite the logged-out
+    // state we're about to set. Concrete failure mode without this bump:
+    // at startup, `fetchAuthState()` runs concurrently with the backend's
+    // startup token probe; the probe hits 401 and emits `auth-expired`,
+    // but the `getState` call (initiated before the credential was cleared)
+    // resolves with the still-cached `user` row and flips `isLoggedIn` back
+    // to true — leaving the UI in a phantom logged-in state.
+    ++authRequestSeq;
     useAuth.setState({
       state: { isLoggedIn: false, user: null },
       authExpired: event,

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -30,6 +30,18 @@ export type DeviceTokenStatus =
   | { status: 'success'; authState: AuthState }
   | { status: 'error'; message: string };
 
+/// 認証切れイベントのペイロード
+///
+/// バックエンドが GitHub から 401 を受け取った際、または起動時のトークン検証で
+/// 失効が確認された際に `auth-expired` イベントとして emit される。
+/// 詳細は `src-tauri/src/auth/session.rs` を参照。
+export interface AuthExpiredEvent {
+  /// マシン可読な理由コード（"github_unauthorized", "startup_validation_failed" など）
+  reason: string;
+  /// UI に表示できる日本語メッセージ
+  message: string;
+}
+
 /// GitHubユーザー
 export interface GitHubUser {
   id: number;


### PR DESCRIPTION
## Summary

Implements a complete authentication lifecycle for handling GitHub token revocation and expiration. When the backend detects a 401 response from GitHub (token revoked/invalid), it now clears the stored credential and emits an `auth-expired` event to the frontend, which surfaces a re-login prompt and suppresses API calls until the user re-authenticates.

## Key Changes

**Backend (Rust/Tauri):**
- Added `src-tauri/src/auth/session.rs` module to centralize 401 handling:
  - `handle_unauthorized()` clears tokens and emits `auth-expired` event (idempotent)
  - `map_github_result()` bridges typed `GitHubError` to Tauri command results, automatically triggering auth-expired flow on 401
  - `classify_unauthorized()` detects 401 errors in stringified results for scheduler integration
  - Defined reason codes (`GITHUB_UNAUTHORIZED`, `STARTUP_VALIDATION_FAILED`, `MANUAL_VALIDATION_FAILED`, `SCHEDULER_UNAUTHORIZED`)

- Updated `src-tauri/src/commands/auth.rs`:
  - `validate_token()` now triggers `handle_unauthorized()` when GitHub rejects the token
  - Added `run_startup_token_validation()` to probe persisted token on app launch (non-blocking, transport-error tolerant)

- Updated `src-tauri/src/lib.rs`:
  - Integrated startup token validation in the setup hook via background task

- Updated `src-tauri/src/sync_scheduler/runner.rs`:
  - Detects 401 in scheduler errors and triggers `handle_unauthorized()` to prevent infinite retry loops

- Wrapped all GitHub API calls in `map_github_result()` across:
  - `src-tauri/src/commands/github.rs` (user profile, stats, contributions, badges, code stats)
  - `src-tauri/src/commands/issues.rs` (repositories, issues, status updates)

- Enhanced `src-tauri/src/auth/token.rs` documentation to clarify `validate_token()` contract (Ok(true/false) vs Err for transport failures)

**Frontend (TypeScript/React):**
- Added `src/components/features/auth/SessionExpiredBanner.tsx`:
  - Persistent banner shown when `authExpired` is set
  - "再ログイン" button routes to home and triggers Device Flow
  - "閉じる" dismisses banner for current session

- Updated `src/stores/authStore.ts`:
  - Added `authExpired` state to track active session expiration events
  - Added `dismissAuthExpired()` action
  - Integrated `events.onAuthExpired()` listener to receive backend events
  - Auto-clears `authExpired` on successful re-login via `fetchAuthState()`

- Updated `src/lib/tauri/events.ts`:
  - Added `onAuthExpired()` listener for `auth-expired` event

- Updated `src/types/auth.ts`:
  - Added `AuthExpiredEvent` interface with `reason` (machine-readable) and `message` (user-facing Japanese text)

- Updated `src/components/layouts/MainLayout/MainLayout.tsx`:
  - Mounted `SessionExpiredBanner` globally so it surfaces on any route

- Added comprehensive documentation in `docs/api/AUTH_LIFECYCLE.md`:
  - State transition diagram (LoggedOut → DeviceFlowPending → LoggedIn → SessionExpired → LoggedOut)
  - Backend/frontend responsibilities
  - 401 detection points and reason codes
  - Event payload specification
  - Known constraints (Device Flow tokens don't expire naturally, detection requires API calls)

## Notable Implementation Details

- **Idempotent design**: `handle_unauthorized()` and frontend listener tolerate duplicate events/calls
- **Network resilience**: Transport errors (5xx, timeouts) do NOT trigger logout; only confirmed 401 does
- **Non-blocking startup**: Token validation runs in background task so splash screen isn't delayed
- **Unified error handling**: `map_github_result()` ensures all GitHub API calls converge on the

https://claude.ai/code/session_01CQGinDgsfZHnpayktq5Wpv
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/development-tools/pull/199" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
