### PR TITLE
Add unit tests for GitHub issues command

### DIFF
--- a/src-tauri/src/commands/issues.rs
+++ b/src-tauri/src/commands/issues.rs
@@ -885,3 +885,140 @@ async fn get_access_token(state: &State<'_, AppState>) -> Result<String, String>
         .await
         .map_err(|e| format!("Failed to get token: {}", e))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::github::issues::{GitHubAssignee, GitHubLabel, GitHubSearchItem};
+    use chrono::TimeZone;
+
+    fn make_search_item(
+        repository_url: &str,
+        pull_request: Option<serde_json::Value>,
+        labels: Vec<&str>,
+    ) -> GitHubSearchItem {
+        let created = Utc.with_ymd_and_hms(2026, 4, 1, 12, 0, 0).unwrap();
+        let updated = Utc.with_ymd_and_hms(2026, 4, 2, 12, 0, 0).unwrap();
+        GitHubSearchItem {
+            id: 42,
+            number: 7,
+            title: "example".into(),
+            body: None,
+            state: "open".into(),
+            state_reason: None,
+            html_url: "https://github.com/octo/test/issues/7".into(),
+            repository_url: repository_url.into(),
+            labels: labels
+                .into_iter()
+                .enumerate()
+                .map(|(i, name)| GitHubLabel {
+                    id: i as i64,
+                    name: name.to_string(),
+                    color: "ededed".into(),
+                    description: None,
+                })
+                .collect(),
+            assignee: Some(GitHubAssignee {
+                id: 1,
+                login: "alice".into(),
+                avatar_url: "https://avatars.githubusercontent.com/u/1".into(),
+            }),
+            assignees: None,
+            user: Some(GitHubAssignee {
+                id: 2,
+                login: "bob".into(),
+                avatar_url: "https://avatars.githubusercontent.com/u/2".into(),
+            }),
+            created_at: created,
+            updated_at: updated,
+            closed_at: None,
+            pull_request,
+        }
+    }
+
+    // TC-001: aggregating logic — verify the issue / source / labels / metadata
+    // mapping for an `assigned` row.
+    #[test]
+    fn convert_search_item_maps_assigned_issue() {
+        let item = make_search_item(
+            "https://api.github.com/repos/octo/test",
+            None,
+            vec!["bug", "priority:high"],
+        );
+
+        let row = convert_search_item(item, "assigned");
+
+        assert_eq!(row.kind, "issue");
+        assert_eq!(row.source, "assigned");
+        assert_eq!(row.repo_owner, "octo");
+        assert_eq!(row.repo_name, "test");
+        assert_eq!(row.repo_full_name, "octo/test");
+        assert_eq!(row.priority.as_deref(), Some("high"));
+        assert_eq!(row.labels, vec!["bug".to_string(), "priority:high".to_string()]);
+        assert_eq!(row.assignee_login.as_deref(), Some("alice"));
+        assert_eq!(row.author_login.as_deref(), Some("bob"));
+    }
+
+    // TC-001 + TC-006: PR detection through `is_pull_request` flows into
+    // `kind = "pull_request"` for review-requested rows.
+    #[test]
+    fn convert_search_item_maps_review_requested_pull_request() {
+        let item = make_search_item(
+            "https://api.github.com/repos/octo/test",
+            Some(serde_json::json!({"url": "..."})),
+            vec![],
+        );
+
+        let row = convert_search_item(item, "review_requested");
+
+        assert_eq!(row.kind, "pull_request");
+        assert_eq!(row.source, "review_requested");
+        assert!(row.priority.is_none());
+        assert!(row.labels.is_empty());
+    }
+
+    // TC-007: a GHES (or any unexpected host) `repository_url` must not be
+    // mis-parsed into a wrong owner/repo. Falling back to the raw URL keeps
+    // the link clickable without inventing a bogus repo path.
+    #[test]
+    fn convert_search_item_falls_back_to_url_for_unexpected_host() {
+        let item = make_search_item(
+            "https://ghe.example.com/api/v3/repos/o/r",
+            None,
+            vec![],
+        );
+
+        let row = convert_search_item(item, "assigned");
+
+        assert_eq!(row.repo_owner, "");
+        assert_eq!(row.repo_name, "");
+        assert_eq!(row.repo_full_name, "https://ghe.example.com/api/v3/repos/o/r");
+    }
+
+    // TC-002 / TC-005: rate-limit and incomplete-results errors must be
+    // classified as transient so the command falls back to cached data.
+    #[test]
+    fn classifies_transient_errors_as_network_or_rate_limit() {
+        assert!(is_network_or_rate_limit_error(&GitHubError::RateLimited(0)));
+        assert!(is_network_or_rate_limit_error(&GitHubError::Incomplete(
+            "search timeout".into()
+        )));
+    }
+
+    // TC-004: 401 must NOT be classified as transient — the command needs to
+    // fire the auth-expired flow instead of serving stale cache.
+    // ApiError / NotFound / GraphQL likewise are surfaced rather than masked.
+    #[test]
+    fn classifies_hard_errors_as_non_transient() {
+        assert!(!is_network_or_rate_limit_error(&GitHubError::Unauthorized));
+        assert!(!is_network_or_rate_limit_error(&GitHubError::ApiError(
+            "500 internal".into()
+        )));
+        assert!(!is_network_or_rate_limit_error(&GitHubError::NotFound(
+            "x".into()
+        )));
+        assert!(!is_network_or_rate_limit_error(&GitHubError::GraphQL(
+            "y".into()
+        )));
+    }
+}

--- a/src-tauri/src/commands/issues.rs
+++ b/src-tauri/src/commands/issues.rs
@@ -954,7 +954,10 @@ mod tests {
         assert_eq!(row.repo_name, "test");
         assert_eq!(row.repo_full_name, "octo/test");
         assert_eq!(row.priority.as_deref(), Some("high"));
-        assert_eq!(row.labels, vec!["bug".to_string(), "priority:high".to_string()]);
+        assert_eq!(
+            row.labels,
+            vec!["bug".to_string(), "priority:high".to_string()]
+        );
         assert_eq!(row.assignee_login.as_deref(), Some("alice"));
         assert_eq!(row.author_login.as_deref(), Some("bob"));
     }
@@ -982,17 +985,16 @@ mod tests {
     // the link clickable without inventing a bogus repo path.
     #[test]
     fn convert_search_item_falls_back_to_url_for_unexpected_host() {
-        let item = make_search_item(
-            "https://ghe.example.com/api/v3/repos/o/r",
-            None,
-            vec![],
-        );
+        let item = make_search_item("https://ghe.example.com/api/v3/repos/o/r", None, vec![]);
 
         let row = convert_search_item(item, "assigned");
 
         assert_eq!(row.repo_owner, "");
         assert_eq!(row.repo_name, "");
-        assert_eq!(row.repo_full_name, "https://ghe.example.com/api/v3/repos/o/r");
+        assert_eq!(
+            row.repo_full_name,
+            "https://ghe.example.com/api/v3/repos/o/r"
+        );
     }
 
     // TC-002 / TC-005: rate-limit and incomplete-results errors must be

--- a/src-tauri/src/commands/issues.rs
+++ b/src-tauri/src/commands/issues.rs
@@ -1009,7 +1009,9 @@ mod tests {
 
     // TC-004: 401 must NOT be classified as transient — the command needs to
     // fire the auth-expired flow instead of serving stale cache.
-    // ApiError / NotFound / GraphQL likewise are surfaced rather than masked.
+    // ApiError / NotFound / GraphQL / JsonParse likewise are surfaced rather
+    // than masked: a malformed Search API payload is a real bug, not a
+    // transient hiccup, and serving stale cache would hide it.
     #[test]
     fn classifies_hard_errors_as_non_transient() {
         assert!(!is_network_or_rate_limit_error(&GitHubError::Unauthorized));
@@ -1021,6 +1023,10 @@ mod tests {
         )));
         assert!(!is_network_or_rate_limit_error(&GitHubError::GraphQL(
             "y".into()
+        )));
+        let json_err = serde_json::from_str::<i32>("not a number").unwrap_err();
+        assert!(!is_network_or_rate_limit_error(&GitHubError::JsonParse(
+            json_err
         )));
     }
 }


### PR DESCRIPTION
## Summary
This PR adds comprehensive unit tests for the GitHub issues command module, covering the core logic for converting GitHub search results and error classification.

## Key Changes
- **Test helper function**: Added `make_search_item()` to construct test `GitHubSearchItem` objects with configurable repository URLs, pull request data, and labels
- **Conversion logic tests**:
  - `convert_search_item_maps_assigned_issue()` — Verifies correct mapping of issue metadata including owner/repo extraction, priority label parsing, and assignee/author fields
  - `convert_search_item_maps_review_requested_pull_request()` — Validates pull request detection and kind classification for review-requested items
  - `convert_search_item_falls_back_to_url_for_unexpected_host()` — Ensures graceful fallback to raw URL for non-GitHub hosts (GHES compatibility)
- **Error classification tests**:
  - `classifies_transient_errors_as_network_or_rate_limit()` — Confirms rate limit and incomplete result errors are treated as transient
  - `classifies_hard_errors_as_non_transient()` — Verifies 401 Unauthorized and other hard errors are not masked as transient

## Notable Details
- Tests are organized with descriptive comments referencing test case IDs (TC-001 through TC-007) for traceability
- Covers edge cases like GHES repository URL parsing and error classification for cache fallback behavior
- Uses chrono for timestamp generation in test fixtures

https://claude.ai/code/session_01EZiHnqQ87omah1zzFPEyYM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **テスト**
  * GitHub検索アイテムの変換処理に関する単体テストを追加しました。担当付与されたIssue、レビュー依頼中のPR、想定外のリポジトリURLホストそれぞれで、種別判定、リポジトリ情報の取り扱い、ラベルからの優先度抽出、担当者／作成者のマッピングを検証します。
  * ネットワーク／レート制限エラー分類に関するテストを追加し、キャッシュフォールバックが許容される一時的エラーと適用されない非一時的エラーの振る舞いを確認します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->