### PR TITLE
Implement SWR-style caching for GitHub stats with cache status UI

### DIFF
--- a/src-tauri/src/commands/cache_fallback.spec.md
+++ b/src-tauri/src/commands/cache_fallback.spec.md
@@ -173,8 +173,10 @@ Dependencies (このファイルが使用するファイル):
 ホーム画面 (`src/pages/Home/Home.tsx`) は本フックを介して `*_with_cache` を呼び、以下を実現する:
 
 - キャッシュ即時表示 → バックグラウンドで再検証 (Stale-While-Revalidate)
-- ウィンドウ復帰時 / ネットワーク再接続時の自動再検証
-- `staleTime` 経過後のみ revalidate を発火（無駄な API コールを抑制）
+- ウィンドウフォーカス時は `staleTime` を経過していれば再検証（無駄な API コールを抑制）
+- ネットワーク再接続時は `staleTime` を待たず即時再検証（オフライン中の停滞分を取り戻すため）
+- `from_cache=true` のレスポンスでは `staleTime` タイマーを更新しないため、
+  キャッシュフォールバック直後はフォーカス復帰でも即座に再検証される
 - `from_cache=true` または直近の revalidate がエラーの場合は `CacheStatusBanner`
   （`src/pages/Home/CacheStatusBanner.tsx`）でユーザーに通知し、最終更新時刻と再試行ボタンを提示する
 

--- a/src-tauri/src/commands/cache_fallback.spec.md
+++ b/src-tauri/src/commands/cache_fallback.spec.md
@@ -52,7 +52,9 @@ pub struct CachedResponse<T> {
 | ------------ | --------------- | -------- | -------------------------- |
 | GitHub Stats | `github_stats`  | 30 分    | ユーザーの GitHub 統計情報 |
 | User Stats   | `user_stats`    | 60 分    | ゲーミフィケーション統計   |
-| Level Info   | `level_info`    | 60 分    | レベル情報                 |
+
+> 期限の値は `src-tauri/src/database/models/cache.rs` の `cache_durations` 定数で集中管理。
+> 両コマンドおよび `sync_github_stats` は成功時に常にこの期限でキャッシュを上書きする。
 
 ### コマンド変更
 
@@ -70,10 +72,13 @@ pub async fn get_github_stats_with_cache(
 **動作フロー:**
 
 1. GitHubStats API を呼び出し
-2. 成功 → キャッシュに保存 → `CachedResponse { data, from_cache: false, ... }` を返す
-3. 失敗 → キャッシュから取得を試行
-   - キャッシュあり → `CachedResponse { data, from_cache: true, cached_at, ... }` を返す
-   - キャッシュなし → エラーを返す
+2. 成功 → 常にキャッシュを上書き保存 → `CachedResponse { data, from_cache: false, ... }` を返す
+3. 失敗
+   - 認証エラー (`Unauthorized`) → 401 ハンドラを呼んでエラーを返す（キャッシュは触らない）
+   - ネットワーク / レート制限エラー → キャッシュから取得を試行
+     - キャッシュあり → `CachedResponse { data, from_cache: true, cached_at, ... }` を返す
+     - キャッシュなし → エラーを返す
+   - その他の API エラー → エラーをそのまま返す
 
 #### get_user_stats_with_cache
 
@@ -164,10 +169,14 @@ Dependencies (このファイルが使用するファイル):
 
 ### フロントエンド表示
 
-キャッシュデータ使用時は以下を表示:
+`src/hooks/useCachedFetch.ts` が SWR ライクな fetcher として両コマンドをラップする。
+ホーム画面 (`src/pages/Home/Home.tsx`) は本フックを介して `*_with_cache` を呼び、以下を実現する:
 
-- 「キャッシュデータを表示中」のインジケーター
-- 最終更新日時（cached_at）
+- キャッシュ即時表示 → バックグラウンドで再検証 (Stale-While-Revalidate)
+- ウィンドウ復帰時 / ネットワーク再接続時の自動再検証
+- `staleTime` 経過後のみ revalidate を発火（無駄な API コールを抑制）
+- `from_cache=true` または直近の revalidate がエラーの場合は `CacheStatusBanner`
+  （`src/pages/Home/CacheStatusBanner.tsx`）でユーザーに通知し、最終更新時刻と再試行ボタンを提示する
 
 ---
 
@@ -175,7 +184,9 @@ Dependencies (このファイルが使用するファイル):
 
 GitHub 統計の自動同期は `crate::sync_scheduler` が担当する。スケジューラはユーザー設定（`sync_on_startup` / `sync_interval_minutes` / `background_sync`）に応じて
 バックグラウンドで `sync_github_stats` を駆動し、結果は本キャッシュ層と同様に DB
-に保存される。
+に保存される。さらに `run_github_sync` は同期成功後に `cache_types::GITHUB_STATS`
+キャッシュを `cache_durations::GITHUB_STATS` で上書きするため、直後の
+`get_github_stats_with_cache` は API を再度呼ばずにキャッシュから即時応答できる。
 
 | トリガー | 担当 | 備考 |
 | --- | --- | --- |

--- a/src-tauri/src/commands/cache_fallback.spec.md
+++ b/src-tauri/src/commands/cache_fallback.spec.md
@@ -135,6 +135,30 @@ pub async fn get_user_stats_with_cache(
   - `from_cache` が `true`
   - UserStats データが返される
 
+### TC-006: 同期成功時のキャッシュ自動更新
+
+- **Given**: ユーザーがログイン済み、`activity_cache` の `github_stats` エントリが
+  存在しない（または期限切れ）
+- **When**: `sync_github_stats` / `run_github_sync` が成功裏に完了する
+- **Then**:
+  - `activity_cache` に `data_type = github_stats` のエントリが UPSERT される
+  - `expires_at` が `now + cache_durations::GITHUB_STATS`（30 分）に設定される
+  - 直後に `get_github_stats_with_cache` を呼ぶと、API を再度叩かずに
+    `from_cache = true` でキャッシュからデータを返せる
+- **Notes**: キャッシュ書き込みはベストエフォートなので、書き込み失敗が
+  同期結果のエラーに昇格しないことも併せて確認する
+
+### TC-007: 認証エラーはフォールバックしない
+
+- **Given**: オンライン状態、`github_stats` キャッシュにデータあり、
+  GitHub API がトークン失効により `401 Unauthorized` を返す
+- **When**: `get_github_stats_with_cache` を呼び出す
+- **Then**:
+  - キャッシュフォールバックは発火せず、エラー（"GitHub API error: ..."）が返る
+  - `handle_unauthorized` が呼び出され、トークンがクリアされ
+    `auth-expired` イベントが emit される
+- **Rationale**: 認証エラーで古いキャッシュを表示し続けるのはセキュリティ上望ましくない
+
 ---
 
 ## DEPENDENCY MAP

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -451,8 +451,8 @@ pub async fn run_github_sync(
     // sync. (Audit §9.2: ensure non-fallback paths populate the cache too.)
     {
         let now = chrono::Utc::now();
-        let expires_at = now
-            + chrono::Duration::minutes(crate::database::models::cache::cache_durations::GITHUB_STATS);
+        let expires_at =
+            now + chrono::Duration::minutes(crate::database::cache_durations::GITHUB_STATS);
         if let Err(e) = state
             .db
             .save_cache(user.id, cache_types::GITHUB_STATS, &stats_json, expires_at)
@@ -1342,10 +1342,8 @@ pub async fn get_github_stats_with_cache(
                 .map_err(|e| format!("Failed to serialize stats: {}", e))?;
 
             let now = chrono::Utc::now();
-            let expires_at = now
-                + chrono::Duration::minutes(
-                    crate::database::models::cache::cache_durations::GITHUB_STATS,
-                );
+            let expires_at =
+                now + chrono::Duration::minutes(crate::database::cache_durations::GITHUB_STATS);
 
             // Save to cache (ignore errors - caching is best effort)
             let _ = state
@@ -1432,10 +1430,8 @@ pub async fn get_user_stats_with_cache(
                 .map_err(|e| format!("Failed to serialize stats: {}", e))?;
 
             let now = chrono::Utc::now();
-            let expires_at = now
-                + chrono::Duration::minutes(
-                    crate::database::models::cache::cache_durations::USER_STATS,
-                );
+            let expires_at =
+                now + chrono::Duration::minutes(crate::database::cache_durations::USER_STATS);
 
             let _ = state
                 .db

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -445,6 +445,23 @@ pub async fn run_github_sync(
         .await
         .map_err(|e| e.to_string())?;
 
+    // Also prime the activity cache so subsequent `get_github_stats_with_cache`
+    // calls can serve the freshly-synced data without re-hitting the API. The
+    // cache is best-effort: a write failure is logged but does not fail the
+    // sync. (Audit §9.2: ensure non-fallback paths populate the cache too.)
+    {
+        let now = chrono::Utc::now();
+        let expires_at = now
+            + chrono::Duration::minutes(crate::database::models::cache::cache_durations::GITHUB_STATS);
+        if let Err(e) = state
+            .db
+            .save_cache(user.id, cache_types::GITHUB_STATS, &stats_json, expires_at)
+            .await
+        {
+            eprintln!("Failed to prime github_stats cache after sync: {}", e);
+        }
+    }
+
     let xp_breakdown_result = XpBreakdownResult {
         commits_xp: xp_breakdown.commits_xp,
         prs_created_xp: xp_breakdown.prs_created_xp,
@@ -1319,12 +1336,16 @@ pub async fn get_github_stats_with_cache(
 
     match api_result {
         Ok(stats) => {
-            // API succeeded - cache the data
+            // API succeeded - always refresh the cache (audit §9.2: cache must
+            // be populated on the success path, not only when falling back).
             let stats_json = serde_json::to_string(&stats)
                 .map_err(|e| format!("Failed to serialize stats: {}", e))?;
 
             let now = chrono::Utc::now();
-            let expires_at = now + chrono::Duration::minutes(30);
+            let expires_at = now
+                + chrono::Duration::minutes(
+                    crate::database::models::cache::cache_durations::GITHUB_STATS,
+                );
 
             // Save to cache (ignore errors - caching is best effort)
             let _ = state
@@ -1401,16 +1422,20 @@ pub async fn get_user_stats_with_cache(
         .map_err(|e| e.to_string())?
         .ok_or("Not logged in")?;
 
-    // User stats are stored locally, so they should always be available
-    // But we still cache for consistency and to support future scenarios
+    // User stats are stored locally, so they should always be available.
+    // Even on the success path we refresh the cache (audit §9.2: cache must
+    // be populated outside the fallback path) so the SWR-style frontend can
+    // render last-known stats during a transient DB failure.
     match state.db.get_user_stats(user.id).await {
         Ok(Some(stats)) => {
-            // Cache the stats
             let stats_json = serde_json::to_string(&stats)
                 .map_err(|e| format!("Failed to serialize stats: {}", e))?;
 
             let now = chrono::Utc::now();
-            let expires_at = now + chrono::Duration::minutes(60);
+            let expires_at = now
+                + chrono::Duration::minutes(
+                    crate::database::models::cache::cache_durations::USER_STATS,
+                );
 
             let _ = state
                 .db

--- a/src-tauri/src/database/models/cache.rs
+++ b/src-tauri/src/database/models/cache.rs
@@ -42,6 +42,8 @@ pub mod cache_durations {
     pub const CONTRIBUTION_GRAPH: i64 = 60;
     /// GitHub stats cache duration (30 minutes)
     pub const GITHUB_STATS: i64 = 30;
+    /// User stats (gamification) cache duration (1 hour)
+    pub const USER_STATS: i64 = 60;
     /// Repositories cache duration (2 hours)
     pub const REPOSITORIES: i64 = 120;
     /// Languages cache duration (24 hours)

--- a/src/hooks/useCachedFetch.ts
+++ b/src/hooks/useCachedFetch.ts
@@ -93,6 +93,13 @@ export function useCachedFetch<T>(
   // Mirror of `data` for use inside event handlers that should not re-bind
   // every render.
   const hasDataRef = useRef(false);
+  // Monotonic "request epoch" bumped whenever the hook is disabled. A run that
+  // started under one epoch must not commit results under another — without
+  // this, a logout + immediate re-login as a different user could let the
+  // previous user's pending fetch resolve and overwrite the new session's
+  // (empty) state. `enabledRef` alone is not enough because both sessions see
+  // `enabled = true`; the epoch distinguishes them.
+  const requestEpochRef = useRef(0);
 
   useEffect(() => {
     mountedRef.current = true;
@@ -104,15 +111,24 @@ export function useCachedFetch<T>(
   const run = useCallback(async (mode: 'initial' | 'revalidate') => {
     if (!enabledRef.current) return;
     if (inFlightRef.current) return;
+    const epochAtStart = requestEpochRef.current;
     inFlightRef.current = true;
     if (mode === 'initial') {
       setIsLoading(true);
     } else {
       setIsRevalidating(true);
     }
+    // Detect whether the run is still the live one for this epoch. A bumped
+    // epoch means the hook was disabled mid-flight; in that case the disable
+    // handler already reset `inFlightRef` and visible state, so we must drop
+    // anything we'd otherwise commit here.
+    const isStillLive = () =>
+      mountedRef.current &&
+      enabledRef.current &&
+      epochAtStart === requestEpochRef.current;
     try {
       const response = await fetcherRef.current();
-      if (!mountedRef.current || !enabledRef.current) return;
+      if (!isStillLive()) return;
       setData(response.data);
       hasDataRef.current = true;
       setFromCache(response.fromCache);
@@ -126,15 +142,21 @@ export function useCachedFetch<T>(
         lastFreshAtRef.current = Date.now();
       }
     } catch (e) {
-      if (!mountedRef.current || !enabledRef.current) return;
+      if (!isStillLive()) return;
       setError(e instanceof Error ? e : new Error(String(e)));
     } finally {
-      inFlightRef.current = false;
-      if (mountedRef.current && enabledRef.current) {
-        if (mode === 'initial') {
-          setIsLoading(false);
-        } else {
-          setIsRevalidating(false);
+      // Only release the in-flight slot if we're still the live request.
+      // Otherwise the disable handler has already cleared it and a fresh
+      // run for the new epoch may have re-acquired it; clearing it again
+      // here would corrupt that newer run.
+      if (epochAtStart === requestEpochRef.current) {
+        inFlightRef.current = false;
+        if (mountedRef.current && enabledRef.current) {
+          if (mode === 'initial') {
+            setIsLoading(false);
+          } else {
+            setIsRevalidating(false);
+          }
         }
       }
     }
@@ -142,9 +164,13 @@ export function useCachedFetch<T>(
 
   // Initial load when enabled flips true; reset all state when it flips false
   // so a logout + login as a different user can't briefly show the previous
-  // user's stats.
+  // user's stats. We bump `requestEpochRef` and clear `inFlightRef` so any
+  // request that was in flight at the time of disable cannot commit results,
+  // and a re-enable can immediately start a new run.
   useEffect(() => {
     if (!enabled) {
+      requestEpochRef.current += 1;
+      inFlightRef.current = false;
       setData(null);
       hasDataRef.current = false;
       setFromCache(false);

--- a/src/hooks/useCachedFetch.ts
+++ b/src/hooks/useCachedFetch.ts
@@ -1,0 +1,172 @@
+/**
+ * useCachedFetch Hook
+ *
+ * SWR (Stale-While-Revalidate) style fetcher for Tauri commands that return
+ * a `CachedResponse<T>` envelope. The hook exposes the cached data immediately
+ * (via the backend cache fallback) and revalidates in the background based on
+ * focus/reconnect events and a configurable `staleTime`.
+ *
+ * Related Documentation:
+ *   - Issue: https://github.com/otomatty/development-tools/issues/182
+ *   - Backend: src-tauri/src/commands/github.rs (`get_*_with_cache`)
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useNetworkStatus } from '@/stores/networkStore';
+import type { CachedResponse } from '@/types';
+
+export interface UseCachedFetchOptions {
+  /** Disable fetching (e.g. while auth is unresolved). */
+  enabled?: boolean;
+  /** Milliseconds the data is considered fresh. Default 30 minutes. */
+  staleTime?: number;
+  /** Revalidate when the window regains focus. Default true. */
+  revalidateOnFocus?: boolean;
+  /** Revalidate when the network reconnects. Default true. */
+  revalidateOnReconnect?: boolean;
+}
+
+export interface UseCachedFetchReturn<T> {
+  /** Latest data (cached or fresh). */
+  data: T | null;
+  /** True while the first load is in flight. */
+  isLoading: boolean;
+  /** True while a background revalidation is in flight. */
+  isRevalidating: boolean;
+  /** The most recent error from the fetcher. */
+  error: Error | null;
+  /** Whether the currently displayed data came from the local cache. */
+  fromCache: boolean;
+  /** ISO8601 timestamp when the displayed data was cached. */
+  cachedAt: string | null;
+  /** ISO8601 timestamp when the cache expires. */
+  expiresAt: string | null;
+  /** Imperatively trigger a revalidation. */
+  revalidate: () => Promise<void>;
+}
+
+const DEFAULT_STALE_TIME_MS = 30 * 60 * 1000;
+
+/**
+ * Wrap a Tauri command returning `CachedResponse<T>` with SWR-like semantics.
+ *
+ * The backend already implements cache-fallback, so the hook's role is to
+ * surface the cache state to the UI and to schedule background revalidation
+ * on focus/reconnect.
+ */
+export function useCachedFetch<T>(
+  fetcher: () => Promise<CachedResponse<T>>,
+  options: UseCachedFetchOptions = {},
+): UseCachedFetchReturn<T> {
+  const {
+    enabled = true,
+    staleTime = DEFAULT_STALE_TIME_MS,
+    revalidateOnFocus = true,
+    revalidateOnReconnect = true,
+  } = options;
+
+  const isOnline = useNetworkStatus(s => s.isOnline);
+
+  const [data, setData] = useState<T | null>(null);
+  const [fromCache, setFromCache] = useState(false);
+  const [cachedAt, setCachedAt] = useState<string | null>(null);
+  const [expiresAt, setExpiresAt] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(enabled);
+  const [isRevalidating, setIsRevalidating] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetcherRef = useRef(fetcher);
+  fetcherRef.current = fetcher;
+
+  const lastFetchedAtRef = useRef<number | null>(null);
+  const inFlightRef = useRef(false);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const run = useCallback(async (mode: 'initial' | 'revalidate') => {
+    if (inFlightRef.current) return;
+    inFlightRef.current = true;
+    if (mode === 'initial') {
+      setIsLoading(true);
+    } else {
+      setIsRevalidating(true);
+    }
+    try {
+      const response = await fetcherRef.current();
+      if (!mountedRef.current) return;
+      setData(response.data);
+      setFromCache(response.fromCache);
+      setCachedAt(response.cachedAt);
+      setExpiresAt(response.expiresAt);
+      setError(null);
+      lastFetchedAtRef.current = Date.now();
+    } catch (e) {
+      if (!mountedRef.current) return;
+      setError(e instanceof Error ? e : new Error(String(e)));
+    } finally {
+      inFlightRef.current = false;
+      if (mountedRef.current) {
+        if (mode === 'initial') {
+          setIsLoading(false);
+        } else {
+          setIsRevalidating(false);
+        }
+      }
+    }
+  }, []);
+
+  // Initial load when enabled flips true.
+  useEffect(() => {
+    if (!enabled) {
+      setIsLoading(false);
+      return;
+    }
+    void run('initial');
+  }, [enabled, run]);
+
+  // Revalidate on focus once data is stale.
+  useEffect(() => {
+    if (!enabled || !revalidateOnFocus) return;
+    const handler = () => {
+      const last = lastFetchedAtRef.current;
+      if (last === null || Date.now() - last >= staleTime) {
+        void run('revalidate');
+      }
+    };
+    window.addEventListener('focus', handler);
+    return () => window.removeEventListener('focus', handler);
+  }, [enabled, revalidateOnFocus, run, staleTime]);
+
+  // Revalidate when the network reconnects.
+  useEffect(() => {
+    if (!enabled || !revalidateOnReconnect) return;
+    if (!isOnline) return;
+    const last = lastFetchedAtRef.current;
+    // If we don't yet have data, the initial-load effect handles it. Only
+    // fire the reconnect revalidation when we already have (likely stale)
+    // data from a prior offline session.
+    if (last === null) return;
+    void run('revalidate');
+  }, [enabled, isOnline, revalidateOnReconnect, run]);
+
+  const revalidate = useCallback(async () => {
+    await run('revalidate');
+  }, [run]);
+
+  return {
+    data,
+    isLoading,
+    isRevalidating,
+    error,
+    fromCache,
+    cachedAt,
+    expiresAt,
+    revalidate,
+  };
+}

--- a/src/hooks/useCachedFetch.ts
+++ b/src/hooks/useCachedFetch.ts
@@ -172,13 +172,19 @@ export function useCachedFetch<T>(
     return () => window.removeEventListener('focus', handler);
   }, [enabled, revalidateOnFocus, run, staleTime]);
 
-  // Revalidate when the network reconnects. We always trigger here — the
-  // common case (came back online, want fresh data) and the recovery case
-  // (initial load failed completely, have nothing on screen) both want a
-  // re-fetch. `inFlightRef` dedupes against an in-progress initial load.
+  // Revalidate when the network reconnects. The `inFlightRef` guard inside
+  // `run` already dedupes the initial-mount case (where this effect fires
+  // simultaneously with the initial-load effect), but we add an explicit
+  // pre-check here so a reader can see the intent: a reconnect-triggered
+  // revalidation only makes sense after at least one load attempt has
+  // produced data — either fresh (`lastFreshAtRef`) or cached
+  // (`hasDataRef`). If the initial load is still in flight or failed
+  // outright with no cache, the initial-load effect — not this one — is
+  // responsible for retrying.
   useEffect(() => {
     if (!enabled || !revalidateOnReconnect) return;
     if (!isOnline) return;
+    if (lastFreshAtRef.current === null && !hasDataRef.current) return;
     void run('revalidate');
   }, [enabled, isOnline, revalidateOnReconnect, run]);
 

--- a/src/hooks/useCachedFetch.ts
+++ b/src/hooks/useCachedFetch.ts
@@ -78,9 +78,21 @@ export function useCachedFetch<T>(
   const fetcherRef = useRef(fetcher);
   fetcherRef.current = fetcher;
 
-  const lastFetchedAtRef = useRef<number | null>(null);
+  // Tracks when fresh (non-cache) data was last received. Used by the
+  // focus-revalidation effect to gate against `staleTime` so we don't slam the
+  // API every time the window is brought to the foreground.
+  const lastFreshAtRef = useRef<number | null>(null);
   const inFlightRef = useRef(false);
   const mountedRef = useRef(true);
+  // Mirror of `enabled` available inside the in-flight async closure. Lets us
+  // discard a late response that arrived after the consumer disabled the hook
+  // (e.g. the user logged out) so the previous user's data never leaks into
+  // the next session.
+  const enabledRef = useRef(enabled);
+  enabledRef.current = enabled;
+  // Mirror of `data` for use inside event handlers that should not re-bind
+  // every render.
+  const hasDataRef = useRef(false);
 
   useEffect(() => {
     mountedRef.current = true;
@@ -90,6 +102,7 @@ export function useCachedFetch<T>(
   }, []);
 
   const run = useCallback(async (mode: 'initial' | 'revalidate') => {
+    if (!enabledRef.current) return;
     if (inFlightRef.current) return;
     inFlightRef.current = true;
     if (mode === 'initial') {
@@ -99,19 +112,25 @@ export function useCachedFetch<T>(
     }
     try {
       const response = await fetcherRef.current();
-      if (!mountedRef.current) return;
+      if (!mountedRef.current || !enabledRef.current) return;
       setData(response.data);
+      hasDataRef.current = true;
       setFromCache(response.fromCache);
       setCachedAt(response.cachedAt);
       setExpiresAt(response.expiresAt);
       setError(null);
-      lastFetchedAtRef.current = Date.now();
+      // Only reset the freshness timer when the response actually came from
+      // the API. If we returned cached data, the data is already considered
+      // stale and a focus/reconnect should be free to revalidate immediately.
+      if (!response.fromCache) {
+        lastFreshAtRef.current = Date.now();
+      }
     } catch (e) {
-      if (!mountedRef.current) return;
+      if (!mountedRef.current || !enabledRef.current) return;
       setError(e instanceof Error ? e : new Error(String(e)));
     } finally {
       inFlightRef.current = false;
-      if (mountedRef.current) {
+      if (mountedRef.current && enabledRef.current) {
         if (mode === 'initial') {
           setIsLoading(false);
         } else {
@@ -121,10 +140,20 @@ export function useCachedFetch<T>(
     }
   }, []);
 
-  // Initial load when enabled flips true.
+  // Initial load when enabled flips true; reset all state when it flips false
+  // so a logout + login as a different user can't briefly show the previous
+  // user's stats.
   useEffect(() => {
     if (!enabled) {
+      setData(null);
+      hasDataRef.current = false;
+      setFromCache(false);
+      setCachedAt(null);
+      setExpiresAt(null);
+      setError(null);
+      setIsRevalidating(false);
       setIsLoading(false);
+      lastFreshAtRef.current = null;
       return;
     }
     void run('initial');
@@ -134,7 +163,7 @@ export function useCachedFetch<T>(
   useEffect(() => {
     if (!enabled || !revalidateOnFocus) return;
     const handler = () => {
-      const last = lastFetchedAtRef.current;
+      const last = lastFreshAtRef.current;
       if (last === null || Date.now() - last >= staleTime) {
         void run('revalidate');
       }
@@ -143,15 +172,13 @@ export function useCachedFetch<T>(
     return () => window.removeEventListener('focus', handler);
   }, [enabled, revalidateOnFocus, run, staleTime]);
 
-  // Revalidate when the network reconnects.
+  // Revalidate when the network reconnects. We always trigger here — the
+  // common case (came back online, want fresh data) and the recovery case
+  // (initial load failed completely, have nothing on screen) both want a
+  // re-fetch. `inFlightRef` dedupes against an in-progress initial load.
   useEffect(() => {
     if (!enabled || !revalidateOnReconnect) return;
     if (!isOnline) return;
-    const last = lastFetchedAtRef.current;
-    // If we don't yet have data, the initial-load effect handles it. Only
-    // fire the reconnect revalidation when we already have (likely stale)
-    // data from a prior offline session.
-    if (last === null) return;
     void run('revalidate');
   }, [enabled, isOnline, revalidateOnReconnect, run]);
 

--- a/src/pages/Home/CacheStatusBanner.tsx
+++ b/src/pages/Home/CacheStatusBanner.tsx
@@ -27,7 +27,10 @@ interface CacheStatusBannerProps {
   onRetry?: () => void;
 }
 
-function formatTimestamp(isoString: string | null): string | null {
+// Format an ISO8601 timestamp as `HH:MM` in the user's local timezone.
+// Local time is intentional here: this is shown directly to the user as
+// "最終更新: HH:MM" and matches what they'd expect from a wall clock.
+function formatLocalTimestamp(isoString: string | null): string | null {
   if (!isoString) return null;
   const date = new Date(isoString);
   if (Number.isNaN(date.getTime())) return null;
@@ -46,7 +49,7 @@ export const CacheStatusBanner = ({
 }: CacheStatusBannerProps) => {
   if (!fromCache && !hasError) return null;
 
-  const cachedTime = formatTimestamp(cachedAt);
+  const cachedTime = formatLocalTimestamp(cachedAt);
   // Distinguish "revalidate failed but cache is on screen" from "initial load
   // failed and we have nothing to show". The original error message implied
   // the former unconditionally, which was misleading in the latter case.

--- a/src/pages/Home/CacheStatusBanner.tsx
+++ b/src/pages/Home/CacheStatusBanner.tsx
@@ -17,6 +17,8 @@ interface CacheStatusBannerProps {
   fromCache: boolean;
   /** Whether the latest revalidation attempt failed. */
   hasError: boolean;
+  /** Whether the dashboard currently has any data to display (cached or fresh). */
+  hasData: boolean;
   /** Whether a background revalidation is currently in flight. */
   isRevalidating: boolean;
   /** ISO8601 timestamp of the cached data being displayed. */
@@ -37,6 +39,7 @@ function formatTimestamp(isoString: string | null): string | null {
 export const CacheStatusBanner = ({
   fromCache,
   hasError,
+  hasData,
   isRevalidating,
   cachedAt,
   onRetry,
@@ -44,9 +47,18 @@ export const CacheStatusBanner = ({
   if (!fromCache && !hasError) return null;
 
   const cachedTime = formatTimestamp(cachedAt);
-  const message = hasError
-    ? '最新化に失敗しました。前回取得したデータを表示中です。'
-    : 'キャッシュされたデータを表示中です。';
+  // Distinguish "revalidate failed but cache is on screen" from "initial load
+  // failed and we have nothing to show". The original error message implied
+  // the former unconditionally, which was misleading in the latter case.
+  let message: string;
+  if (hasError && !hasData) {
+    message = 'データの取得に失敗しました。再試行してください。';
+  } else if (hasError) {
+    message = '最新化に失敗しました。前回取得したデータを表示中です。';
+  } else {
+    message = 'キャッシュされたデータを表示中です。';
+  }
+  const showCachedTime = cachedTime !== null && hasData;
 
   return (
     <div
@@ -56,7 +68,7 @@ export const CacheStatusBanner = ({
       <Icon name="alert-triangle" className="w-4 h-4 flex-shrink-0" />
       <span className="flex-1">
         {message}
-        {cachedTime && (
+        {showCachedTime && (
           <span className="ml-2 text-amber-300/80 text-xs">
             最終更新: {cachedTime}
           </span>

--- a/src/pages/Home/CacheStatusBanner.tsx
+++ b/src/pages/Home/CacheStatusBanner.tsx
@@ -1,0 +1,81 @@
+/**
+ * CacheStatusBanner Component
+ *
+ * Inline banner shown on the Home dashboard when one of the SWR-style data
+ * loaders falls back to cached data or fails to revalidate. Distinct from the
+ * global `OfflineBanner` — that signals network state, this one signals the
+ * freshness of the data the dashboard is currently rendering.
+ *
+ * Related Documentation:
+ *   - Issue: https://github.com/otomatty/development-tools/issues/182
+ */
+
+import { Icon } from '@/components/icons';
+
+interface CacheStatusBannerProps {
+  /** Whether any of the visible data is being served from the cache. */
+  fromCache: boolean;
+  /** Whether the latest revalidation attempt failed. */
+  hasError: boolean;
+  /** Whether a background revalidation is currently in flight. */
+  isRevalidating: boolean;
+  /** ISO8601 timestamp of the cached data being displayed. */
+  cachedAt: string | null;
+  /** Trigger a manual revalidation. */
+  onRetry?: () => void;
+}
+
+function formatTimestamp(isoString: string | null): string | null {
+  if (!isoString) return null;
+  const date = new Date(isoString);
+  if (Number.isNaN(date.getTime())) return null;
+  const hours = date.getHours().toString().padStart(2, '0');
+  const minutes = date.getMinutes().toString().padStart(2, '0');
+  return `${hours}:${minutes}`;
+}
+
+export const CacheStatusBanner = ({
+  fromCache,
+  hasError,
+  isRevalidating,
+  cachedAt,
+  onRetry,
+}: CacheStatusBannerProps) => {
+  if (!fromCache && !hasError) return null;
+
+  const cachedTime = formatTimestamp(cachedAt);
+  const message = hasError
+    ? '最新化に失敗しました。前回取得したデータを表示中です。'
+    : 'キャッシュされたデータを表示中です。';
+
+  return (
+    <div
+      role="status"
+      className="flex items-center gap-2 px-4 py-2 mb-4 bg-amber-500/10 border border-amber-500/30 text-amber-200 text-sm rounded-lg"
+    >
+      <Icon name="alert-triangle" className="w-4 h-4 flex-shrink-0" />
+      <span className="flex-1">
+        {message}
+        {cachedTime && (
+          <span className="ml-2 text-amber-300/80 text-xs">
+            最終更新: {cachedTime}
+          </span>
+        )}
+      </span>
+      {onRetry && (
+        <button
+          type="button"
+          onClick={onRetry}
+          disabled={isRevalidating}
+          className="flex items-center gap-1 px-2 py-1 text-xs rounded hover:bg-amber-500/20 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          <Icon
+            name="refresh-cw"
+            className={`w-3 h-3 ${isRevalidating ? 'animate-spin' : ''}`}
+          />
+          <span>{isRevalidating ? '更新中...' : '再試行'}</span>
+        </button>
+      )}
+    </div>
+  );
+};

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -112,6 +112,8 @@ export const Home = () => {
 
   const fromCache = githubStatsQuery.fromCache || userStatsQuery.fromCache;
   const hasError = githubStatsQuery.error !== null || userStatsQuery.error !== null;
+  const hasData =
+    githubStatsQuery.data !== null || userStatsQuery.data !== null;
   const isRevalidating =
     githubStatsQuery.isRevalidating || userStatsQuery.isRevalidating;
   // Surface the older of the two cache timestamps so the user sees the
@@ -130,6 +132,7 @@ export const Home = () => {
           <CacheStatusBanner
             fromCache={fromCache}
             hasError={hasError}
+            hasData={hasData}
             isRevalidating={isRevalidating}
             cachedAt={bannerCachedAt}
             onRetry={handleRetry}

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -84,20 +84,29 @@ export const Home = () => {
     };
   }, [enabled]);
 
+  const githubRevalidate = githubStatsQuery.revalidate;
+  const userRevalidate = userStatsQuery.revalidate;
   const handleRetry = useCallback(() => {
-    void githubStatsQuery.revalidate();
-    void userStatsQuery.revalidate();
-  }, [githubStatsQuery, userStatsQuery]);
+    void githubRevalidate();
+    void userRevalidate();
+  }, [githubRevalidate, userRevalidate]);
 
   // Initial loading: wait for auth restore and the first data fetch when
   // logged in. Cached data short-circuits this — once any cached value is
   // available we render the dashboard and let the banner communicate
   // freshness.
+  //
+  // We deliberately do NOT depend on the hooks' `isLoading` flags here. When
+  // `enabled` flips from false to true, those flags only become true after
+  // the initial-load effect fires — which is one render frame too late.
+  // Anchoring on `data === null && error === null` shows the skeleton until
+  // either succeeds, avoiding a flash of empty dashboard.
+  const githubPending =
+    githubStatsQuery.data === null && githubStatsQuery.error === null;
+  const userPending =
+    userStatsQuery.data === null && userStatsQuery.error === null;
   const initialDataLoading =
-    isLoggedIn &&
-    (githubStatsQuery.isLoading || userStatsQuery.isLoading || levelLoading) &&
-    githubStatsQuery.data === null &&
-    userStatsQuery.data === null;
+    isLoggedIn && (githubPending || userPending || levelLoading);
 
   const isLoading = authLoading || initialDataLoading;
 

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -4,17 +4,26 @@
  * Main dashboard page showing gamification features.
  * Displays LoginCard for unauthenticated users or DashboardContent for authenticated users.
  *
+ * GitHub stats and user stats are fetched through `*_with_cache` Tauri commands
+ * with SWR-style revalidation so the dashboard stays responsive even when the
+ * GitHub API is slow, rate-limited, or unreachable.
+ *
  * Related Documentation:
- *   - Issue: https://github.com/otomatty/development-tools/issues/149
- *   - Original (Leptos): ../components/pages/home/mod.rs
+ *   - Issues: https://github.com/otomatty/development-tools/issues/149
+ *             https://github.com/otomatty/development-tools/issues/182
  */
 
-import { useState, useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { LoginCard } from '../../components/features/auth';
 import { DashboardContent, XpNotification } from '../../components/features/gamification';
 import { useAuth } from '../../stores/authStore';
+import { useCachedFetch } from '../../hooks/useCachedFetch';
 import { gamification, github } from '../../lib/tauri/commands';
-import type { GitHubStats, LevelInfo, UserStats, XpGainedEvent } from '../../types';
+import type { LevelInfo, XpGainedEvent } from '../../types';
+import { CacheStatusBanner } from './CacheStatusBanner';
+
+const STATS_STALE_TIME_MS = 30 * 60 * 1000; // 30 minutes
+const USER_STATS_STALE_TIME_MS = 60 * 60 * 1000; // 60 minutes
 
 // Home skeleton loader
 const HomeSkeleton = () => (
@@ -33,56 +42,96 @@ export const Home = () => {
   const isLoggedIn = useAuth(s => s.state.isLoggedIn);
   const authLoading = useAuth(s => s.isLoading);
   const [xpEvent, setXpEvent] = useState<XpGainedEvent | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [githubStats, setGithubStats] = useState<GitHubStats | null>(null);
+
+  const enabled = !authLoading && isLoggedIn;
+
+  const githubStatsQuery = useCachedFetch(github.getStatsWithCache, {
+    enabled,
+    staleTime: STATS_STALE_TIME_MS,
+  });
+
+  const userStatsQuery = useCachedFetch(github.getUserStatsWithCache, {
+    enabled,
+    staleTime: USER_STATS_STALE_TIME_MS,
+  });
+
+  // `level_info` does not yet have a `_with_cache` variant — it is computed
+  // from local DB state and is cheap, so a plain fetch is fine here.
   const [levelInfo, setLevelInfo] = useState<LevelInfo | null>(null);
-  const [userStats, setUserStats] = useState<UserStats | null>(null);
-  const [dataLoading, setDataLoading] = useState(false);
+  const [levelLoading, setLevelLoading] = useState(false);
 
   useEffect(() => {
-    // Wait for auth restoration to complete
-    if (authLoading) return;
-
-    if (!isLoggedIn) {
-      setLoading(false);
+    if (!enabled) {
+      setLevelInfo(null);
       return;
     }
-
     let cancelled = false;
-    setLoading(true);
-    setDataLoading(true);
-    Promise.all([
-      github.getStats().catch(e => { console.error('Failed to load GitHub stats:', e); return null; }),
-      gamification.getLevelInfo().catch(e => { console.error('Failed to load level info:', e); return null; }),
-      github.getUserStats().catch(e => { console.error('Failed to load user stats:', e); return null; }),
-    ]).then(([stats, level, uStats]) => {
-      if (cancelled) return;
-      setGithubStats(stats);
-      setLevelInfo(level);
-      setUserStats(uStats);
-      setDataLoading(false);
-      setLoading(false);
-    });
+    setLevelLoading(true);
+    gamification
+      .getLevelInfo()
+      .then(info => {
+        if (!cancelled) setLevelInfo(info);
+      })
+      .catch(e => {
+        console.error('Failed to load level info:', e);
+        if (!cancelled) setLevelInfo(null);
+      })
+      .finally(() => {
+        if (!cancelled) setLevelLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled]);
 
-    return () => { cancelled = true; };
-  }, [authLoading, isLoggedIn]);
+  const handleRetry = useCallback(() => {
+    void githubStatsQuery.revalidate();
+    void userStatsQuery.revalidate();
+  }, [githubStatsQuery, userStatsQuery]);
 
-  // TODO: [FEATURE] Implement stats diff resource when sync result tracking is available
-  // Stats diff is typically available after sync, but currently not implemented
+  // Initial loading: wait for auth restore and the first data fetch when
+  // logged in. Cached data short-circuits this — once any cached value is
+  // available we render the dashboard and let the banner communicate
+  // freshness.
+  const initialDataLoading =
+    isLoggedIn &&
+    (githubStatsQuery.isLoading || userStatsQuery.isLoading || levelLoading) &&
+    githubStatsQuery.data === null &&
+    userStatsQuery.data === null;
 
-  const isLoading = loading || (isLoggedIn && dataLoading);
+  const isLoading = authLoading || initialDataLoading;
+
+  const fromCache = githubStatsQuery.fromCache || userStatsQuery.fromCache;
+  const hasError = githubStatsQuery.error !== null || userStatsQuery.error !== null;
+  const isRevalidating =
+    githubStatsQuery.isRevalidating || userStatsQuery.isRevalidating;
+  // Surface the older of the two cache timestamps so the user sees the
+  // worst-case staleness rather than the freshest sub-component's.
+  const bannerCachedAt =
+    [githubStatsQuery.cachedAt, userStatsQuery.cachedAt]
+      .filter((value): value is string => value !== null)
+      .sort()[0] ?? null;
 
   return (
     <div className="flex-1 overflow-y-auto p-6">
       {isLoading ? (
         <HomeSkeleton />
       ) : isLoggedIn ? (
-        <DashboardContent
-          levelInfo={levelInfo}
-          userStats={userStats}
-          githubStats={githubStats}
-          statsDiff={null}
-        />
+        <>
+          <CacheStatusBanner
+            fromCache={fromCache}
+            hasError={hasError}
+            isRevalidating={isRevalidating}
+            cachedAt={bannerCachedAt}
+            onRetry={handleRetry}
+          />
+          <DashboardContent
+            levelInfo={levelInfo}
+            userStats={userStatsQuery.data}
+            githubStats={githubStatsQuery.data}
+            statsDiff={null}
+          />
+        </>
       ) : (
         <LoginCard />
       )}


### PR DESCRIPTION
## Summary

Implements Stale-While-Revalidate (SWR) pattern for GitHub and user stats fetching, allowing the dashboard to display cached data immediately while revalidating in the background. Adds a new `useCachedFetch` hook and `CacheStatusBanner` component to communicate cache freshness to users.

## Key Changes

- **New `useCachedFetch` hook** (`src/hooks/useCachedFetch.ts`): SWR-style fetcher for Tauri commands returning `CachedResponse<T>`. Exposes cached data immediately via backend cache fallback and revalidates on focus/reconnect events based on configurable `staleTime`.

- **Cache status UI** (`src/pages/Home/CacheStatusBanner.tsx`): New banner component that displays when data is served from cache or revalidation fails. Shows last update time and provides a manual retry button.

- **Home page refactor** (`src/pages/Home/Home.tsx`): Migrated from Promise.all sequential fetching to `useCachedFetch` for GitHub stats and user stats. Implements proper loading states that distinguish between initial load and background revalidation. Displays `CacheStatusBanner` when data is stale or errors occur.

- **Backend cache priming** (`src-tauri/src/commands/github.rs`): 
  - `run_github_sync` now primes the `GITHUB_STATS` cache after successful sync so subsequent `get_github_stats_with_cache` calls serve fresh data without re-hitting the API
  - Both `get_github_stats_with_cache` and `get_user_stats_with_cache` now always refresh the cache on success (not just on fallback), ensuring the SWR frontend can render last-known stats during transient failures

- **Cache duration constants** (`src-tauri/src/database/models/cache.rs`): Centralized cache expiration times (`GITHUB_STATS: 30 min`, `USER_STATS: 60 min`) for consistency across sync and fetch paths.

- **Documentation** (`src-tauri/src/commands/cache_fallback.spec.md`): Updated spec to clarify cache population on success paths, error handling strategy, and frontend SWR integration.

## Implementation Details

- The hook prevents redundant in-flight requests and respects the `enabled` flag to avoid fetching before auth is resolved
- Revalidation only triggers when data is stale (older than `staleTime`), reducing unnecessary API calls
- Network reconnection triggers revalidation only if data already exists (avoiding duplicate initial loads)
- Component unmounting is tracked to prevent state updates on unmounted components
- Cache timestamps are surfaced to the UI so users see worst-case staleness across multiple data sources

https://claude.ai/code/session_01LRGgEvwCPyoQ1jCtu8Ck4c
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/development-tools/pull/200" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ホームにキャッシュステータスバナーを追加：キャッシュ表示、再検証状況、再試行操作を表示します。
  * 汎用のキャッシュ対応フェッチフックを導入し、SWR風の stale-while-revalidate（フォーカス/再接続での再検証、手動再検証）を提供します。

* **改善**
  * キャッシュ有効期限を中央管理に統一し、同期処理や成功した取得で即時上書きされます。
  * ネットワーク/レート制限失敗時はキャッシュフォールバックを行い、401（認証切れ）はフォールバックせず認証失効を通知します。

* **テスト / ドキュメント**
  * フォールバックと同期挙動を検証するテストを追加、関連ドキュメントを更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->