### PR TITLE
feat: Add GitHub Notifications integration with ETag-based polling

### DIFF
--- a/src-tauri/src/auth/token.rs
+++ b/src-tauri/src/auth/token.rs
@@ -84,6 +84,25 @@ impl TokenManager {
             .map_err(|e| e.into())
     }
 
+    /// Get the current user *and* the decrypted access token from the same
+    /// row read.
+    ///
+    /// Combining the two lookups closes a race where the user logs out (or
+    /// switches accounts) between separate `get_access_token()` and
+    /// `get_current_user()` calls — without it, a command can issue an API
+    /// request with account A's token and then persist the response under
+    /// account B's local `user.id`. Callers that need both must use this
+    /// method instead of the two-step pattern.
+    pub async fn get_current_user_with_token(&self) -> TokenResult<(User, String)> {
+        let user = self
+            .db
+            .get_current_user()
+            .await?
+            .ok_or(TokenError::NotLoggedIn)?;
+        let token = self.crypto.decrypt(&user.access_token_encrypted)?;
+        Ok((user, token))
+    }
+
     /// Create a new user from OAuth token
     pub async fn create_user_from_token(
         &self,

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -78,11 +78,40 @@ pub async fn get_auth_state(state: State<'_, AppState>) -> Result<AuthState, Str
 /// Logout current user
 #[command]
 pub async fn logout(state: State<'_, AppState>) -> Result<(), String> {
+    // Capture the user *before* the token wipe so we can purge their
+    // notifications cache below — once `logout()` clears the token,
+    // `get_current_user()` still works (logout preserves user data) so
+    // technically either order works, but capturing here avoids a race
+    // if the order ever changes.
+    let user_id = state
+        .token_manager
+        .get_current_user()
+        .await
+        .map_err(|e| e.to_string())?
+        .map(|u| u.id);
+
     state
         .token_manager
         .logout()
         .await
         .map_err(|e| e.to_string())?;
+
+    // Purge the notifications cache so issue / PR titles and repo names
+    // captured while logged in don't sit in the local DB indefinitely
+    // (the cache TTL is intentionally long so it survives
+    // `clear_expired_cache`'s startup sweep, but a logout is an explicit
+    // signal that the data is no longer needed). The ETag / cursor in
+    // `sync_metadata` are non-sensitive hashes and are kept so a re-login
+    // can resume conditional polling.
+    if let Some(uid) = user_id {
+        if let Err(e) = state
+            .db
+            .delete_cache_entry(uid, crate::database::cache_types::GITHUB_NOTIFICATIONS)
+            .await
+        {
+            eprintln!("Failed to purge notifications cache on logout: {}", e);
+        }
+    }
 
     Ok(())
 }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -3,6 +3,7 @@ pub mod challenge;
 pub mod gamification;
 pub mod github;
 pub mod issues;
+pub mod notifications;
 pub mod scheduler;
 pub mod settings;
 
@@ -11,5 +12,6 @@ pub use challenge::*;
 pub use gamification::*;
 pub use github::*;
 pub use issues::*;
+pub use notifications::*;
 pub use scheduler::*;
 pub use settings::*;

--- a/src-tauri/src/commands/notifications.rs
+++ b/src-tauri/src/commands/notifications.rs
@@ -2,17 +2,23 @@
 //!
 //! Surface mentions, review requests, and issue / PR comments to the frontend.
 //! Uses ETag-based conditional fetching (persisted on `sync_metadata`) so
-//! polling costs zero rate-limit budget when nothing has changed.
+//! polling costs zero rate-limit budget when nothing has changed. The
+//! returned items are also persisted to `activity_cache` so that 304
+//! responses (and cold starts) can still render the last-known list
+//! without forcing a fresh fetch.
 //!
 //! Related Issue: GitHub Issue #186 - GitHub Notifications 連携
 //! Related Audit: 監査レポート §1 ギャップ表 / §8 G-05.
 
 use chrono::{DateTime, Utc};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use tauri::{command, AppHandle, Emitter, State};
 
 use super::auth::AppState;
 use crate::auth::map_github_result;
+use crate::database::cache_durations;
+use crate::database::cache_types;
+use crate::github::client::GitHubError;
 use crate::github::{
     build_notification_html_url, GitHubNotification, NotificationsClient, NotificationsResponse,
 };
@@ -25,7 +31,7 @@ pub const GITHUB_NOTIFICATIONS_SYNC_TYPE: &str = "github_notifications";
 ///
 /// Flat shape — each row pre-computes the browser URL so the UI doesn't need
 /// to mirror `build_html_url`'s API → web translation.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NotificationItem {
     pub id: String,
@@ -67,27 +73,32 @@ impl From<&GitHubNotification> for NotificationItem {
 pub struct NotificationsPayload {
     pub items: Vec<NotificationItem>,
     pub unread_count: i32,
-    /// True when GitHub returned 304 — the items list is empty and the
-    /// caller should keep showing whatever it already had.
+    /// True when the list came from the local cache rather than a fresh
+    /// GitHub fetch (e.g. GitHub responded 304).
     pub from_cache: bool,
     /// `x-poll-interval` (seconds) hint from GitHub. The scheduler honours
     /// this; the UI just surfaces it for diagnostics.
     pub poll_interval_seconds: Option<u64>,
 }
 
-/// Event emitted when new unread notifications are observed during a sync.
+/// Event emitted when the scheduler observes new notification activity.
+///
+/// Includes the freshly-fetched items so the UI can update directly
+/// without a second round-trip — a re-fetch would race the just-persisted
+/// ETag and come back as 304.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NotificationsUpdatedEvent {
     pub unread_count: i32,
     pub new_count: i32,
+    pub items: Vec<NotificationItem>,
 }
 
 /// Fetch the authenticated user's notifications.
 ///
 /// Pulls the previous ETag from `sync_metadata` to issue a conditional
-/// request. On 304 returns `from_cache = true` with an empty list — the
-/// frontend should ignore the empty payload and keep its current state.
+/// request. On 304 (or transient network failure) returns the last-known
+/// list from `activity_cache` with `from_cache = true`.
 #[command]
 pub async fn get_notifications(
     app: AppHandle,
@@ -112,12 +123,15 @@ pub async fn get_notifications(
         .await
         .map_err(|e| e.to_string())?;
     let prior_etag = metadata.as_ref().and_then(|m| m.etag.clone());
+    let prior_cursor = metadata.as_ref().and_then(|m| m.last_sync_cursor.clone());
 
     let client = NotificationsClient::new(token);
     let response = map_github_result(
         &app,
         state.inner(),
-        client.list_notifications(prior_etag.as_deref(), false).await,
+        client
+            .list_notifications(prior_etag.as_deref(), false)
+            .await,
     )
     .await?;
 
@@ -125,13 +139,27 @@ pub async fn get_notifications(
         NotificationsResponse::NotModified {
             poll_interval_seconds,
         } => {
-            // Refresh `last_sync_at` so the scheduler knows we polled
-            // successfully even when nothing changed. The ETag we already
-            // hold remains valid.
-            persist_sync_success(state.inner(), user.id, None).await;
+            // 304: explicitly preserve the existing ETag and cursor so a
+            // future call to `update_sync_metadata` (e.g. through a
+            // different code path) can't accidentally clear them via the
+            // COALESCE pattern. `last_sync_at` still gets refreshed.
+            persist_sync_success_with_cursor(
+                state.inner(),
+                user.id,
+                prior_etag.as_deref(),
+                prior_cursor.as_deref(),
+            )
+            .await;
+
+            // Return the last-known list from the cache so cold starts
+            // (where the in-memory store is empty but the persisted ETag
+            // is fresh) still show notifications.
+            let cached = load_cached_items(state.inner(), user.id).await;
+            let unread_count = cached.iter().filter(|i| i.unread).count() as i32;
+
             Ok(NotificationsPayload {
-                items: Vec::new(),
-                unread_count: 0,
+                items: cached,
+                unread_count,
                 from_cache: true,
                 poll_interval_seconds,
             })
@@ -145,7 +173,7 @@ pub async fn get_notifications(
                 notifications.iter().map(NotificationItem::from).collect();
             let unread_count = items.iter().filter(|i| i.unread).count() as i32;
 
-            // Persist the new ETag and the latest seen `updated_at` so the
+            // Persist the new ETag + the latest seen `updated_at` so the
             // next poll can issue a conditional request and detect
             // genuinely-new items. A failure here is logged but doesn't
             // fail the command — we already have the data.
@@ -161,6 +189,11 @@ pub async fn get_notifications(
                 new_cursor.as_deref(),
             )
             .await;
+
+            // Mirror the items into `activity_cache` so the next 304 (or a
+            // cold start before the first scheduler tick) can still serve
+            // a populated list.
+            save_items_cache(state.inner(), user.id, &items).await;
 
             Ok(NotificationsPayload {
                 items,
@@ -188,18 +221,36 @@ pub async fn mark_notification_read(
         .map_err(|e| e.to_string())?;
 
     let client = NotificationsClient::new(token);
-    map_github_result(&app, state.inner(), client.mark_thread_as_read(&thread_id).await).await
+    map_github_result(
+        &app,
+        state.inner(),
+        client.mark_thread_as_read(&thread_id).await,
+    )
+    .await
 }
 
-/// Refresh notifications and emit a `notifications-updated` event when the
-/// unread count changes. Used by the background scheduler.
+/// Outcome of [`run_notifications_sync`] — surfaced to the scheduler so it
+/// can apply rate-limit backoff to the notifications stream independently
+/// of the stats sync.
+pub enum NotificationsSyncOutcome {
+    /// Sync completed (304 or fresh data); the scheduler can poll again on
+    /// its normal cadence.
+    Ok,
+    /// GitHub responded with 0 remaining + a reset timestamp. The scheduler
+    /// should hold off on the next notifications poll until then.
+    RateLimited { reset_at: DateTime<Utc> },
+}
+
+/// Refresh notifications and emit a `notifications-updated` event when new
+/// activity is observed. Used by the background scheduler.
 ///
-/// Returns the unread count so the scheduler can record it; errors are
-/// returned as strings to match the rest of the command surface.
+/// Returns a [`NotificationsSyncOutcome`] so the scheduler can record a
+/// rate-limit reset and back off accordingly. Other errors (network /
+/// auth) are returned as strings to match the rest of the command surface.
 pub async fn run_notifications_sync(
     app: &AppHandle,
     state: &AppState,
-) -> Result<i32, String> {
+) -> Result<NotificationsSyncOutcome, String> {
     let token = state
         .token_manager
         .get_access_token()
@@ -219,37 +270,60 @@ pub async fn run_notifications_sync(
         .await
         .map_err(|e| e.to_string())?;
     let prior_etag = metadata.as_ref().and_then(|m| m.etag.clone());
+    let prior_cursor = metadata.as_ref().and_then(|m| m.last_sync_cursor.clone());
 
     let client = NotificationsClient::new(token);
-    let response = map_github_result(
-        app,
-        state,
-        client.list_notifications(prior_etag.as_deref(), false).await,
-    )
-    .await?;
+    let raw_result = client
+        .list_notifications(prior_etag.as_deref(), false)
+        .await;
+
+    // Intercept rate-limit errors so we can persist the reset and back off
+    // on subsequent ticks. Other errors fall through to the standard
+    // `map_github_result` treatment (which handles auth-expired etc.).
+    if let Err(GitHubError::RateLimited(reset_ts)) = &raw_result {
+        let reset_at = DateTime::from_timestamp(*reset_ts, 0).unwrap_or_else(Utc::now);
+        if let Err(e) = state
+            .db
+            .record_sync_rate_limit(user.id, GITHUB_NOTIFICATIONS_SYNC_TYPE, reset_at)
+            .await
+        {
+            eprintln!("Failed to record notifications rate-limit: {}", e);
+        }
+        return Ok(NotificationsSyncOutcome::RateLimited { reset_at });
+    }
+
+    let response = map_github_result(app, state, raw_result).await?;
 
     match response {
         NotificationsResponse::NotModified { .. } => {
-            persist_sync_success(state, user.id, None).await;
-            // No-op event: the unread count didn't change. We deliberately
-            // skip emitting `notifications-updated` to avoid waking the UI
-            // for nothing.
-            Ok(0)
+            // 304: explicitly preserve the existing ETag and cursor (the
+            // server hasn't given us new ones).
+            persist_sync_success_with_cursor(
+                state,
+                user.id,
+                prior_etag.as_deref(),
+                prior_cursor.as_deref(),
+            )
+            .await;
+            // No-op event: the unread count didn't change. Skip emitting
+            // `notifications-updated` to avoid waking the UI for nothing.
+            Ok(NotificationsSyncOutcome::Ok)
         }
         NotificationsResponse::Modified {
             notifications,
             etag,
             ..
         } => {
-            let unread_count = notifications.iter().filter(|n| n.unread).count() as i32;
+            let items: Vec<NotificationItem> =
+                notifications.iter().map(NotificationItem::from).collect();
+            let unread_count = items.iter().filter(|i| i.unread).count() as i32;
 
-            // Find the cutoff used for "new since last poll": stored in
-            // `sync_metadata.last_sync_cursor` as an RFC3339 timestamp. The
-            // first run has no cutoff and we suppress toasts to avoid a
-            // backlog dump.
-            let last_seen_at = metadata
+            // Cutoff used for "new since last poll": stored in
+            // `sync_metadata.last_sync_cursor` as an RFC3339 timestamp.
+            // The first run has no cutoff and we suppress toasts to avoid
+            // a backlog dump.
+            let last_seen_at = prior_cursor
                 .as_ref()
-                .and_then(|m| m.last_sync_cursor.as_ref())
                 .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
                 .map(|dt| dt.with_timezone(&Utc));
 
@@ -274,18 +348,26 @@ pub async fn run_notifications_sync(
                 .map(|n| n.updated_at)
                 .max()
                 .map(|t| t.to_rfc3339());
-            persist_sync_success_with_cursor(state, user.id, etag.as_deref(), new_cursor.as_deref())
-                .await;
+            persist_sync_success_with_cursor(
+                state,
+                user.id,
+                etag.as_deref(),
+                new_cursor.as_deref(),
+            )
+            .await;
+            save_items_cache(state, user.id, &items).await;
 
-            // Emit the event regardless of whether the count is zero — the UI
-            // consumes this as a "go re-fetch the list" signal.
+            // Emit the items inline — the frontend would otherwise have
+            // to re-fetch and immediately hit the just-saved ETag, getting
+            // 304 and stale UI back.
             let event = NotificationsUpdatedEvent {
                 unread_count,
                 new_count,
+                items,
             };
             let _ = app.emit("notifications-updated", &event);
 
-            Ok(unread_count)
+            Ok(NotificationsSyncOutcome::Ok)
         }
     }
 }
@@ -307,7 +389,10 @@ async fn maybe_send_os_notifications(
     let settings = match state.db.get_or_create_user_settings(user_id).await {
         Ok(s) => s,
         Err(e) => {
-            eprintln!("Failed to load user settings for notifications toast: {}", e);
+            eprintln!(
+                "Failed to load user settings for notifications toast: {}",
+                e
+            );
             return;
         }
     };
@@ -342,16 +427,14 @@ async fn maybe_send_os_notifications(
 
 /// Persist a successful notifications sync to `sync_metadata`.
 ///
+/// Always writes `last_sync_at`. ETag and cursor are passed through to
+/// `update_sync_metadata`, which uses `COALESCE(?, col)` so `None` keeps
+/// the existing column value — call sites should pass the prior values
+/// explicitly on 304 to make the intent obvious in code review.
+///
 /// Best-effort writes — failures are logged but never fail the user-facing
 /// command. Mirrors `commands::github::persist_sync_success` for the stats
 /// sync.
-async fn persist_sync_success(state: &AppState, user_id: i64, etag: Option<&str>) {
-    persist_sync_success_with_cursor(state, user_id, etag, None).await;
-}
-
-/// Variant of [`persist_sync_success`] that also writes the
-/// `last_sync_cursor` (used to track the most recent notification
-/// `updated_at` so the next poll knows what's "new").
 async fn persist_sync_success_with_cursor(
     state: &AppState,
     user_id: i64,
@@ -400,5 +483,53 @@ async fn persist_sync_success_with_cursor(
         .await
     {
         eprintln!("Failed to clear notifications sync_rate_limit: {}", e);
+    }
+}
+
+/// Save the notifications list to `activity_cache` so 304 responses (and
+/// cold starts before the scheduler ticks) can still serve a populated UI.
+async fn save_items_cache(state: &AppState, user_id: i64, items: &[NotificationItem]) {
+    let json = match serde_json::to_string(items) {
+        Ok(j) => j,
+        Err(e) => {
+            eprintln!("Failed to serialize notifications cache: {}", e);
+            return;
+        }
+    };
+    let expires_at = Utc::now() + chrono::Duration::minutes(cache_durations::GITHUB_NOTIFICATIONS);
+    if let Err(e) = state
+        .db
+        .save_cache(
+            user_id,
+            cache_types::GITHUB_NOTIFICATIONS,
+            &json,
+            expires_at,
+        )
+        .await
+    {
+        eprintln!("Failed to persist notifications cache: {}", e);
+    }
+}
+
+/// Load the cached notifications list. Falls back to an empty Vec on miss
+/// or parse failure — callers treat this as "no known items".
+///
+/// We use `get_any_cache` (rather than `get_cache`, which filters expired)
+/// because the cache TTL is just a stale-render bound: a slightly-stale
+/// list is still better than an empty UI when GitHub responds 304.
+async fn load_cached_items(state: &AppState, user_id: i64) -> Vec<NotificationItem> {
+    match state
+        .db
+        .get_any_cache(user_id, cache_types::GITHUB_NOTIFICATIONS)
+        .await
+    {
+        Ok(Some((json, _cached_at, _expires_at))) => {
+            serde_json::from_str(&json).unwrap_or_default()
+        }
+        Ok(None) => Vec::new(),
+        Err(e) => {
+            eprintln!("Failed to load notifications cache: {}", e);
+            Vec::new()
+        }
     }
 }

--- a/src-tauri/src/commands/notifications.rs
+++ b/src-tauri/src/commands/notifications.rs
@@ -256,23 +256,40 @@ pub async fn get_notifications(
                 notifications.iter().map(NotificationItem::from).collect();
             let unread_count = items.iter().filter(|i| i.unread).count() as i32;
 
-            // Persist the new ETag + the latest seen `updated_at` so the
-            // next poll can issue a conditional request and detect
-            // genuinely-new items. The cursor is monotonic — see
-            // `merge_cursor` for why.
-            let new_cursor = merge_cursor(prior_cursor.as_deref(), &notifications);
-            persist_sync_success_with_cursor(
-                state.inner(),
-                user.id,
-                etag.as_deref(),
-                new_cursor.as_deref(),
-            )
-            .await;
+            // Re-check the active user before persisting. If the user
+            // logged out (or switched accounts) while we were awaiting
+            // GitHub, `logout` may have already purged this user's
+            // notifications cache; without the recheck a delayed save
+            // would repopulate it with titles/repo names that should
+            // no longer be on disk. The error path silently returns the
+            // freshly-fetched list to the caller without persisting —
+            // they're the one who initiated the call so they can render
+            // the in-flight result, but it isn't written back to local
+            // state.
+            let still_same_user = matches!(
+                state.token_manager.get_current_user().await,
+                Ok(Some(u)) if u.id == user.id
+            );
 
-            // Mirror the items into `activity_cache` so the next 304 (or a
-            // cold start before the first scheduler tick) can still serve
-            // a populated list.
-            save_items_cache(state.inner(), user.id, &items).await;
+            if still_same_user {
+                // Persist the new ETag + the latest seen `updated_at` so
+                // the next poll can issue a conditional request and
+                // detect genuinely-new items. The cursor is monotonic —
+                // see `merge_cursor` for why.
+                let new_cursor = merge_cursor(prior_cursor.as_deref(), &notifications);
+                persist_sync_success_with_cursor(
+                    state.inner(),
+                    user.id,
+                    etag.as_deref(),
+                    new_cursor.as_deref(),
+                )
+                .await;
+
+                // Mirror the items into `activity_cache` so the next 304
+                // (or a cold start before the first scheduler tick) can
+                // still serve a populated list.
+                save_items_cache(state.inner(), user.id, &items).await;
+            }
 
             Ok(NotificationsPayload {
                 items,
@@ -441,6 +458,28 @@ pub async fn run_notifications_sync(
                     .count() as i32,
                 None => 0,
             };
+
+            // Re-check the active user before any side effects. Logout /
+            // account switch can land in the brief window between
+            // `list_notifications` returning and us writing back to the
+            // cache; without this re-check, a delayed save would
+            // repopulate the `activity_cache` row that `logout` just
+            // purged with user A's titles + repo names. The
+            // `notifications-updated` event has its own userId guard on
+            // the frontend, but that doesn't help the persisted DB row.
+            match state.token_manager.get_current_user().await {
+                Ok(Some(current)) if current.id == user.id => {}
+                Ok(_) => {
+                    return Ok(NotificationsSyncOutcome::UserChanged);
+                }
+                Err(e) => {
+                    eprintln!(
+                        "Scheduler: notifications post-fetch user check failed: {}",
+                        e
+                    );
+                    return Ok(NotificationsSyncOutcome::UserChanged);
+                }
+            }
 
             // Surface the actually-new unread mentions / review requests as
             // OS notifications. Suppressed on first poll (no cutoff yet) to

--- a/src-tauri/src/commands/notifications.rs
+++ b/src-tauri/src/commands/notifications.rs
@@ -126,14 +126,37 @@ pub async fn get_notifications(
     let prior_cursor = metadata.as_ref().and_then(|m| m.last_sync_cursor.clone());
 
     let client = NotificationsClient::new(token);
-    let response = map_github_result(
-        &app,
-        state.inner(),
-        client
-            .list_notifications(prior_etag.as_deref(), false)
-            .await,
-    )
-    .await?;
+    let raw_result = client
+        .list_notifications(prior_etag.as_deref(), false)
+        .await;
+
+    // For transient failures (network blip, GitHub 5xx, even rate limit)
+    // we'd rather serve the user's last-known list than return a hard
+    // error and clear the dropdown. Auth-expired still propagates so the
+    // session-expired banner can fire and the user can re-login.
+    let response = match map_github_result(&app, state.inner(), raw_result).await {
+        Ok(r) => r,
+        Err(err_msg) => {
+            // The string is what `GitHubError::Display` produces. Auth-
+            // expired keeps the original error contract — UI surfaces a
+            // re-login prompt instead of stale data.
+            if err_msg.contains("Authentication failed") {
+                return Err(err_msg);
+            }
+            eprintln!(
+                "get_notifications: transient failure, serving cache: {}",
+                err_msg
+            );
+            let cached = load_cached_items(state.inner(), user.id).await;
+            let unread_count = cached.iter().filter(|i| i.unread).count() as i32;
+            return Ok(NotificationsPayload {
+                items: cached,
+                unread_count,
+                from_cache: true,
+                poll_interval_seconds: None,
+            });
+        }
+    };
 
     match response {
         NotificationsResponse::NotModified {
@@ -234,8 +257,14 @@ pub async fn mark_notification_read(
 /// of the stats sync.
 pub enum NotificationsSyncOutcome {
     /// Sync completed (304 or fresh data); the scheduler can poll again on
-    /// its normal cadence.
-    Ok,
+    /// its normal cadence (or honour the `poll_interval_seconds` hint when
+    /// GitHub asks for a longer wait).
+    Ok {
+        /// `x-poll-interval` (seconds) header from GitHub. The scheduler
+        /// uses this as a soft floor on the next notifications poll —
+        /// GitHub asks clients to honour it as their adaptive throttle.
+        poll_interval_seconds: Option<u64>,
+    },
     /// GitHub responded with 0 remaining + a reset timestamp. The scheduler
     /// should hold off on the next notifications poll until then.
     RateLimited { reset_at: DateTime<Utc> },
@@ -295,7 +324,9 @@ pub async fn run_notifications_sync(
     let response = map_github_result(app, state, raw_result).await?;
 
     match response {
-        NotificationsResponse::NotModified { .. } => {
+        NotificationsResponse::NotModified {
+            poll_interval_seconds,
+        } => {
             // 304: explicitly preserve the existing ETag and cursor (the
             // server hasn't given us new ones).
             persist_sync_success_with_cursor(
@@ -307,12 +338,14 @@ pub async fn run_notifications_sync(
             .await;
             // No-op event: the unread count didn't change. Skip emitting
             // `notifications-updated` to avoid waking the UI for nothing.
-            Ok(NotificationsSyncOutcome::Ok)
+            Ok(NotificationsSyncOutcome::Ok {
+                poll_interval_seconds,
+            })
         }
         NotificationsResponse::Modified {
             notifications,
             etag,
-            ..
+            poll_interval_seconds,
         } => {
             let items: Vec<NotificationItem> =
                 notifications.iter().map(NotificationItem::from).collect();
@@ -367,7 +400,9 @@ pub async fn run_notifications_sync(
             };
             let _ = app.emit("notifications-updated", &event);
 
-            Ok(NotificationsSyncOutcome::Ok)
+            Ok(NotificationsSyncOutcome::Ok {
+                poll_interval_seconds,
+            })
         }
     }
 }

--- a/src-tauri/src/commands/notifications.rs
+++ b/src-tauri/src/commands/notifications.rs
@@ -86,9 +86,18 @@ pub struct NotificationsPayload {
 /// Includes the freshly-fetched items so the UI can update directly
 /// without a second round-trip — a re-fetch would race the just-persisted
 /// ETag and come back as 304.
+///
+/// `user_id` is the local DB id of the user the scheduler captured before
+/// it awaited GitHub. The frontend cross-checks this against the
+/// currently logged-in user and discards mismatches: if an account
+/// switch happens while `run_notifications_sync` is mid-flight, the
+/// emitted event carries the *previous* user's data, and applying it
+/// blindly to user B's UI would leak unread counts / repo titles
+/// across accounts.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NotificationsUpdatedEvent {
+    pub user_id: i64,
     pub unread_count: i32,
     pub new_count: i32,
     pub items: Vec<NotificationItem>,
@@ -139,18 +148,24 @@ pub async fn get_notifications(
     // For transient failures (network blip, GitHub 5xx, even rate limit)
     // we'd rather serve the user's last-known list than return a hard
     // error and clear the dropdown. Auth-expired still propagates so the
-    // session-expired banner can fire and the user can re-login.
+    // session-expired banner can fire and the user can re-login. When
+    // the cache is empty (first run, post-cleanup, etc.) we *also*
+    // propagate — pretending the user has 0 notifications when really
+    // we just couldn't reach GitHub would silently mask outages.
     let response = match map_github_result(&app, state.inner(), raw_result).await {
         Ok(r) => r,
         Err(err_msg) => {
             if unauthorized {
                 return Err(err_msg);
             }
+            let cached = load_cached_items(state.inner(), user.id).await;
+            if cached.is_empty() {
+                return Err(err_msg);
+            }
             eprintln!(
                 "get_notifications: transient failure, serving cache: {}",
                 err_msg
             );
-            let cached = load_cached_items(state.inner(), user.id).await;
             let unread_count = cached.iter().filter(|i| i.unread).count() as i32;
             return Ok(NotificationsPayload {
                 items: cached,
@@ -423,8 +438,11 @@ pub async fn run_notifications_sync(
 
             // Emit the items inline — the frontend would otherwise have
             // to re-fetch and immediately hit the just-saved ETag, getting
-            // 304 and stale UI back.
+            // 304 and stale UI back. `user_id` is captured before the
+            // GitHub round-trip so the frontend can discard the event if
+            // an account switch happened while we were awaiting the API.
             let event = NotificationsUpdatedEvent {
+                user_id: user.id,
                 unread_count,
                 new_count,
                 items,

--- a/src-tauri/src/commands/notifications.rs
+++ b/src-tauri/src/commands/notifications.rs
@@ -1,0 +1,404 @@
+//! GitHub Notifications commands for Tauri
+//!
+//! Surface mentions, review requests, and issue / PR comments to the frontend.
+//! Uses ETag-based conditional fetching (persisted on `sync_metadata`) so
+//! polling costs zero rate-limit budget when nothing has changed.
+//!
+//! Related Issue: GitHub Issue #186 - GitHub Notifications 連携
+//! Related Audit: 監査レポート §1 ギャップ表 / §8 G-05.
+
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use tauri::{command, AppHandle, Emitter, State};
+
+use super::auth::AppState;
+use crate::auth::map_github_result;
+use crate::github::{
+    build_notification_html_url, GitHubNotification, NotificationsClient, NotificationsResponse,
+};
+
+/// Sync type key used to namespace notifications metadata in `sync_metadata`.
+/// Distinct from `github_stats` so the two ETag streams don't collide.
+pub const GITHUB_NOTIFICATIONS_SYNC_TYPE: &str = "github_notifications";
+
+/// One notification surfaced to the frontend.
+///
+/// Flat shape — each row pre-computes the browser URL so the UI doesn't need
+/// to mirror `build_html_url`'s API → web translation.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NotificationItem {
+    pub id: String,
+    pub unread: bool,
+    /// `mention` / `review_requested` / `assign` / `comment` / etc. Surfaced
+    /// verbatim so the UI can decide how to label / filter each type.
+    pub reason: String,
+    pub title: String,
+    /// `Issue` / `PullRequest` / `Commit` / `Discussion`.
+    pub subject_type: String,
+    pub repo_full_name: String,
+    pub repo_url: String,
+    pub html_url: String,
+    /// ISO8601.
+    pub updated_at: String,
+    pub last_read_at: Option<String>,
+}
+
+impl From<&GitHubNotification> for NotificationItem {
+    fn from(n: &GitHubNotification) -> Self {
+        Self {
+            id: n.id.clone(),
+            unread: n.unread,
+            reason: n.reason.clone(),
+            title: n.subject.title.clone(),
+            subject_type: n.subject.kind.clone(),
+            repo_full_name: n.repository.full_name.clone(),
+            repo_url: n.repository.html_url.clone(),
+            html_url: build_notification_html_url(n),
+            updated_at: n.updated_at.to_rfc3339(),
+            last_read_at: n.last_read_at.as_ref().map(|t| t.to_rfc3339()),
+        }
+    }
+}
+
+/// Aggregated payload returned by `get_notifications`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NotificationsPayload {
+    pub items: Vec<NotificationItem>,
+    pub unread_count: i32,
+    /// True when GitHub returned 304 — the items list is empty and the
+    /// caller should keep showing whatever it already had.
+    pub from_cache: bool,
+    /// `x-poll-interval` (seconds) hint from GitHub. The scheduler honours
+    /// this; the UI just surfaces it for diagnostics.
+    pub poll_interval_seconds: Option<u64>,
+}
+
+/// Event emitted when new unread notifications are observed during a sync.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NotificationsUpdatedEvent {
+    pub unread_count: i32,
+    pub new_count: i32,
+}
+
+/// Fetch the authenticated user's notifications.
+///
+/// Pulls the previous ETag from `sync_metadata` to issue a conditional
+/// request. On 304 returns `from_cache = true` with an empty list — the
+/// frontend should ignore the empty payload and keep its current state.
+#[command]
+pub async fn get_notifications(
+    app: AppHandle,
+    state: State<'_, AppState>,
+) -> Result<NotificationsPayload, String> {
+    let token = state
+        .token_manager
+        .get_access_token()
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let user = state
+        .token_manager
+        .get_current_user()
+        .await
+        .map_err(|e| e.to_string())?
+        .ok_or("Not logged in")?;
+
+    let metadata = state
+        .db
+        .get_sync_metadata(user.id, GITHUB_NOTIFICATIONS_SYNC_TYPE)
+        .await
+        .map_err(|e| e.to_string())?;
+    let prior_etag = metadata.as_ref().and_then(|m| m.etag.clone());
+
+    let client = NotificationsClient::new(token);
+    let response = map_github_result(
+        &app,
+        state.inner(),
+        client.list_notifications(prior_etag.as_deref(), false).await,
+    )
+    .await?;
+
+    match response {
+        NotificationsResponse::NotModified {
+            poll_interval_seconds,
+        } => {
+            // Refresh `last_sync_at` so the scheduler knows we polled
+            // successfully even when nothing changed. The ETag we already
+            // hold remains valid.
+            persist_sync_success(state.inner(), user.id, None).await;
+            Ok(NotificationsPayload {
+                items: Vec::new(),
+                unread_count: 0,
+                from_cache: true,
+                poll_interval_seconds,
+            })
+        }
+        NotificationsResponse::Modified {
+            notifications,
+            etag,
+            poll_interval_seconds,
+        } => {
+            let items: Vec<NotificationItem> =
+                notifications.iter().map(NotificationItem::from).collect();
+            let unread_count = items.iter().filter(|i| i.unread).count() as i32;
+
+            // Persist the new ETag and the latest seen `updated_at` so the
+            // next poll can issue a conditional request and detect
+            // genuinely-new items. A failure here is logged but doesn't
+            // fail the command — we already have the data.
+            let new_cursor = notifications
+                .iter()
+                .map(|n| n.updated_at)
+                .max()
+                .map(|t| t.to_rfc3339());
+            persist_sync_success_with_cursor(
+                state.inner(),
+                user.id,
+                etag.as_deref(),
+                new_cursor.as_deref(),
+            )
+            .await;
+
+            Ok(NotificationsPayload {
+                items,
+                unread_count,
+                from_cache: false,
+                poll_interval_seconds,
+            })
+        }
+    }
+}
+
+/// Mark a single GitHub notification thread as read.
+///
+/// `thread_id` is the `id` field from a notification row.
+#[command]
+pub async fn mark_notification_read(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    thread_id: String,
+) -> Result<(), String> {
+    let token = state
+        .token_manager
+        .get_access_token()
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let client = NotificationsClient::new(token);
+    map_github_result(&app, state.inner(), client.mark_thread_as_read(&thread_id).await).await
+}
+
+/// Refresh notifications and emit a `notifications-updated` event when the
+/// unread count changes. Used by the background scheduler.
+///
+/// Returns the unread count so the scheduler can record it; errors are
+/// returned as strings to match the rest of the command surface.
+pub async fn run_notifications_sync(
+    app: &AppHandle,
+    state: &AppState,
+) -> Result<i32, String> {
+    let token = state
+        .token_manager
+        .get_access_token()
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let user = state
+        .token_manager
+        .get_current_user()
+        .await
+        .map_err(|e| e.to_string())?
+        .ok_or("Not logged in")?;
+
+    let metadata = state
+        .db
+        .get_sync_metadata(user.id, GITHUB_NOTIFICATIONS_SYNC_TYPE)
+        .await
+        .map_err(|e| e.to_string())?;
+    let prior_etag = metadata.as_ref().and_then(|m| m.etag.clone());
+
+    let client = NotificationsClient::new(token);
+    let response = map_github_result(
+        app,
+        state,
+        client.list_notifications(prior_etag.as_deref(), false).await,
+    )
+    .await?;
+
+    match response {
+        NotificationsResponse::NotModified { .. } => {
+            persist_sync_success(state, user.id, None).await;
+            // No-op event: the unread count didn't change. We deliberately
+            // skip emitting `notifications-updated` to avoid waking the UI
+            // for nothing.
+            Ok(0)
+        }
+        NotificationsResponse::Modified {
+            notifications,
+            etag,
+            ..
+        } => {
+            let unread_count = notifications.iter().filter(|n| n.unread).count() as i32;
+
+            // Find the cutoff used for "new since last poll": stored in
+            // `sync_metadata.last_sync_cursor` as an RFC3339 timestamp. The
+            // first run has no cutoff and we suppress toasts to avoid a
+            // backlog dump.
+            let last_seen_at = metadata
+                .as_ref()
+                .and_then(|m| m.last_sync_cursor.as_ref())
+                .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+                .map(|dt| dt.with_timezone(&Utc));
+
+            let new_count = match last_seen_at {
+                Some(cutoff) => notifications
+                    .iter()
+                    .filter(|n| n.unread && n.updated_at > cutoff)
+                    .count() as i32,
+                None => 0,
+            };
+
+            // Surface the actually-new unread mentions / review requests as
+            // OS notifications. Suppressed on first poll (no cutoff yet) to
+            // avoid spamming a backlog of pre-existing items.
+            if last_seen_at.is_some() {
+                maybe_send_os_notifications(app, state, user.id, &notifications, last_seen_at)
+                    .await;
+            }
+
+            let new_cursor = notifications
+                .iter()
+                .map(|n| n.updated_at)
+                .max()
+                .map(|t| t.to_rfc3339());
+            persist_sync_success_with_cursor(state, user.id, etag.as_deref(), new_cursor.as_deref())
+                .await;
+
+            // Emit the event regardless of whether the count is zero — the UI
+            // consumes this as a "go re-fetch the list" signal.
+            let event = NotificationsUpdatedEvent {
+                unread_count,
+                new_count,
+            };
+            let _ = app.emit("notifications-updated", &event);
+
+            Ok(unread_count)
+        }
+    }
+}
+
+/// Send OS-native notifications for items strictly newer than `cutoff`.
+///
+/// Limits to a small batch so a burst of activity doesn't dump dozens of
+/// toasts. The user's notification settings still gate whether anything is
+/// sent at the OS level — see `utils::notifications::send_notification`.
+async fn maybe_send_os_notifications(
+    app: &AppHandle,
+    state: &AppState,
+    user_id: i64,
+    notifications: &[GitHubNotification],
+    cutoff: Option<DateTime<Utc>>,
+) {
+    const MAX_TOASTS: usize = 3;
+
+    let settings = match state.db.get_or_create_user_settings(user_id).await {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("Failed to load user settings for notifications toast: {}", e);
+            return;
+        }
+    };
+
+    // Highest-signal reasons surfaced first; comment-only updates are noisier
+    // so we let the in-app badge handle them.
+    let priority_reasons = ["mention", "review_requested", "assign", "team_mention"];
+    let toasts: Vec<&GitHubNotification> = notifications
+        .iter()
+        .filter(|n| {
+            n.unread
+                && priority_reasons.contains(&n.reason.as_str())
+                && cutoff.is_none_or(|c| n.updated_at > c)
+        })
+        .take(MAX_TOASTS)
+        .collect();
+
+    for n in toasts {
+        let title = match n.reason.as_str() {
+            "mention" | "team_mention" => "GitHub: メンション",
+            "review_requested" => "GitHub: レビュー依頼",
+            "assign" => "GitHub: アサイン",
+            _ => "GitHub 通知",
+        };
+        let body = format!("{} ({})", n.subject.title, n.repository.full_name);
+        if let Err(e) = crate::utils::notifications::send_notification(app, &settings, title, &body)
+        {
+            eprintln!("Failed to send GitHub notification toast: {}", e);
+        }
+    }
+}
+
+/// Persist a successful notifications sync to `sync_metadata`.
+///
+/// Best-effort writes — failures are logged but never fail the user-facing
+/// command. Mirrors `commands::github::persist_sync_success` for the stats
+/// sync.
+async fn persist_sync_success(state: &AppState, user_id: i64, etag: Option<&str>) {
+    persist_sync_success_with_cursor(state, user_id, etag, None).await;
+}
+
+/// Variant of [`persist_sync_success`] that also writes the
+/// `last_sync_cursor` (used to track the most recent notification
+/// `updated_at` so the next poll knows what's "new").
+async fn persist_sync_success_with_cursor(
+    state: &AppState,
+    user_id: i64,
+    etag: Option<&str>,
+    cursor: Option<&str>,
+) {
+    if let Err(e) = state
+        .db
+        .get_or_create_sync_metadata(user_id, GITHUB_NOTIFICATIONS_SYNC_TYPE)
+        .await
+    {
+        eprintln!("Failed to ensure notifications sync_metadata row: {}", e);
+        return;
+    }
+
+    let now = chrono::Utc::now().to_rfc3339();
+    if let Err(e) = state
+        .db
+        .update_sync_metadata(
+            user_id,
+            GITHUB_NOTIFICATIONS_SYNC_TYPE,
+            Some(now),
+            cursor,
+            etag,
+            None,
+            None,
+        )
+        .await
+    {
+        eprintln!(
+            "Failed to update notifications sync_metadata after sync: {}",
+            e
+        );
+    }
+
+    if let Err(e) = state
+        .db
+        .clear_sync_skipped(user_id, GITHUB_NOTIFICATIONS_SYNC_TYPE)
+        .await
+    {
+        eprintln!("Failed to clear notifications sync_skipped: {}", e);
+    }
+    if let Err(e) = state
+        .db
+        .clear_sync_rate_limit(user_id, GITHUB_NOTIFICATIONS_SYNC_TYPE)
+        .await
+    {
+        eprintln!("Failed to clear notifications sync_rate_limit: {}", e);
+    }
+}

--- a/src-tauri/src/commands/notifications.rs
+++ b/src-tauri/src/commands/notifications.rs
@@ -113,18 +113,17 @@ pub async fn get_notifications(
     app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<NotificationsPayload, String> {
-    let token = state
+    // Atomic snapshot — without it, an account switch between
+    // `get_access_token()` and `get_current_user()` would let us call
+    // GitHub with user A's token and persist the response under user B's
+    // local id (and the `notifications-updated` event's userId guard
+    // wouldn't catch this since the captured user.id is wrong from the
+    // start).
+    let (user, token) = state
         .token_manager
-        .get_access_token()
+        .get_current_user_with_token()
         .await
         .map_err(|e| e.to_string())?;
-
-    let user = state
-        .token_manager
-        .get_current_user()
-        .await
-        .map_err(|e| e.to_string())?
-        .ok_or("Not logged in")?;
 
     let metadata = state
         .db
@@ -330,18 +329,13 @@ pub async fn run_notifications_sync(
     app: &AppHandle,
     state: &AppState,
 ) -> Result<NotificationsSyncOutcome, String> {
-    let token = state
+    // Atomic snapshot — see `get_notifications` for why fetching the user
+    // and the decrypted token together matters.
+    let (user, token) = state
         .token_manager
-        .get_access_token()
+        .get_current_user_with_token()
         .await
         .map_err(|e| e.to_string())?;
-
-    let user = state
-        .token_manager
-        .get_current_user()
-        .await
-        .map_err(|e| e.to_string())?
-        .ok_or("Not logged in")?;
 
     let metadata = state
         .db

--- a/src-tauri/src/commands/notifications.rs
+++ b/src-tauri/src/commands/notifications.rs
@@ -129,6 +129,12 @@ pub async fn get_notifications(
     let raw_result = client
         .list_notifications(prior_etag.as_deref(), false)
         .await;
+    // Snapshot the unauthorized variant *before* `map_github_result`
+    // consumes the result. Matching on the typed error here is more
+    // robust than string-matching the Display output, which would silently
+    // start treating 401s as cacheable transient failures the moment the
+    // error message is reworded or localised.
+    let unauthorized = matches!(&raw_result, Err(GitHubError::Unauthorized));
 
     // For transient failures (network blip, GitHub 5xx, even rate limit)
     // we'd rather serve the user's last-known list than return a hard
@@ -137,10 +143,7 @@ pub async fn get_notifications(
     let response = match map_github_result(&app, state.inner(), raw_result).await {
         Ok(r) => r,
         Err(err_msg) => {
-            // The string is what `GitHubError::Display` produces. Auth-
-            // expired keeps the original error contract — UI surfaces a
-            // re-login prompt instead of stale data.
-            if err_msg.contains("Authentication failed") {
+            if unauthorized {
                 return Err(err_msg);
             }
             eprintln!(

--- a/src-tauri/src/commands/notifications.rs
+++ b/src-tauri/src/commands/notifications.rs
@@ -157,10 +157,14 @@ pub async fn get_notifications(
             if unauthorized {
                 return Err(err_msg);
             }
+            // Only serve cache when we actually have a row — including a
+            // legitimate empty-inbox snapshot (`Some(vec![])`). A miss
+            // (`None`) means we have nothing to show, so propagate the
+            // original error rather than fake "0 notifications".
             let cached = load_cached_items(state.inner(), user.id).await;
-            if cached.is_empty() {
+            let Some(cached) = cached else {
                 return Err(err_msg);
-            }
+            };
             eprintln!(
                 "get_notifications: transient failure, serving cache: {}",
                 err_msg
@@ -181,12 +185,12 @@ pub async fn get_notifications(
         } => {
             // Return the last-known list from the cache so cold starts
             // (where the in-memory store is empty but the persisted ETag
-            // is fresh) still show notifications.
-            let cached = load_cached_items(state.inner(), user.id).await;
-            if !cached.is_empty() {
-                // Happy 304 path: preserve existing ETag and cursor (the
-                // server hasn't given us new ones) and return the cached
-                // list.
+            // is fresh) still show notifications. Distinguish a real
+            // miss (`None`) from a legitimate empty inbox (`Some(vec![])`)
+            // — only the former forces a recovery refetch; the latter
+            // is a perfectly valid cached "0 unread" state and should
+            // keep the ETag path active.
+            if let Some(cached) = load_cached_items(state.inner(), user.id).await {
                 persist_sync_success_with_cursor(
                     state.inner(),
                     user.id,
@@ -202,13 +206,14 @@ pub async fn get_notifications(
                     poll_interval_seconds,
                 });
             }
-            // Recovery path: 304 with no cached items means the persisted
-            // ETag still matches GitHub but the local cache row was wiped
-            // (TTL'd by `clear_expired_cache` on startup). Without a
-            // re-fetch the user would see an empty inbox until the next
-            // GitHub-side change. Drop the conditional request and try
-            // once more — the second call cannot 304 because we send no
-            // `If-None-Match`, so it always returns Modified.
+            // Recovery path: 304 with no cache row means the persisted
+            // ETag still matches GitHub but the local cache was wiped
+            // (TTL'd by `clear_expired_cache` on startup, or purged on
+            // logout). Without a re-fetch the user would see an empty
+            // inbox until the next GitHub-side change. Drop the
+            // conditional request and try once more — the second call
+            // cannot 304 because we send no `If-None-Match`, so it
+            // always returns Modified.
             eprintln!("get_notifications: 304 with empty cache, refetching unconditionally");
             let raw_retry = client.list_notifications(None, false).await;
             map_github_result(&app, state.inner(), raw_retry).await?
@@ -231,7 +236,9 @@ pub async fn get_notifications(
                 prior_cursor.as_deref(),
             )
             .await;
-            let cached = load_cached_items(state.inner(), user.id).await;
+            let cached = load_cached_items(state.inner(), user.id)
+                .await
+                .unwrap_or_default();
             let unread_count = cached.iter().filter(|i| i.unread).count() as i32;
             Ok(NotificationsPayload {
                 items: cached,
@@ -610,25 +617,34 @@ async fn save_items_cache(state: &AppState, user_id: i64, items: &[NotificationI
     }
 }
 
-/// Load the cached notifications list. Falls back to an empty Vec on miss
-/// or parse failure — callers treat this as "no known items".
+/// Load the cached notifications list. Distinguishes a cache miss
+/// (`None` — no row in `activity_cache` at all) from an empty inbox
+/// (`Some(vec![])` — last sync legitimately found 0 unread items). The
+/// caller needs the difference: a 304 response paired with `None` means
+/// the row was wiped (e.g. via `clear_expired_cache`) and the ETag is
+/// stale relative to the cache, so we must refetch unconditionally;
+/// `Some(vec![])` means the user genuinely has 0 unread and we can keep
+/// the ETag path active without burning an extra request.
 ///
-/// We use `get_any_cache` (rather than `get_cache`, which filters expired)
-/// because the cache TTL is just a stale-render bound: a slightly-stale
-/// list is still better than an empty UI when GitHub responds 304.
-async fn load_cached_items(state: &AppState, user_id: i64) -> Vec<NotificationItem> {
+/// We use `get_any_cache` (rather than `get_valid_cache`, which filters
+/// expired entries) because the cache TTL is just a stale-render bound:
+/// a slightly-stale list is still better than an empty UI when GitHub
+/// responds 304.
+async fn load_cached_items(state: &AppState, user_id: i64) -> Option<Vec<NotificationItem>> {
     match state
         .db
         .get_any_cache(user_id, cache_types::GITHUB_NOTIFICATIONS)
         .await
     {
         Ok(Some((json, _cached_at, _expires_at))) => {
-            serde_json::from_str(&json).unwrap_or_default()
+            // Parse failures are treated as a miss so the recovery
+            // path can refetch a known-good payload.
+            serde_json::from_str(&json).ok()
         }
-        Ok(None) => Vec::new(),
+        Ok(None) => None,
         Err(e) => {
             eprintln!("Failed to load notifications cache: {}", e);
-            Vec::new()
+            None
         }
     }
 }

--- a/src-tauri/src/commands/notifications.rs
+++ b/src-tauri/src/commands/notifications.rs
@@ -324,10 +324,23 @@ pub enum NotificationsSyncOutcome {
     /// GitHub responded with 0 remaining + a reset timestamp. The scheduler
     /// should hold off on the next notifications poll until then.
     RateLimited { reset_at: DateTime<Utc> },
+    /// The active user changed between the scheduler's permission check
+    /// and this call. The fetch was skipped — the scheduler must not
+    /// record any backoff under the stale user.id.
+    UserChanged,
 }
 
 /// Refresh notifications and emit a `notifications-updated` event when new
 /// activity is observed. Used by the background scheduler.
+///
+/// `expected_user_id` is the user the caller already evaluated permission
+/// (e.g. `settings.background_sync`) against. If the active user has
+/// changed by the time we take a fresh snapshot, we abort with
+/// [`NotificationsSyncOutcome::UserChanged`] so the scheduler can re-do
+/// its gating against the new account on the next iteration. Without this
+/// check, an account switch in the brief window between the scheduler's
+/// permission read and this call could let user B's poll fire even when
+/// they have `background_sync = false`.
 ///
 /// Returns a [`NotificationsSyncOutcome`] so the scheduler can record a
 /// rate-limit reset and back off accordingly. Other errors (network /
@@ -335,6 +348,7 @@ pub enum NotificationsSyncOutcome {
 pub async fn run_notifications_sync(
     app: &AppHandle,
     state: &AppState,
+    expected_user_id: i64,
 ) -> Result<NotificationsSyncOutcome, String> {
     // Atomic snapshot — see `get_notifications` for why fetching the user
     // and the decrypted token together matters.
@@ -343,6 +357,15 @@ pub async fn run_notifications_sync(
         .get_current_user_with_token()
         .await
         .map_err(|e| e.to_string())?;
+
+    // Abort if the caller's gating decision was made against a different
+    // user. Without this guard, an account switch between the
+    // scheduler's `settings.background_sync` read and this call could
+    // poll user B with user A's permission, and the resulting backoff
+    // would land under user B's id even though the gate said "user A".
+    if user.id != expected_user_id {
+        return Ok(NotificationsSyncOutcome::UserChanged);
+    }
 
     let metadata = state
         .db

--- a/src-tauri/src/commands/notifications.rs
+++ b/src-tauri/src/commands/notifications.rs
@@ -161,14 +161,55 @@ pub async fn get_notifications(
         }
     };
 
-    match response {
+    let response = match response {
         NotificationsResponse::NotModified {
             poll_interval_seconds,
         } => {
-            // 304: explicitly preserve the existing ETag and cursor so a
-            // future call to `update_sync_metadata` (e.g. through a
-            // different code path) can't accidentally clear them via the
-            // COALESCE pattern. `last_sync_at` still gets refreshed.
+            // Return the last-known list from the cache so cold starts
+            // (where the in-memory store is empty but the persisted ETag
+            // is fresh) still show notifications.
+            let cached = load_cached_items(state.inner(), user.id).await;
+            if !cached.is_empty() {
+                // Happy 304 path: preserve existing ETag and cursor (the
+                // server hasn't given us new ones) and return the cached
+                // list.
+                persist_sync_success_with_cursor(
+                    state.inner(),
+                    user.id,
+                    prior_etag.as_deref(),
+                    prior_cursor.as_deref(),
+                )
+                .await;
+                let unread_count = cached.iter().filter(|i| i.unread).count() as i32;
+                return Ok(NotificationsPayload {
+                    items: cached,
+                    unread_count,
+                    from_cache: true,
+                    poll_interval_seconds,
+                });
+            }
+            // Recovery path: 304 with no cached items means the persisted
+            // ETag still matches GitHub but the local cache row was wiped
+            // (TTL'd by `clear_expired_cache` on startup). Without a
+            // re-fetch the user would see an empty inbox until the next
+            // GitHub-side change. Drop the conditional request and try
+            // once more — the second call cannot 304 because we send no
+            // `If-None-Match`, so it always returns Modified.
+            eprintln!("get_notifications: 304 with empty cache, refetching unconditionally");
+            let raw_retry = client.list_notifications(None, false).await;
+            map_github_result(&app, state.inner(), raw_retry).await?
+        }
+        modified @ NotificationsResponse::Modified { .. } => modified,
+    };
+
+    match response {
+        // The recovery path can't produce a 304 (no If-None-Match was
+        // sent), so collapsing back to NotModified here is unreachable.
+        // Treat it defensively: preserve metadata and return whatever
+        // cache holds.
+        NotificationsResponse::NotModified {
+            poll_interval_seconds,
+        } => {
             persist_sync_success_with_cursor(
                 state.inner(),
                 user.id,
@@ -176,13 +217,8 @@ pub async fn get_notifications(
                 prior_cursor.as_deref(),
             )
             .await;
-
-            // Return the last-known list from the cache so cold starts
-            // (where the in-memory store is empty but the persisted ETag
-            // is fresh) still show notifications.
             let cached = load_cached_items(state.inner(), user.id).await;
             let unread_count = cached.iter().filter(|i| i.unread).count() as i32;
-
             Ok(NotificationsPayload {
                 items: cached,
                 unread_count,
@@ -201,13 +237,9 @@ pub async fn get_notifications(
 
             // Persist the new ETag + the latest seen `updated_at` so the
             // next poll can issue a conditional request and detect
-            // genuinely-new items. A failure here is logged but doesn't
-            // fail the command — we already have the data.
-            let new_cursor = notifications
-                .iter()
-                .map(|n| n.updated_at)
-                .max()
-                .map(|t| t.to_rfc3339());
+            // genuinely-new items. The cursor is monotonic — see
+            // `merge_cursor` for why.
+            let new_cursor = merge_cursor(prior_cursor.as_deref(), &notifications);
             persist_sync_success_with_cursor(
                 state.inner(),
                 user.id,
@@ -379,11 +411,7 @@ pub async fn run_notifications_sync(
                     .await;
             }
 
-            let new_cursor = notifications
-                .iter()
-                .map(|n| n.updated_at)
-                .max()
-                .map(|t| t.to_rfc3339());
+            let new_cursor = merge_cursor(prior_cursor.as_deref(), &notifications);
             persist_sync_success_with_cursor(
                 state,
                 user.id,
@@ -407,6 +435,27 @@ pub async fn run_notifications_sync(
                 poll_interval_seconds,
             })
         }
+    }
+}
+
+/// Compute the cursor to persist after a successful fetch.
+///
+/// Returns the *later* of the prior cursor and the highest `updated_at`
+/// observed in this response. Without the monotonic guard, marking the
+/// newest unread thread as read makes the next unread-only response have
+/// a lower max `updated_at` than the prior cursor — persisting that
+/// would let already-seen threads with timestamps between the two
+/// values re-appear as "new" on the following poll, inflating
+/// `new_count` and re-firing OS toasts.
+fn merge_cursor(prior: Option<&str>, notifications: &[GitHubNotification]) -> Option<String> {
+    let observed = notifications.iter().map(|n| n.updated_at).max();
+    let prior_dt = prior
+        .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+        .map(|dt| dt.with_timezone(&Utc));
+    match (observed, prior_dt) {
+        (Some(o), Some(p)) => Some(o.max(p).to_rfc3339()),
+        (Some(o), None) => Some(o.to_rfc3339()),
+        (None, p) => p.map(|dt| dt.to_rfc3339()),
     }
 }
 

--- a/src-tauri/src/database/models/cache.rs
+++ b/src-tauri/src/database/models/cache.rs
@@ -65,8 +65,13 @@ pub mod cache_durations {
     /// Backed by GraphQL (5000 points/hour) — short TTL keeps the panel
     /// responsive without burning the budget on focus revalidations.
     pub const MY_PR_PROGRESS: i64 = 5;
-    /// GitHub Notifications cache duration (60 minutes). The ETag covers
-    /// freshness; this TTL just bounds how stale a cold-start render can
-    /// be when GitHub returns 304 against a long-unchanged inbox.
-    pub const GITHUB_NOTIFICATIONS: i64 = 60;
+    /// GitHub Notifications cache duration. Set very high (≈1 year)
+    /// because the ETag-backed flow needs the cache to outlive the
+    /// `clear_expired_cache` startup sweep — a deleted cache row paired
+    /// with a still-current ETag would otherwise force a transparent
+    /// re-fetch on every cold start (handled by the 304+empty-cache
+    /// recovery path in `get_notifications`, which is fine but visible).
+    /// Notifications data isn't sensitive enough to justify a short TTL,
+    /// and the row is overwritten on every successful sync.
+    pub const GITHUB_NOTIFICATIONS: i64 = 60 * 24 * 365;
 }

--- a/src-tauri/src/database/models/cache.rs
+++ b/src-tauri/src/database/models/cache.rs
@@ -40,6 +40,9 @@ pub mod cache_types {
     /// PR progress dashboard payload (mergeable / checks / reviewDecision)
     /// for the viewer's open PRs. See Issue #185.
     pub const MY_PR_PROGRESS: &str = "my_pr_progress";
+    /// GitHub Notifications list (cached so a 304 response can still serve
+    /// the UI without forcing a re-fetch). See Issue #186.
+    pub const GITHUB_NOTIFICATIONS: &str = "github_notifications";
 }
 
 /// Default cache durations in minutes
@@ -62,4 +65,8 @@ pub mod cache_durations {
     /// Backed by GraphQL (5000 points/hour) — short TTL keeps the panel
     /// responsive without burning the budget on focus revalidations.
     pub const MY_PR_PROGRESS: i64 = 5;
+    /// GitHub Notifications cache duration (60 minutes). The ETag covers
+    /// freshness; this TTL just bounds how stale a cold-start render can
+    /// be when GitHub returns 304 against a long-unchanged inbox.
+    pub const GITHUB_NOTIFICATIONS: i64 = 60;
 }

--- a/src-tauri/src/database/repository/cache.rs
+++ b/src-tauri/src/database/repository/cache.rs
@@ -169,4 +169,18 @@ impl Database {
 
         Ok(result.rows_affected())
     }
+
+    /// Delete a single cache entry by `(user_id, data_type)`. Used to purge
+    /// targeted payloads (e.g. notifications) on logout without dropping
+    /// the rest of the user's cache.
+    pub async fn delete_cache_entry(&self, user_id: i64, data_type: &str) -> DbResult<u64> {
+        let result = sqlx::query("DELETE FROM activity_cache WHERE user_id = ? AND data_type = ?")
+            .bind(user_id)
+            .bind(data_type)
+            .execute(self.pool())
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?;
+
+        Ok(result.rows_affected())
+    }
 }

--- a/src-tauri/src/github/mod.rs
+++ b/src-tauri/src/github/mod.rs
@@ -5,8 +5,13 @@
 
 pub mod client;
 pub mod issues;
+pub mod notifications;
 pub mod types;
 
 pub use client::GitHubClient;
 pub use issues::{generate_actions_template, IssuesClient};
+pub use notifications::{
+    build_html_url as build_notification_html_url, GitHubNotification, NotificationsClient,
+    NotificationsResponse,
+};
 pub use types::*;

--- a/src-tauri/src/github/notifications.rs
+++ b/src-tauri/src/github/notifications.rs
@@ -92,8 +92,18 @@ pub struct NotificationsClient {
 
 impl NotificationsClient {
     pub fn new(access_token: String) -> Self {
+        // A bare `Client::new()` has no connect / overall timeout, so a
+        // hung TLS handshake or stalled response would block the
+        // scheduler tick (and any user-initiated `get_notifications`
+        // call) indefinitely. The numbers mirror what other reqwest
+        // best-practice docs recommend for a public REST API.
+        let client = reqwest::Client::builder()
+            .connect_timeout(std::time::Duration::from_secs(10))
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new());
         Self {
-            client: reqwest::Client::new(),
+            client,
             access_token,
         }
     }
@@ -251,7 +261,14 @@ pub fn build_html_url(notification: &GitHubNotification) -> String {
         if let Some(rest) = api_url.strip_prefix("https://api.github.com/repos/") {
             // rest = "{owner}/{repo}/{issues|pulls}/{n}" or
             // "{owner}/{repo}/{commits}/{sha}".
-            let translated = rest.replacen("/pulls/", "/pull/", 1);
+            //
+            // Both `pulls` and `commits` are API-only plurals — the
+            // GitHub web UI mounts them at `/pull/{n}` and
+            // `/commit/{sha}` respectively. Notifications can surface
+            // either, so we translate both.
+            let translated =
+                rest.replacen("/pulls/", "/pull/", 1)
+                    .replacen("/commits/", "/commit/", 1);
             return format!("https://github.com/{}", translated);
         }
         return api_url.clone();
@@ -298,6 +315,20 @@ mod tests {
         // UI is at `/pull/{n}`. Forgetting to translate causes 404s.
         let n = make_notification(Some("https://api.github.com/repos/octo/repo/pulls/7"));
         assert_eq!(build_html_url(&n), "https://github.com/octo/repo/pull/7");
+    }
+
+    #[test]
+    fn build_html_url_translates_commit_api_url() {
+        // Commit notifications use `/commits/{sha}` on the API but the web
+        // UI mounts the singular `/commit/{sha}` — without the translation
+        // the user lands on the commits *list* (or a 404 in some repos).
+        let n = make_notification(Some(
+            "https://api.github.com/repos/octo/repo/commits/abc123",
+        ));
+        assert_eq!(
+            build_html_url(&n),
+            "https://github.com/octo/repo/commit/abc123"
+        );
     }
 
     #[test]

--- a/src-tauri/src/github/notifications.rs
+++ b/src-tauri/src/github/notifications.rs
@@ -1,0 +1,316 @@
+//! GitHub Notifications API client
+//!
+//! Wraps the REST `GET /notifications` and related mark-as-read endpoints.
+//! Uses ETag-based conditional requests so polling repeatedly costs zero
+//! rate-limit budget when nothing has changed (GitHub returns 304 with no
+//! body).
+//!
+//! Related Issue: GitHub Issue #186 - GitHub Notifications 連携
+//! Related Audit: 監査レポート §1 ギャップ表 / §8 G-05.
+
+use chrono::{DateTime, Utc};
+use reqwest::header::{HeaderMap, HeaderValue, ACCEPT, AUTHORIZATION, IF_NONE_MATCH, USER_AGENT};
+use serde::{Deserialize, Serialize};
+
+use super::client::{GitHubError, GitHubResult};
+
+const GITHUB_API_URL: &str = "https://api.github.com";
+const USER_AGENT_VALUE: &str = "development-tools/1.0";
+
+/// One row of the `GET /notifications` response.
+///
+/// Only the fields the UI consumes are deserialised; the rest of the payload
+/// (e.g. `subscription_url`) is ignored.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GitHubNotification {
+    /// Stable thread ID — used for `mark thread as read`.
+    pub id: String,
+    pub unread: bool,
+    /// Reason GitHub surfaced this notification (mention, review_requested,
+    /// assign, comment, etc.).
+    pub reason: String,
+    pub updated_at: DateTime<Utc>,
+    pub last_read_at: Option<DateTime<Utc>>,
+    pub subject: NotificationSubject,
+    pub repository: NotificationRepository,
+}
+
+/// Inner `subject` envelope: title + the API URL of the underlying issue / PR.
+///
+/// `url` looks like `https://api.github.com/repos/{owner}/{repo}/issues/{n}`
+/// or `.../pulls/{n}`. We translate it to a browser URL on the frontend so
+/// clicking a notification opens the actual page.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NotificationSubject {
+    pub title: String,
+    /// `Issue` / `PullRequest` / `Commit` / `Discussion` / etc.
+    #[serde(rename = "type")]
+    pub kind: String,
+    pub url: Option<String>,
+    pub latest_comment_url: Option<String>,
+}
+
+/// Subset of the repository payload we need for display.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NotificationRepository {
+    pub id: i64,
+    pub name: String,
+    pub full_name: String,
+    pub html_url: String,
+    pub private: bool,
+}
+
+/// Result of a conditional fetch.
+///
+/// `NotModified` is the happy path when the ETag is still fresh — the caller
+/// keeps showing whatever is already cached and skips DB writes.
+#[derive(Debug, Clone)]
+pub enum NotificationsResponse {
+    Modified {
+        notifications: Vec<GitHubNotification>,
+        /// New ETag to persist for the next conditional request.
+        etag: Option<String>,
+        /// `x-poll-interval` header (in seconds). GitHub asks clients to
+        /// honour this — it's their adaptive throttle for the notifications
+        /// endpoint.
+        poll_interval_seconds: Option<u64>,
+    },
+    NotModified {
+        poll_interval_seconds: Option<u64>,
+    },
+}
+
+/// GitHub Notifications client.
+///
+/// Mirrors `IssuesClient` in shape — separate from `GitHubClient` because the
+/// `If-None-Match` plumbing and 304 handling don't fit the existing
+/// success-or-error JSON-only `get` helper.
+pub struct NotificationsClient {
+    client: reqwest::Client,
+    access_token: String,
+}
+
+impl NotificationsClient {
+    pub fn new(access_token: String) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            access_token,
+        }
+    }
+
+    fn build_headers(&self, etag: Option<&str>) -> GitHubResult<HeaderMap> {
+        let mut headers = HeaderMap::new();
+        headers.insert(USER_AGENT, HeaderValue::from_static(USER_AGENT_VALUE));
+        headers.insert(
+            AUTHORIZATION,
+            HeaderValue::from_str(&format!("Bearer {}", self.access_token))
+                .map_err(|e| GitHubError::ApiError(format!("Invalid token format: {}", e)))?,
+        );
+        headers.insert(
+            ACCEPT,
+            HeaderValue::from_static("application/vnd.github+json"),
+        );
+        headers.insert(
+            "X-GitHub-Api-Version",
+            HeaderValue::from_static("2022-11-28"),
+        );
+        if let Some(etag_value) = etag {
+            // GitHub returns weak ETags for the notifications endpoint
+            // (e.g. `W/"abcdef"`); we forward whatever was persisted
+            // verbatim. Invalid bytes degrade gracefully — drop the header
+            // and refetch unconditionally on the next call.
+            if let Ok(header_value) = HeaderValue::from_str(etag_value) {
+                headers.insert(IF_NONE_MATCH, header_value);
+            }
+        }
+        Ok(headers)
+    }
+
+    /// Fetch notifications, optionally conditional on a previously stored
+    /// ETag. Returns `NotModified` on 304 so the caller can short-circuit.
+    ///
+    /// `all = false` (the GitHub default) means only unread notifications.
+    /// We hardcode this — the UI surfaces unread items only — but expose it
+    /// as a parameter for future flexibility.
+    pub async fn list_notifications(
+        &self,
+        etag: Option<&str>,
+        all: bool,
+    ) -> GitHubResult<NotificationsResponse> {
+        let url = format!(
+            "{}/notifications?all={}&per_page=50",
+            GITHUB_API_URL,
+            if all { "true" } else { "false" }
+        );
+
+        let headers = self.build_headers(etag)?;
+        let response = self.client.get(&url).headers(headers).send().await?;
+
+        let status = response.status();
+        let new_etag = response
+            .headers()
+            .get(reqwest::header::ETAG)
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string());
+        let poll_interval_seconds = response
+            .headers()
+            .get("x-poll-interval")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.parse::<u64>().ok());
+
+        if status == reqwest::StatusCode::NOT_MODIFIED {
+            return Ok(NotificationsResponse::NotModified {
+                poll_interval_seconds,
+            });
+        }
+
+        if status == reqwest::StatusCode::UNAUTHORIZED {
+            return Err(GitHubError::Unauthorized);
+        }
+
+        if status == reqwest::StatusCode::FORBIDDEN {
+            // Mirror IssuesClient's 0-remaining → RateLimited mapping so the
+            // scheduler treats notifications throttling identically to the
+            // stats sync.
+            let remaining_zero = response
+                .headers()
+                .get("x-ratelimit-remaining")
+                .and_then(|v| v.to_str().ok())
+                .map(|v| v == "0")
+                .unwrap_or(false);
+            if remaining_zero {
+                let reset = response
+                    .headers()
+                    .get("x-ratelimit-reset")
+                    .and_then(|v| v.to_str().ok())
+                    .and_then(|v| v.parse::<i64>().ok())
+                    .unwrap_or(0);
+                return Err(GitHubError::RateLimited(reset));
+            }
+        }
+
+        if !status.is_success() {
+            let error_text = response.text().await.unwrap_or_default();
+            return Err(GitHubError::ApiError(format!(
+                "Status {}: {}",
+                status, error_text
+            )));
+        }
+
+        let notifications: Vec<GitHubNotification> = response.json().await?;
+        Ok(NotificationsResponse::Modified {
+            notifications,
+            etag: new_etag,
+            poll_interval_seconds,
+        })
+    }
+
+    /// Mark a single notification thread as read.
+    ///
+    /// `PATCH /notifications/threads/{thread_id}` returns 205 (Reset Content)
+    /// on success per the GitHub docs.
+    pub async fn mark_thread_as_read(&self, thread_id: &str) -> GitHubResult<()> {
+        let url = format!("{}/notifications/threads/{}", GITHUB_API_URL, thread_id);
+        let headers = self.build_headers(None)?;
+        let response = self.client.patch(&url).headers(headers).send().await?;
+
+        match response.status() {
+            status if status.is_success() => Ok(()),
+            reqwest::StatusCode::RESET_CONTENT => Ok(()),
+            reqwest::StatusCode::NOT_MODIFIED => Ok(()),
+            reqwest::StatusCode::UNAUTHORIZED => Err(GitHubError::Unauthorized),
+            reqwest::StatusCode::NOT_FOUND => Err(GitHubError::NotFound(thread_id.to_string())),
+            status => {
+                let error_text = response.text().await.unwrap_or_default();
+                Err(GitHubError::ApiError(format!(
+                    "Status {}: {}",
+                    status, error_text
+                )))
+            }
+        }
+    }
+}
+
+/// Translate a notification subject's API URL to a browser URL.
+///
+/// The notifications endpoint surfaces API URLs like
+/// `https://api.github.com/repos/octo/test/issues/42` or
+/// `.../pulls/42`. Clicking through should open the GitHub web UI, so we
+/// rewrite `api.github.com/repos/...` → `github.com/...` and translate
+/// `pulls` → `pull` (plural is API-only).
+///
+/// Falls back to the repository's `html_url` when the subject URL is
+/// missing (some `Discussion` and `Commit` rows have no API URL).
+pub fn build_html_url(notification: &GitHubNotification) -> String {
+    if let Some(api_url) = &notification.subject.url {
+        if let Some(rest) = api_url.strip_prefix("https://api.github.com/repos/") {
+            // rest = "{owner}/{repo}/{issues|pulls}/{n}" or
+            // "{owner}/{repo}/{commits}/{sha}".
+            let translated = rest.replacen("/pulls/", "/pull/", 1);
+            return format!("https://github.com/{}", translated);
+        }
+        return api_url.clone();
+    }
+    notification.repository.html_url.clone()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_notification(api_url: Option<&str>) -> GitHubNotification {
+        GitHubNotification {
+            id: "123".to_string(),
+            unread: true,
+            reason: "mention".to_string(),
+            updated_at: Utc::now(),
+            last_read_at: None,
+            subject: NotificationSubject {
+                title: "Test".to_string(),
+                kind: "Issue".to_string(),
+                url: api_url.map(|s| s.to_string()),
+                latest_comment_url: None,
+            },
+            repository: NotificationRepository {
+                id: 1,
+                name: "repo".to_string(),
+                full_name: "octo/repo".to_string(),
+                html_url: "https://github.com/octo/repo".to_string(),
+                private: false,
+            },
+        }
+    }
+
+    #[test]
+    fn build_html_url_translates_issue_api_url() {
+        let n = make_notification(Some(
+            "https://api.github.com/repos/octo/repo/issues/42",
+        ));
+        assert_eq!(build_html_url(&n), "https://github.com/octo/repo/issues/42");
+    }
+
+    #[test]
+    fn build_html_url_translates_pull_request_api_url() {
+        // The notifications API uses the plural `pulls` segment, but the web
+        // UI is at `/pull/{n}`. Forgetting to translate causes 404s.
+        let n = make_notification(Some(
+            "https://api.github.com/repos/octo/repo/pulls/7",
+        ));
+        assert_eq!(build_html_url(&n), "https://github.com/octo/repo/pull/7");
+    }
+
+    #[test]
+    fn build_html_url_falls_back_to_repo_when_subject_url_missing() {
+        let n = make_notification(None);
+        assert_eq!(build_html_url(&n), "https://github.com/octo/repo");
+    }
+
+    #[test]
+    fn build_html_url_passes_through_unexpected_host() {
+        // Defensive: a GHES instance would surface a different host. We
+        // forward the URL untouched rather than mangle it.
+        let url = "https://ghe.example.com/api/v3/repos/o/r/issues/1";
+        let n = make_notification(Some(url));
+        assert_eq!(build_html_url(&n), url);
+    }
+}

--- a/src-tauri/src/github/notifications.rs
+++ b/src-tauri/src/github/notifications.rs
@@ -137,8 +137,13 @@ impl NotificationsClient {
         etag: Option<&str>,
         all: bool,
     ) -> GitHubResult<NotificationsResponse> {
+        // `per_page=100` is GitHub's maximum and also the threshold the UI
+        // needs to reach the `99+` badge cap. Full Link-header pagination
+        // is intentionally omitted: the UI shows at most one page of
+        // recent unread items and a 100-row dropdown is already
+        // unwieldy — beyond that, users navigate to github.com.
         let url = format!(
-            "{}/notifications?all={}&per_page=50",
+            "{}/notifications?all={}&per_page=100",
             GITHUB_API_URL,
             if all { "true" } else { "false" }
         );
@@ -283,9 +288,7 @@ mod tests {
 
     #[test]
     fn build_html_url_translates_issue_api_url() {
-        let n = make_notification(Some(
-            "https://api.github.com/repos/octo/repo/issues/42",
-        ));
+        let n = make_notification(Some("https://api.github.com/repos/octo/repo/issues/42"));
         assert_eq!(build_html_url(&n), "https://github.com/octo/repo/issues/42");
     }
 
@@ -293,9 +296,7 @@ mod tests {
     fn build_html_url_translates_pull_request_api_url() {
         // The notifications API uses the plural `pulls` segment, but the web
         // UI is at `/pull/{n}`. Forgetting to translate causes 404s.
-        let n = make_notification(Some(
-            "https://api.github.com/repos/octo/repo/pulls/7",
-        ));
+        let n = make_notification(Some("https://api.github.com/repos/octo/repo/pulls/7"));
         assert_eq!(build_html_url(&n), "https://github.com/octo/repo/pull/7");
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -56,7 +56,6 @@ use commands::{
     get_near_completion_badges,
     // GitHub Notifications commands (Issue #186)
     get_notifications,
-    mark_notification_read,
     get_project,
     get_project_issues,
     get_projects,
@@ -70,6 +69,7 @@ use commands::{
     get_xp_history,
     link_repository,
     logout,
+    mark_notification_read,
     open_external_url,
     open_url,
     poll_device_token,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -54,6 +54,9 @@ use commands::{
     // PR progress dashboard panel command (Issue #185)
     get_my_pr_progress_with_cache,
     get_near_completion_badges,
+    // GitHub Notifications commands (Issue #186)
+    get_notifications,
+    mark_notification_read,
     get_project,
     get_project_issues,
     get_projects,
@@ -243,6 +246,9 @@ pub fn run() {
             create_github_issue,
             get_my_open_work_with_cache,
             get_my_pr_progress_with_cache,
+            // GitHub Notifications commands (Issue #186)
+            get_notifications,
+            mark_notification_read,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/sync_scheduler/runner.rs
+++ b/src-tauri/src/sync_scheduler/runner.rs
@@ -76,6 +76,11 @@ async fn run_loop(app: AppHandle, notify: Arc<Notify>, status: Arc<RwLock<Schedu
     // the next iteration to lose the rate-limit context and risk hitting the
     // GitHub API again before the reset.
     let mut rate_limit_reset_fallback: Option<DateTime<Utc>> = None;
+    // In-memory floor for the next notifications poll. Tracks GitHub's
+    // `x-poll-interval` hint (and rate-limit resets) so we don't poll
+    // notifications more aggressively than GitHub asks. Reset to `None`
+    // means "may poll on the next tick".
+    let mut notifications_next_allowed_at: Option<DateTime<Utc>> = None;
 
     loop {
         let state = app.state::<AppState>();
@@ -139,35 +144,41 @@ async fn run_loop(app: AppHandle, notify: Arc<Notify>, status: Arc<RwLock<Schedu
 
         write_status(&status, &settings, metadata.as_ref(), projected_next, true).await;
 
+        // Poll GitHub Notifications on its own cadence (Issue #186).
+        // Independent of the stats `SchedulerAction` so a stats Sleep /
+        // Idle / RateLimited doesn't freeze the inbox. The endpoint is
+        // conditional via ETag (304 = zero rate budget) and the call is
+        // self-throttled via `notifications_due_to_poll`, which honours
+        // both GitHub's `x-poll-interval` hint and any persisted
+        // rate-limit reset.
+        if notifications_due_to_poll(state.inner(), user.id, notifications_next_allowed_at, now)
+            .await
+        {
+            match run_notifications_sync(&app, state.inner()).await {
+                Ok(NotificationsSyncOutcome::Ok {
+                    poll_interval_seconds,
+                }) => {
+                    notifications_next_allowed_at = poll_interval_seconds
+                        .map(|secs| Utc::now() + chrono::Duration::seconds(secs as i64));
+                }
+                Ok(NotificationsSyncOutcome::RateLimited { reset_at }) => {
+                    eprintln!(
+                        "Scheduler: notifications API rate-limited until {}",
+                        reset_at.to_rfc3339()
+                    );
+                    notifications_next_allowed_at = Some(reset_at);
+                }
+                Err(e) => {
+                    eprintln!("Scheduler: notifications sync failed: {}", e);
+                }
+            }
+        }
+
         let action = decide_action(&inputs);
         match action {
             SchedulerAction::RunSync => {
                 is_first_run = false;
                 eprintln!("Scheduler: running scheduled sync for user {}", user.id);
-
-                // Poll GitHub Notifications first (Issue #186). Decoupled
-                // from the stats sync result so a stats failure (network,
-                // GraphQL hiccup, etc.) doesn't freeze the inbox until the
-                // next interval. The endpoint is conditional via ETag so
-                // a 304 costs zero rate budget; rate-limit responses are
-                // persisted to a separate `sync_metadata` row and honoured
-                // on subsequent ticks via `notifications_throttled`.
-                if notifications_throttled(state.inner(), user.id).await {
-                    eprintln!("Scheduler: skipping notifications poll while rate-limited");
-                } else {
-                    match run_notifications_sync(&app, state.inner()).await {
-                        Ok(NotificationsSyncOutcome::Ok) => {}
-                        Ok(NotificationsSyncOutcome::RateLimited { reset_at }) => {
-                            eprintln!(
-                                "Scheduler: notifications API rate-limited until {}",
-                                reset_at.to_rfc3339()
-                            );
-                        }
-                        Err(e) => {
-                            eprintln!("Scheduler: notifications sync failed: {}", e);
-                        }
-                    }
-                }
 
                 match run_github_sync(&app, state.inner()).await {
                     Ok(_) => {
@@ -566,6 +577,37 @@ async fn notifications_throttled(state: &AppState, user_id: i64) -> bool {
     metadata
         .and_then(|m| m.rate_limit_reset_at_parsed())
         .is_some_and(|reset| reset > Utc::now())
+}
+
+/// Decide whether to fire a notifications poll on this scheduler tick.
+///
+/// Composes two throttles:
+/// 1. Persisted rate-limit reset (`sync_metadata.rate_limit_reset_at`,
+///    written by `run_notifications_sync` when GitHub returns 403 with
+///    0 remaining) — survives across app restarts.
+/// 2. In-memory `next_allowed_at` derived from GitHub's
+///    `x-poll-interval` header — softer hint, not persisted because
+///    GitHub re-emits it on every response.
+///
+/// Either being in the future blocks the poll. The persisted-rate-limit
+/// branch logs a single line per skip; the soft poll-interval window
+/// fires every short tick and is intentionally silent to avoid spam.
+async fn notifications_due_to_poll(
+    state: &AppState,
+    user_id: i64,
+    next_allowed_at: Option<DateTime<Utc>>,
+    now: DateTime<Utc>,
+) -> bool {
+    if let Some(allowed) = next_allowed_at {
+        if allowed > now {
+            return false;
+        }
+    }
+    if notifications_throttled(state, user_id).await {
+        eprintln!("Scheduler: skipping notifications poll while rate-limited");
+        return false;
+    }
+    true
 }
 
 /// Classify a `run_github_sync` error string as rate-limited.

--- a/src-tauri/src/sync_scheduler/runner.rs
+++ b/src-tauri/src/sync_scheduler/runner.rs
@@ -24,6 +24,7 @@ use crate::github::client::GitHubError;
 use super::actions::{decide_action, next_sync_at};
 use super::state::{
     skip_reasons, SchedulerAction, SchedulerInputs, SchedulerStatus, GITHUB_STATS_SYNC_TYPE,
+    MAX_SLEEP_SECONDS,
 };
 
 /// Handle returned by [`start_scheduler`] and stored in Tauri's managed state.
@@ -310,8 +311,17 @@ async fn run_loop(app: AppHandle, notify: Arc<Notify>, status: Arc<RwLock<Schedu
 
                         // Always sleep at least MIN_FAILURE_SLEEP_SECONDS after a
                         // failure so transient errors don't trigger a tight
-                        // retry loop.
-                        wait_for_change_or_timeout(&notify, sleep_secs).await;
+                        // retry loop. Capped by `cap_sleep_for_notifications`
+                        // so a long stats backoff (rate-limit reset can be
+                        // 30 min away) doesn't hold up an otherwise-healthy
+                        // notifications stream.
+                        let capped = cap_sleep_for_notifications(
+                            sleep_secs,
+                            notifications_next_allowed.as_ref(),
+                            user.id,
+                            Utc::now(),
+                        );
+                        wait_for_change_or_timeout(&notify, capped).await;
                     }
                 }
             }
@@ -340,7 +350,13 @@ async fn run_loop(app: AppHandle, notify: Arc<Notify>, status: Arc<RwLock<Schedu
                     persist_startup_baseline(&state.db, user.id).await;
                 }
                 is_first_run = false;
-                wait_for_change_or_timeout(&notify, seconds).await;
+                let capped = cap_sleep_for_notifications(
+                    seconds,
+                    notifications_next_allowed.as_ref(),
+                    user.id,
+                    Utc::now(),
+                );
+                wait_for_change_or_timeout(&notify, capped).await;
             }
             SchedulerAction::Idle { reason } => {
                 is_first_run = false;
@@ -373,7 +389,15 @@ async fn run_loop(app: AppHandle, notify: Arc<Notify>, status: Arc<RwLock<Schedu
                         .await,
                 );
                 update_status_skipped(&status, reason, now).await;
-                wait_for_change_or_timeout(&notify, seconds).await;
+                // Cap the rate-limit backoff so the notifications stream
+                // doesn't get starved during a stats-side rate limit.
+                let capped = cap_sleep_for_notifications(
+                    seconds,
+                    notifications_next_allowed.as_ref(),
+                    user.id,
+                    Utc::now(),
+                );
+                wait_for_change_or_timeout(&notify, capped).await;
             }
         }
     }
@@ -522,6 +546,27 @@ async fn set_status_logged_out(status: &RwLock<SchedulerStatus>) {
         last_skipped_reason: Some(skip_reasons::NOT_LOGGED_IN.to_string()),
         ..SchedulerStatus::default()
     };
+}
+
+/// Cap a stats-decided sleep so the notifications poll cadence isn't
+/// starved when stats has a long backoff (rate-limit failure, etc.).
+/// Without this, `MAX_FAILURE_SLEEP_SECONDS` (30 min) on the stats side
+/// would freeze the inbox for that long even when the notifications
+/// endpoint has plenty of budget. Returns the smaller of the intended
+/// stats sleep and the time until notifications are next allowed to
+/// poll (defaulting to `MAX_SLEEP_SECONDS` when there's no in-memory
+/// hint, since that's already the loop's natural cap on responsiveness).
+fn cap_sleep_for_notifications(
+    intended: u64,
+    notifications_next_allowed: Option<&(i64, DateTime<Utc>)>,
+    user_id: i64,
+    now: DateTime<Utc>,
+) -> u64 {
+    let notif_wake = match notifications_next_allowed {
+        Some(&(uid, at)) if uid == user_id => (at - now).num_seconds().max(0) as u64,
+        _ => MAX_SLEEP_SECONDS,
+    };
+    intended.min(notif_wake)
 }
 
 async fn wait_for_change_or_timeout(notify: &Notify, seconds: u64) {

--- a/src-tauri/src/sync_scheduler/runner.rs
+++ b/src-tauri/src/sync_scheduler/runner.rs
@@ -187,6 +187,17 @@ async fn run_loop(app: AppHandle, notify: Arc<Notify>, status: Arc<RwLock<Schedu
                 }
                 Err(e) => {
                     eprintln!("Scheduler: notifications sync failed: {}", e);
+                    // Apply a minimum backoff on transient failures so a
+                    // network outage doesn't translate into a tight retry
+                    // loop (the loop's stats-side sleep can be capped to
+                    // 0 by `cap_sleep_for_notifications` if
+                    // `notifications_next_allowed` is in the past, so we
+                    // need an active future floor here).
+                    notifications_next_allowed = Some((
+                        user.id,
+                        Utc::now()
+                            + chrono::Duration::seconds(NOTIFICATIONS_FAILURE_BACKOFF_SECONDS),
+                    ));
                 }
             }
         }
@@ -548,14 +559,24 @@ async fn set_status_logged_out(status: &RwLock<SchedulerStatus>) {
     };
 }
 
+/// Minimum backoff applied after `run_notifications_sync` returns a
+/// transient error so a network outage can't translate into a tight
+/// retry loop. The notifications poll naturally re-tries after this
+/// window expires.
+const NOTIFICATIONS_FAILURE_BACKOFF_SECONDS: i64 = 60;
+
 /// Cap a stats-decided sleep so the notifications poll cadence isn't
 /// starved when stats has a long backoff (rate-limit failure, etc.).
 /// Without this, `MAX_FAILURE_SLEEP_SECONDS` (30 min) on the stats side
 /// would freeze the inbox for that long even when the notifications
 /// endpoint has plenty of budget. Returns the smaller of the intended
 /// stats sleep and the time until notifications are next allowed to
-/// poll (defaulting to `MAX_SLEEP_SECONDS` when there's no in-memory
-/// hint, since that's already the loop's natural cap on responsiveness).
+/// poll.
+///
+/// A past `next_allowed` (or `None`) is treated as "no constraint" and
+/// the cap falls back to `MAX_SLEEP_SECONDS` rather than 0 — otherwise
+/// a stale-but-expired hint would let the scheduler busy-loop on a
+/// failing notifications endpoint at zero-sleep intervals.
 fn cap_sleep_for_notifications(
     intended: u64,
     notifications_next_allowed: Option<&(i64, DateTime<Utc>)>,
@@ -563,7 +584,7 @@ fn cap_sleep_for_notifications(
     now: DateTime<Utc>,
 ) -> u64 {
     let notif_wake = match notifications_next_allowed {
-        Some(&(uid, at)) if uid == user_id => (at - now).num_seconds().max(0) as u64,
+        Some(&(uid, at)) if uid == user_id && at > now => (at - now).num_seconds() as u64,
         _ => MAX_SLEEP_SECONDS,
     };
     intended.min(notif_wake)

--- a/src-tauri/src/sync_scheduler/runner.rs
+++ b/src-tauri/src/sync_scheduler/runner.rs
@@ -14,6 +14,7 @@ use tokio::sync::{Notify, RwLock};
 use crate::auth::{classify_unauthorized, handle_unauthorized, reasons};
 use crate::commands::auth::AppState;
 use crate::commands::github::run_github_sync;
+use crate::commands::notifications::run_notifications_sync;
 use crate::database::models::code_stats::SyncMetadata;
 use crate::database::models::UserSettings;
 use crate::github::client::GitHubError;
@@ -151,6 +152,17 @@ async fn run_loop(app: AppHandle, notify: Arc<Notify>, status: Arc<RwLock<Schedu
                         // A successful sync invalidates any in-memory rate-limit
                         // fallback we may have been carrying.
                         rate_limit_reset_fallback = None;
+
+                        // Piggyback the GitHub Notifications poll on the stats
+                        // sync tick (Issue #186). The notifications endpoint
+                        // is conditional via ETag so a 304 costs zero rate
+                        // budget; an actual modification emits the
+                        // `notifications-updated` event for the UI. Failures
+                        // here must not unwind the stats success — log and
+                        // continue.
+                        if let Err(e) = run_notifications_sync(&app, state.inner()).await {
+                            eprintln!("Scheduler: notifications sync failed: {}", e);
+                        }
                     }
                     Err(err_msg) => {
                         eprintln!("Scheduler: scheduled sync failed: {}", err_msg);

--- a/src-tauri/src/sync_scheduler/runner.rs
+++ b/src-tauri/src/sync_scheduler/runner.rs
@@ -386,8 +386,17 @@ async fn run_loop(app: AppHandle, notify: Arc<Notify>, status: Arc<RwLock<Schedu
                 // Wake on settings changes immediately, but also re-poll on a
                 // bounded interval as a safety net for non-settings transitions
                 // (logout/login, an account switch, etc.) that don't currently
-                // emit a notify.
-                wait_for_change_or_timeout(&notify, IDLE_POLL_SECONDS).await;
+                // emit a notify. Cap by notifications cadence so manual-only
+                // stats (`sync_interval_minutes <= 0`) doesn't freeze the
+                // notifications stream — the comment above the inbox poll
+                // promises Sleep/Idle/RateLimited won't lock it out.
+                let capped = cap_sleep_for_notifications(
+                    IDLE_POLL_SECONDS,
+                    notifications_next_allowed.as_ref(),
+                    user.id,
+                    Utc::now(),
+                );
+                wait_for_change_or_timeout(&notify, capped).await;
             }
             SchedulerAction::RateLimited { reason, seconds } => {
                 is_first_run = false;

--- a/src-tauri/src/sync_scheduler/runner.rs
+++ b/src-tauri/src/sync_scheduler/runner.rs
@@ -76,11 +76,14 @@ async fn run_loop(app: AppHandle, notify: Arc<Notify>, status: Arc<RwLock<Schedu
     // the next iteration to lose the rate-limit context and risk hitting the
     // GitHub API again before the reset.
     let mut rate_limit_reset_fallback: Option<DateTime<Utc>> = None;
-    // In-memory floor for the next notifications poll. Tracks GitHub's
-    // `x-poll-interval` hint (and rate-limit resets) so we don't poll
-    // notifications more aggressively than GitHub asks. Reset to `None`
-    // means "may poll on the next tick".
-    let mut notifications_next_allowed_at: Option<DateTime<Utc>> = None;
+    // In-memory floor for the next notifications poll, scoped to the
+    // user that produced the hint. Tracks GitHub's `x-poll-interval`
+    // header (and rate-limit resets) so we don't poll notifications
+    // more aggressively than GitHub asks. Keyed by user.id so an
+    // account switch doesn't carry the previous user's backoff onto
+    // the new session — their `sync_metadata` row holds any persistent
+    // rate-limit state.
+    let mut notifications_next_allowed: Option<(i64, DateTime<Utc>)> = None;
 
     loop {
         let state = app.state::<AppState>();
@@ -157,23 +160,29 @@ async fn run_loop(app: AppHandle, notify: Arc<Notify>, status: Arc<RwLock<Schedu
         // notifications are pure background activity (the user can still
         // refresh manually via the bell button which calls
         // `get_notifications` directly).
+        // Only the in-memory floor for the current user applies; an
+        // account switch invalidates the previous user's backoff window
+        // (their persisted `sync_metadata.rate_limit_reset_at` is per-user
+        // and remains the source of truth across sessions).
+        let next_allowed_for_user = notifications_next_allowed
+            .filter(|(uid, _)| *uid == user.id)
+            .map(|(_, at)| at);
         if settings.background_sync
-            && notifications_due_to_poll(state.inner(), user.id, notifications_next_allowed_at, now)
-                .await
+            && notifications_due_to_poll(state.inner(), user.id, next_allowed_for_user, now).await
         {
             match run_notifications_sync(&app, state.inner()).await {
                 Ok(NotificationsSyncOutcome::Ok {
                     poll_interval_seconds,
                 }) => {
-                    notifications_next_allowed_at = poll_interval_seconds
-                        .map(|secs| Utc::now() + chrono::Duration::seconds(secs as i64));
+                    notifications_next_allowed = poll_interval_seconds
+                        .map(|secs| (user.id, Utc::now() + chrono::Duration::seconds(secs as i64)));
                 }
                 Ok(NotificationsSyncOutcome::RateLimited { reset_at }) => {
                     eprintln!(
                         "Scheduler: notifications API rate-limited until {}",
                         reset_at.to_rfc3339()
                     );
-                    notifications_next_allowed_at = Some(reset_at);
+                    notifications_next_allowed = Some((user.id, reset_at));
                 }
                 Err(e) => {
                     eprintln!("Scheduler: notifications sync failed: {}", e);

--- a/src-tauri/src/sync_scheduler/runner.rs
+++ b/src-tauri/src/sync_scheduler/runner.rs
@@ -151,8 +151,15 @@ async fn run_loop(app: AppHandle, notify: Arc<Notify>, status: Arc<RwLock<Schedu
         // self-throttled via `notifications_due_to_poll`, which honours
         // both GitHub's `x-poll-interval` hint and any persisted
         // rate-limit reset.
-        if notifications_due_to_poll(state.inner(), user.id, notifications_next_allowed_at, now)
-            .await
+        //
+        // Honour `background_sync = false` here too: the contract is
+        // "background API activity halts when the user opts out", and
+        // notifications are pure background activity (the user can still
+        // refresh manually via the bell button which calls
+        // `get_notifications` directly).
+        if settings.background_sync
+            && notifications_due_to_poll(state.inner(), user.id, notifications_next_allowed_at, now)
+                .await
         {
             match run_notifications_sync(&app, state.inner()).await {
                 Ok(NotificationsSyncOutcome::Ok {

--- a/src-tauri/src/sync_scheduler/runner.rs
+++ b/src-tauri/src/sync_scheduler/runner.rs
@@ -14,7 +14,9 @@ use tokio::sync::{Notify, RwLock};
 use crate::auth::{classify_unauthorized, handle_unauthorized, reasons};
 use crate::commands::auth::AppState;
 use crate::commands::github::run_github_sync;
-use crate::commands::notifications::run_notifications_sync;
+use crate::commands::notifications::{
+    run_notifications_sync, NotificationsSyncOutcome, GITHUB_NOTIFICATIONS_SYNC_TYPE,
+};
 use crate::database::models::code_stats::SyncMetadata;
 use crate::database::models::UserSettings;
 use crate::github::client::GitHubError;
@@ -143,6 +145,30 @@ async fn run_loop(app: AppHandle, notify: Arc<Notify>, status: Arc<RwLock<Schedu
                 is_first_run = false;
                 eprintln!("Scheduler: running scheduled sync for user {}", user.id);
 
+                // Poll GitHub Notifications first (Issue #186). Decoupled
+                // from the stats sync result so a stats failure (network,
+                // GraphQL hiccup, etc.) doesn't freeze the inbox until the
+                // next interval. The endpoint is conditional via ETag so
+                // a 304 costs zero rate budget; rate-limit responses are
+                // persisted to a separate `sync_metadata` row and honoured
+                // on subsequent ticks via `notifications_throttled`.
+                if notifications_throttled(state.inner(), user.id).await {
+                    eprintln!("Scheduler: skipping notifications poll while rate-limited");
+                } else {
+                    match run_notifications_sync(&app, state.inner()).await {
+                        Ok(NotificationsSyncOutcome::Ok) => {}
+                        Ok(NotificationsSyncOutcome::RateLimited { reset_at }) => {
+                            eprintln!(
+                                "Scheduler: notifications API rate-limited until {}",
+                                reset_at.to_rfc3339()
+                            );
+                        }
+                        Err(e) => {
+                            eprintln!("Scheduler: notifications sync failed: {}", e);
+                        }
+                    }
+                }
+
                 match run_github_sync(&app, state.inner()).await {
                     Ok(_) => {
                         // Post-sync metadata is persisted inside `run_github_sync`
@@ -152,17 +178,6 @@ async fn run_loop(app: AppHandle, notify: Arc<Notify>, status: Arc<RwLock<Schedu
                         // A successful sync invalidates any in-memory rate-limit
                         // fallback we may have been carrying.
                         rate_limit_reset_fallback = None;
-
-                        // Piggyback the GitHub Notifications poll on the stats
-                        // sync tick (Issue #186). The notifications endpoint
-                        // is conditional via ETag so a 304 costs zero rate
-                        // budget; an actual modification emits the
-                        // `notifications-updated` event for the UI. Failures
-                        // here must not unwind the stats success — log and
-                        // continue.
-                        if let Err(e) = run_notifications_sync(&app, state.inner()).await {
-                            eprintln!("Scheduler: notifications sync failed: {}", e);
-                        }
                     }
                     Err(err_msg) => {
                         eprintln!("Scheduler: scheduled sync failed: {}", err_msg);
@@ -522,6 +537,35 @@ async fn persist_startup_baseline(db: &crate::database::Database, user_id: i64) 
         db.record_scheduler_baseline(user_id, GITHUB_STATS_SYNC_TYPE, Utc::now())
             .await,
     );
+}
+
+/// Check whether the notifications endpoint is currently rate-limited per
+/// the persisted `sync_metadata` row.
+///
+/// `record_sync_rate_limit` writes the reset timestamp inside
+/// `run_notifications_sync` when GitHub returns a 0-remaining 403; we
+/// honour it here so the next tick doesn't immediately re-poll and burn
+/// through the limit again. A read failure errs on "not throttled" — it's
+/// safer to re-poll once than to silently freeze the inbox.
+async fn notifications_throttled(state: &AppState, user_id: i64) -> bool {
+    let metadata = match state
+        .db
+        .get_sync_metadata(user_id, GITHUB_NOTIFICATIONS_SYNC_TYPE)
+        .await
+    {
+        Ok(m) => m,
+        Err(e) => {
+            eprintln!(
+                "Scheduler: failed to read notifications sync_metadata: {}",
+                e
+            );
+            return false;
+        }
+    };
+
+    metadata
+        .and_then(|m| m.rate_limit_reset_at_parsed())
+        .is_some_and(|reset| reset > Utc::now())
 }
 
 /// Classify a `run_github_sync` error string as rate-limited.

--- a/src-tauri/src/sync_scheduler/runner.rs
+++ b/src-tauri/src/sync_scheduler/runner.rs
@@ -171,7 +171,7 @@ async fn run_loop(app: AppHandle, notify: Arc<Notify>, status: Arc<RwLock<Schedu
         if settings.background_sync
             && notifications_due_to_poll(state.inner(), user.id, next_allowed_for_user, now).await
         {
-            match run_notifications_sync(&app, state.inner()).await {
+            match run_notifications_sync(&app, state.inner(), user.id).await {
                 Ok(NotificationsSyncOutcome::Ok {
                     poll_interval_seconds,
                 }) => {
@@ -184,6 +184,17 @@ async fn run_loop(app: AppHandle, notify: Arc<Notify>, status: Arc<RwLock<Schedu
                         reset_at.to_rfc3339()
                     );
                     notifications_next_allowed = Some((user.id, reset_at));
+                }
+                Ok(NotificationsSyncOutcome::UserChanged) => {
+                    // Mid-flight account switch — abandon this iteration's
+                    // notifications poll. Drop any in-memory floor that
+                    // belonged to the previous user; the next iteration
+                    // will re-evaluate against the new user's settings
+                    // and persisted state.
+                    eprintln!(
+                        "Scheduler: notifications poll skipped — active user changed mid-flight"
+                    );
+                    notifications_next_allowed = None;
                 }
                 Err(e) => {
                     eprintln!("Scheduler: notifications sync failed: {}", e);

--- a/src/components/features/notifications/NotificationsButton.tsx
+++ b/src/components/features/notifications/NotificationsButton.tsx
@@ -50,6 +50,15 @@ export const NotificationsButton = () => {
     let unlistenFn: (() => void) | null = null;
     void events
       .onNotificationsUpdated((event) => {
+        // Drop events whose `userId` doesn't match the currently
+        // logged-in user — the scheduler captures user.id *before* the
+        // GitHub round-trip, so an account switch mid-flight produces
+        // an event with the previous user's data. Applying it would
+        // leak repo titles / unread counts across accounts.
+        const currentUserId = useAuth.getState().state.user?.id;
+        if (currentUserId === undefined || event.userId !== currentUserId) {
+          return;
+        }
         // Apply the items from the event payload directly. A re-fetch
         // would race the just-persisted ETag and come back as 304,
         // leaving the UI showing the pre-event list.

--- a/src/components/features/notifications/NotificationsButton.tsx
+++ b/src/components/features/notifications/NotificationsButton.tsx
@@ -23,6 +23,7 @@ export const NotificationsButton = () => {
   const unreadCount = useNotifications((s) => s.unreadCount);
   const fetchNotifications = useNotifications((s) => s.fetch);
   const setFromEvent = useNotifications((s) => s.setFromEvent);
+  const resetNotifications = useNotifications((s) => s.reset);
   const [isOpen, setIsOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -30,7 +31,13 @@ export const NotificationsButton = () => {
   // the store already short-circuits when logged out, but this also avoids
   // wiring up event listeners we won't use.
   useEffect(() => {
-    if (!isLoggedIn) return;
+    if (!isLoggedIn) {
+      // Wipe local state so account switches don't briefly show the
+      // previous user's unread badge / dropdown contents before the
+      // next fetch lands.
+      resetNotifications();
+      return;
+    }
 
     void fetchNotifications();
 
@@ -60,7 +67,7 @@ export const NotificationsButton = () => {
       disposed = true;
       if (unlistenFn) unlistenFn();
     };
-  }, [isLoggedIn, fetchNotifications, setFromEvent]);
+  }, [isLoggedIn, fetchNotifications, setFromEvent, resetNotifications]);
 
   // Close the dropdown when clicking outside.
   useEffect(() => {

--- a/src/components/features/notifications/NotificationsButton.tsx
+++ b/src/components/features/notifications/NotificationsButton.tsx
@@ -22,6 +22,7 @@ export const NotificationsButton = () => {
   const isLoggedIn = useAuth((s) => s.state.isLoggedIn);
   const unreadCount = useNotifications((s) => s.unreadCount);
   const fetchNotifications = useNotifications((s) => s.fetch);
+  const setFromEvent = useNotifications((s) => s.setFromEvent);
   const [isOpen, setIsOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -33,19 +34,33 @@ export const NotificationsButton = () => {
 
     void fetchNotifications();
 
+    // The `disposed` flag protects against the cleanup running before
+    // the listener Promise resolves: without it, an unmount during the
+    // brief async window would leak the Tauri listener and re-mounting
+    // (e.g. on re-login) would attach a duplicate, double-firing
+    // `fetchNotifications` for every backend push.
+    let disposed = false;
     let unlistenFn: (() => void) | null = null;
     void events
-      .onNotificationsUpdated(() => {
-        void fetchNotifications();
+      .onNotificationsUpdated((event) => {
+        // Apply the items from the event payload directly. A re-fetch
+        // would race the just-persisted ETag and come back as 304,
+        // leaving the UI showing the pre-event list.
+        setFromEvent(event.items, event.unreadCount);
       })
       .then((unlisten) => {
+        if (disposed) {
+          unlisten();
+          return;
+        }
         unlistenFn = unlisten;
       });
 
     return () => {
+      disposed = true;
       if (unlistenFn) unlistenFn();
     };
-  }, [isLoggedIn, fetchNotifications]);
+  }, [isLoggedIn, fetchNotifications, setFromEvent]);
 
   // Close the dropdown when clicking outside.
   useEffect(() => {

--- a/src/components/features/notifications/NotificationsButton.tsx
+++ b/src/components/features/notifications/NotificationsButton.tsx
@@ -1,0 +1,100 @@
+/**
+ * Notifications Button
+ *
+ * Sidebar bell + unread badge that opens the notifications dropdown.
+ * Subscribes to the backend's `notifications-updated` event so it stays
+ * fresh without manual polling from the UI.
+ *
+ * Related Documentation:
+ *   - Issue: https://github.com/otomatty/development-tools/issues/186
+ *   - Backend: src-tauri/src/commands/notifications.rs
+ *   - Store: src/stores/notificationsStore.ts
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { Icon } from '@/components/icons';
+import { useNotifications } from '@/stores/notificationsStore';
+import { useAuth } from '@/stores/authStore';
+import { events } from '@/lib/tauri/events';
+import { NotificationsDropdown } from './NotificationsDropdown';
+
+export const NotificationsButton = () => {
+  const isLoggedIn = useAuth((s) => s.state.isLoggedIn);
+  const unreadCount = useNotifications((s) => s.unreadCount);
+  const fetchNotifications = useNotifications((s) => s.fetch);
+  const [isOpen, setIsOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Initial load + subscribe to backend pushes. Only run when logged in —
+  // the store already short-circuits when logged out, but this also avoids
+  // wiring up event listeners we won't use.
+  useEffect(() => {
+    if (!isLoggedIn) return;
+
+    void fetchNotifications();
+
+    let unlistenFn: (() => void) | null = null;
+    void events
+      .onNotificationsUpdated(() => {
+        void fetchNotifications();
+      })
+      .then((unlisten) => {
+        unlistenFn = unlisten;
+      });
+
+    return () => {
+      if (unlistenFn) unlistenFn();
+    };
+  }, [isLoggedIn, fetchNotifications]);
+
+  // Close the dropdown when clicking outside.
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleClick = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [isOpen]);
+
+  if (!isLoggedIn) return null;
+
+  // GitHub caps the unread count display at 99+ in the web UI; we mirror
+  // that to keep the badge from blowing past two characters.
+  const badgeLabel = unreadCount > 99 ? '99+' : unreadCount.toString();
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setIsOpen((open) => !open)}
+        aria-label={
+          unreadCount > 0
+            ? `通知 (${unreadCount}件未読)`
+            : '通知'
+        }
+        aria-expanded={isOpen}
+        className={`relative p-2 rounded-lg transition-all duration-200 ${
+          isOpen
+            ? 'bg-gm-accent-cyan/20 text-gm-accent-cyan'
+            : 'text-slate-400 hover:bg-slate-800 hover:text-dt-text'
+        }`}
+        title="通知"
+      >
+        <Icon name="bell" className="w-5 h-5" />
+        {unreadCount > 0 && (
+          <span
+            className="absolute -top-1 -right-1 min-w-[18px] h-[18px] px-1 rounded-full bg-red-500 text-white text-[10px] font-bold flex items-center justify-center"
+            aria-hidden="true"
+          >
+            {badgeLabel}
+          </span>
+        )}
+      </button>
+      {isOpen && <NotificationsDropdown onClose={() => setIsOpen(false)} />}
+    </div>
+  );
+};

--- a/src/components/features/notifications/NotificationsDropdown.tsx
+++ b/src/components/features/notifications/NotificationsDropdown.tsx
@@ -30,16 +30,18 @@ export const NotificationsDropdown = ({ onClose }: NotificationsDropdownProps) =
   const markRead = useNotifications((s) => s.markRead);
 
   const handleOpen = async (item: NotificationItem) => {
-    // Mark as read locally + on GitHub, then open the URL in the user's
-    // browser. Order matters: opening the URL can race the API call but the
-    // optimistic update fires immediately so the list reflects the click.
-    if (item.unread) {
-      void markRead(item.id);
-    }
+    // Open the URL first; only mark as read if the user actually got to
+    // the issue/PR. If `openExternalUrl` rejects (deny / no browser),
+    // leaving the unread state intact lets the user retry without
+    // losing track of the item.
     try {
       await settingsApi.openExternalUrl(item.htmlUrl);
     } catch (e) {
       console.error('Failed to open notification URL', e);
+      return;
+    }
+    if (item.unread) {
+      void markRead(item.id);
     }
     onClose();
   };

--- a/src/components/features/notifications/NotificationsDropdown.tsx
+++ b/src/components/features/notifications/NotificationsDropdown.tsx
@@ -1,0 +1,153 @@
+/**
+ * Notifications Dropdown
+ *
+ * List of GitHub notifications shown when the sidebar bell is clicked.
+ * Each row links out to the underlying issue / PR and marks the thread
+ * as read on click.
+ *
+ * Related Documentation:
+ *   - Issue: https://github.com/otomatty/development-tools/issues/186
+ *   - Store: src/stores/notificationsStore.ts
+ */
+
+import { Icon } from '@/components/icons';
+import { useNotifications } from '@/stores/notificationsStore';
+import { settings as settingsApi } from '@/lib/tauri/commands';
+import {
+  notificationReasonLabel,
+  type NotificationItem,
+} from '@/types';
+
+interface NotificationsDropdownProps {
+  onClose: () => void;
+}
+
+export const NotificationsDropdown = ({ onClose }: NotificationsDropdownProps) => {
+  const items = useNotifications((s) => s.items);
+  const isLoading = useNotifications((s) => s.isLoading);
+  const error = useNotifications((s) => s.error);
+  const refresh = useNotifications((s) => s.fetch);
+  const markRead = useNotifications((s) => s.markRead);
+
+  const handleOpen = async (item: NotificationItem) => {
+    // Mark as read locally + on GitHub, then open the URL in the user's
+    // browser. Order matters: opening the URL can race the API call but the
+    // optimistic update fires immediately so the list reflects the click.
+    if (item.unread) {
+      void markRead(item.id);
+    }
+    try {
+      await settingsApi.openExternalUrl(item.htmlUrl);
+    } catch (e) {
+      console.error('Failed to open notification URL', e);
+    }
+    onClose();
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-label="通知一覧"
+      className="absolute bottom-full mb-2 right-0 w-96 max-h-[480px] bg-slate-900 border border-slate-700 rounded-lg shadow-xl overflow-hidden flex flex-col z-50"
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-2.5 border-b border-slate-700">
+        <h3 className="text-sm font-semibold text-dt-text">通知</h3>
+        <button
+          type="button"
+          onClick={() => void refresh()}
+          disabled={isLoading}
+          aria-label="再読み込み"
+          className="p-1 rounded hover:bg-slate-800 text-slate-400 hover:text-dt-text transition-colors disabled:opacity-50"
+        >
+          <Icon
+            name="refresh-cw"
+            className={`w-4 h-4 ${isLoading ? 'animate-spin' : ''}`}
+          />
+        </button>
+      </div>
+
+      {/* Body */}
+      <div className="flex-1 overflow-y-auto">
+        {error && (
+          <div className="px-4 py-3 text-xs text-red-400 bg-red-500/10 border-b border-red-500/20">
+            {error}
+          </div>
+        )}
+
+        {!isLoading && items.length === 0 && !error && (
+          <div className="px-4 py-8 text-center text-sm text-slate-400">
+            通知はありません
+          </div>
+        )}
+
+        {items.length > 0 && (
+          <ul className="divide-y divide-slate-800">
+            {items.map((item) => (
+              <li key={item.id}>
+                <button
+                  type="button"
+                  onClick={() => void handleOpen(item)}
+                  className={`w-full text-left px-4 py-3 hover:bg-slate-800 transition-colors ${
+                    item.unread ? 'bg-slate-800/40' : ''
+                  }`}
+                >
+                  <div className="flex items-start gap-2">
+                    {item.unread && (
+                      <span
+                        aria-hidden="true"
+                        className="mt-1.5 w-2 h-2 rounded-full bg-gm-accent-cyan flex-shrink-0"
+                      />
+                    )}
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2 mb-1">
+                        <span className="text-[10px] uppercase tracking-wide text-gm-accent-purple font-semibold">
+                          {notificationReasonLabel(item.reason)}
+                        </span>
+                        <span className="text-[10px] text-slate-500 truncate">
+                          {item.repoFullName}
+                        </span>
+                      </div>
+                      <div
+                        className={`text-sm truncate ${
+                          item.unread ? 'text-dt-text font-medium' : 'text-slate-400'
+                        }`}
+                      >
+                        {item.title}
+                      </div>
+                      <div className="text-[11px] text-slate-500 mt-0.5">
+                        {formatRelativeTime(item.updatedAt)}
+                      </div>
+                    </div>
+                  </div>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+};
+
+/**
+ * Format an ISO8601 timestamp as "5分前" / "2時間前" / etc.
+ *
+ * Falls back to a localized date when the timestamp is older than a week —
+ * the user can hover the date for the precise time anyway.
+ */
+function formatRelativeTime(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+
+  const diffMs = Date.now() - date.getTime();
+  const diffSec = Math.floor(diffMs / 1000);
+  if (diffSec < 60) return `${diffSec}秒前`;
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) return `${diffMin}分前`;
+  const diffHour = Math.floor(diffMin / 60);
+  if (diffHour < 24) return `${diffHour}時間前`;
+  const diffDay = Math.floor(diffHour / 24);
+  if (diffDay < 7) return `${diffDay}日前`;
+  return date.toLocaleDateString('ja-JP');
+}

--- a/src/components/features/notifications/index.ts
+++ b/src/components/features/notifications/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Notifications Feature Components
+ *
+ * GitHub Notifications UI: sidebar bell badge + dropdown list.
+ *
+ * Related Documentation:
+ *   - Issue: https://github.com/otomatty/development-tools/issues/186
+ */
+
+export { NotificationsButton } from './NotificationsButton';
+export { NotificationsDropdown } from './NotificationsDropdown';

--- a/src/components/layouts/Sidebar/Sidebar.tsx
+++ b/src/components/layouts/Sidebar/Sidebar.tsx
@@ -12,6 +12,7 @@
 
 import { Link, useLocation } from 'react-router-dom';
 import { Icon } from '@/components/icons';
+import { NotificationsButton } from '@/components/features/notifications';
 import { SidebarItem } from './SidebarItem';
 
 interface NavItem {
@@ -76,19 +77,23 @@ export const Sidebar = () => {
       <div className="p-3 border-t border-slate-700/50">
         <div className="flex items-center justify-between">
           <div className="text-xs text-dt-text-sub">v0.1.0</div>
-          {/* Settings button */}
-          <Link
-            to="/settings"
-            className={`p-2 rounded-lg transition-all duration-200 ${
-              isSettingsActive
-                ? 'bg-gm-accent-cyan/20 text-gm-accent-cyan'
-                : 'text-slate-400 hover:bg-slate-800 hover:text-dt-text'
-            }`}
-            title="Settings"
-            aria-label="Settings"
-          >
-            <Icon name="settings" className="w-5 h-5" />
-          </Link>
+          <div className="flex items-center gap-1">
+            {/* Notifications button (Issue #186) */}
+            <NotificationsButton />
+            {/* Settings button */}
+            <Link
+              to="/settings"
+              className={`p-2 rounded-lg transition-all duration-200 ${
+                isSettingsActive
+                  ? 'bg-gm-accent-cyan/20 text-gm-accent-cyan'
+                  : 'text-slate-400 hover:bg-slate-800 hover:text-dt-text'
+              }`}
+              title="Settings"
+              aria-label="Settings"
+            >
+              <Icon name="settings" className="w-5 h-5" />
+            </Link>
+          </div>
         </div>
       </div>
     </aside>

--- a/src/lib/tauri/commands.ts
+++ b/src/lib/tauri/commands.ts
@@ -48,6 +48,7 @@ import type {
   CachedResponse,
   CacheStats,
   SchedulerStatus,
+  NotificationsPayload,
 } from '@/types';
 
 // ============================================================================
@@ -468,6 +469,31 @@ export const github = {
    */
   getUserStatsWithCache: (): Promise<CachedResponse<UserStats>> =>
     invoke<CachedResponse<UserStats>>('get_user_stats_with_cache'),
+};
+
+// ============================================================================
+// GitHub Notifications Commands (Issue #186)
+// ============================================================================
+
+export const notifications = {
+  /**
+   * Fetch the authenticated user's GitHub notifications.
+   *
+   * Backed by `GET /notifications` with an ETag-based conditional request,
+   * so a poll that observes no changes costs zero rate-limit budget. When
+   * the server returns 304, the payload's `fromCache` is true and `items`
+   * is empty — keep showing whatever was rendered previously.
+   */
+  list: (): Promise<NotificationsPayload> =>
+    invoke<NotificationsPayload>('get_notifications'),
+
+  /**
+   * Mark a single notification thread as read on GitHub.
+   *
+   * `threadId` is the `id` field on a NotificationItem.
+   */
+  markRead: (threadId: string): Promise<void> =>
+    invoke<void>('mark_notification_read', { threadId }),
 };
 
 // ============================================================================

--- a/src/lib/tauri/commands.ts
+++ b/src/lib/tauri/commands.ts
@@ -490,10 +490,12 @@ export const notifications = {
   /**
    * Mark a single notification thread as read on GitHub.
    *
-   * `threadId` is the `id` field on a NotificationItem.
+   * `threadId` is the `id` field on a NotificationItem. The Tauri command
+   * takes `thread_id` (snake_case) — Tauri 2 accepts either casing, but we
+   * pass snake_case to stay consistent with the rest of this codebase.
    */
   markRead: (threadId: string): Promise<void> =>
-    invoke<void>('mark_notification_read', { threadId }),
+    invoke<void>('mark_notification_read', { thread_id: threadId }),
 };
 
 // ============================================================================

--- a/src/lib/tauri/events.ts
+++ b/src/lib/tauri/events.ts
@@ -16,6 +16,7 @@ import type {
   XpGainedEvent,
   StreakMilestoneEvent,
   BadgeEarnedEvent,
+  NotificationsUpdatedEvent,
 } from '@/types';
 
 // ============================================================================
@@ -71,5 +72,23 @@ export const events = {
    */
   onBadgeEarned: (callback: (event: BadgeEarnedEvent) => void): Promise<UnlistenFn> =>
     listen<BadgeEarnedEvent>('badge-earned', (event) => callback(event.payload)),
+
+  // ============================================================================
+  // GitHub Notifications Events (Issue #186)
+  // ============================================================================
+
+  /**
+   * Listen for changes to the authenticated user's GitHub notifications.
+   *
+   * Emitted by the background scheduler whenever a poll observes a
+   * non-304 response. The frontend should treat this as a cue to re-fetch
+   * the notifications list.
+   */
+  onNotificationsUpdated: (
+    callback: (event: NotificationsUpdatedEvent) => void,
+  ): Promise<UnlistenFn> =>
+    listen<NotificationsUpdatedEvent>('notifications-updated', (event) =>
+      callback(event.payload),
+    ),
 };
 

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -12,6 +12,7 @@
 // Export all stores
 export * from './authStore';
 export * from './navigationStore';
+export * from './notificationsStore';
 export * from './settingsStore';
 export * from './networkStore';
 export * from './animationStore';

--- a/src/stores/notificationsStore.ts
+++ b/src/stores/notificationsStore.ts
@@ -59,13 +59,16 @@ export const useNotifications = create<NotificationsStore>((set, get) => ({
     // 0 without flashing an error.
     if (!useAuth.getState().state.isLoggedIn) return;
 
-    // Capture the session generation at launch. If `reset()` (logout) or
-    // a `setFromEvent` push runs while we're awaiting the API, the
-    // captured value will mismatch on resume and we drop the response —
+    // Capture the session generation at launch *and* bump it. The bump
+    // means concurrent fetches (e.g. user clicks refresh twice) don't
+    // share a `launchGen` — only the most recent one will commit; the
+    // earlier ones will see a mismatch on resume and drop. If `reset()`
+    // (logout) or a `setFromEvent` push runs while we're awaiting the
+    // API, the captured value will likewise mismatch and we drop —
     // otherwise an in-flight fetch from user A could overwrite user B's
     // empty state after an account switch.
-    const launchGen = get().sessionGen;
-    set({ isLoading: true, error: null });
+    const launchGen = get().sessionGen + 1;
+    set({ sessionGen: launchGen, isLoading: true, error: null });
     try {
       const payload = await notificationsApi.list();
       if (get().sessionGen !== launchGen) {

--- a/src/stores/notificationsStore.ts
+++ b/src/stores/notificationsStore.ts
@@ -1,0 +1,90 @@
+/**
+ * Notifications Store
+ *
+ * Holds the GitHub Notifications list and unread count, refreshed via
+ * `notifications.list()` and pushed to via the `notifications-updated`
+ * Tauri event.
+ *
+ * Related Documentation:
+ *   - Issue: https://github.com/otomatty/development-tools/issues/186
+ *   - Backend: src-tauri/src/commands/notifications.rs
+ *   - Tauri API: src/lib/tauri/commands.ts (notifications)
+ */
+
+import { create } from 'zustand';
+import type { NotificationItem } from '@/types';
+import { notifications as notificationsApi } from '@/lib/tauri/commands';
+import { useAuth } from './authStore';
+
+interface NotificationsStore {
+  items: NotificationItem[];
+  unreadCount: number;
+  isLoading: boolean;
+  error: string | null;
+  /** ISO8601 timestamp of the last successful refresh. */
+  lastFetchedAt: string | null;
+
+  fetch: () => Promise<void>;
+  markRead: (threadId: string) => Promise<void>;
+}
+
+export const useNotifications = create<NotificationsStore>((set, get) => ({
+  items: [],
+  unreadCount: 0,
+  isLoading: false,
+  error: null,
+  lastFetchedAt: null,
+
+  fetch: async () => {
+    // Skip when logged out — the backend would return "Not logged in" and
+    // clutter the error state. Stays silent so the bell badge can render
+    // 0 without flashing an error.
+    if (!useAuth.getState().state.isLoggedIn) return;
+
+    set({ isLoading: true, error: null });
+    try {
+      const payload = await notificationsApi.list();
+      // 304: backend returns an empty list with `fromCache=true`. Don't
+      // overwrite the cached items — keep showing what the user already
+      // sees, but refresh `lastFetchedAt` so the UI knows the poll
+      // succeeded.
+      if (payload.fromCache) {
+        set({
+          isLoading: false,
+          lastFetchedAt: new Date().toISOString(),
+        });
+        return;
+      }
+      set({
+        items: payload.items,
+        unreadCount: payload.unreadCount,
+        isLoading: false,
+        lastFetchedAt: new Date().toISOString(),
+      });
+    } catch (e) {
+      set({
+        isLoading: false,
+        error: typeof e === 'string' ? e : (e as Error).message ?? 'Failed to fetch notifications',
+      });
+    }
+  },
+
+  markRead: async (threadId: string) => {
+    // Optimistic update: mark the row read locally before the API call so
+    // the bell badge reacts instantly. Roll back if the API rejects.
+    const prev = get().items;
+    const updated = prev.map((n) => (n.id === threadId ? { ...n, unread: false } : n));
+    const newUnread = updated.filter((n) => n.unread).length;
+    set({ items: updated, unreadCount: newUnread });
+
+    try {
+      await notificationsApi.markRead(threadId);
+    } catch (e) {
+      set({
+        items: prev,
+        unreadCount: prev.filter((n) => n.unread).length,
+        error: typeof e === 'string' ? e : (e as Error).message ?? 'Failed to mark as read',
+      });
+    }
+  },
+}));

--- a/src/stores/notificationsStore.ts
+++ b/src/stores/notificationsStore.ts
@@ -23,6 +23,15 @@ interface NotificationsStore {
   error: string | null;
   /** ISO8601 timestamp of the last successful refresh. */
   lastFetchedAt: string | null;
+  /**
+   * Monotonic counter bumped on every state-mutating action (fetch start,
+   * setFromEvent, reset, markRead). In-flight fetches capture this on
+   * launch and discard their result if it changed while they were
+   * awaiting the API — this prevents user A's response from being
+   * written back into the store after user A logged out and user B
+   * already started a new session.
+   */
+  sessionGen: number;
 
   fetch: () => Promise<void>;
   /** Replace the list directly (used by the `notifications-updated` event). */
@@ -42,6 +51,7 @@ export const useNotifications = create<NotificationsStore>((set, get) => ({
   isLoading: false,
   error: null,
   lastFetchedAt: null,
+  sessionGen: 0,
 
   fetch: async () => {
     // Skip when logged out — the backend would return "Not logged in" and
@@ -49,13 +59,16 @@ export const useNotifications = create<NotificationsStore>((set, get) => ({
     // 0 without flashing an error.
     if (!useAuth.getState().state.isLoggedIn) return;
 
+    // Capture the session generation at launch. If `reset()` (logout) or
+    // a `setFromEvent` push runs while we're awaiting the API, the
+    // captured value will mismatch on resume and we drop the response —
+    // otherwise an in-flight fetch from user A could overwrite user B's
+    // empty state after an account switch.
+    const launchGen = get().sessionGen;
     set({ isLoading: true, error: null });
     try {
       const payload = await notificationsApi.list();
-      // The backend serves cached items on 304 (`fromCache=true`), so we
-      // can replace the local list either way — `items` is always the
-      // canonical view. The `fromCache` flag is preserved for diagnostics
-      // but doesn't change the update logic.
+      if (get().sessionGen !== launchGen) return;
       set({
         items: payload.items,
         unreadCount: payload.unreadCount,
@@ -63,6 +76,7 @@ export const useNotifications = create<NotificationsStore>((set, get) => ({
         lastFetchedAt: new Date().toISOString(),
       });
     } catch (e) {
+      if (get().sessionGen !== launchGen) return;
       set({
         isLoading: false,
         error: typeof e === 'string' ? e : (e as Error).message ?? 'Failed to fetch notifications',
@@ -71,22 +85,27 @@ export const useNotifications = create<NotificationsStore>((set, get) => ({
   },
 
   setFromEvent: (items, unreadCount) => {
-    set({
+    set((s) => ({
       items,
       unreadCount,
       error: null,
       lastFetchedAt: new Date().toISOString(),
-    });
+      sessionGen: s.sessionGen + 1,
+    }));
   },
 
   reset: () => {
-    set({
+    // Bumping `sessionGen` here is what closes the cross-account leak —
+    // any fetch in flight at logout time will compare against the new
+    // value on resume and drop its response.
+    set((s) => ({
       items: [],
       unreadCount: 0,
       isLoading: false,
       error: null,
       lastFetchedAt: null,
-    });
+      sessionGen: s.sessionGen + 1,
+    }));
   },
 
   markRead: async (threadId: string) => {
@@ -94,7 +113,11 @@ export const useNotifications = create<NotificationsStore>((set, get) => ({
     // the bell badge reacts instantly.
     const prev = get().items;
     const updated = prev.map((n) => (n.id === threadId ? { ...n, unread: false } : n));
-    set({ items: updated, unreadCount: updated.filter((n) => n.unread).length });
+    set((s) => ({
+      items: updated,
+      unreadCount: updated.filter((n) => n.unread).length,
+      sessionGen: s.sessionGen + 1,
+    }));
 
     try {
       await notificationsApi.markRead(threadId);

--- a/src/stores/notificationsStore.ts
+++ b/src/stores/notificationsStore.ts
@@ -28,6 +28,12 @@ interface NotificationsStore {
   /** Replace the list directly (used by the `notifications-updated` event). */
   setFromEvent: (items: NotificationItem[], unreadCount: number) => void;
   markRead: (threadId: string) => Promise<void>;
+  /**
+   * Wipe local state. Called when the user logs out so the next account
+   * doesn't see the previous user's unread count or repo titles in the
+   * brief window before the first authenticated fetch completes.
+   */
+  reset: () => void;
 }
 
 export const useNotifications = create<NotificationsStore>((set, get) => ({
@@ -70,6 +76,16 @@ export const useNotifications = create<NotificationsStore>((set, get) => ({
       unreadCount,
       error: null,
       lastFetchedAt: new Date().toISOString(),
+    });
+  },
+
+  reset: () => {
+    set({
+      items: [],
+      unreadCount: 0,
+      isLoading: false,
+      error: null,
+      lastFetchedAt: null,
     });
   },
 

--- a/src/stores/notificationsStore.ts
+++ b/src/stores/notificationsStore.ts
@@ -25,6 +25,8 @@ interface NotificationsStore {
   lastFetchedAt: string | null;
 
   fetch: () => Promise<void>;
+  /** Replace the list directly (used by the `notifications-updated` event). */
+  setFromEvent: (items: NotificationItem[], unreadCount: number) => void;
   markRead: (threadId: string) => Promise<void>;
 }
 
@@ -44,17 +46,10 @@ export const useNotifications = create<NotificationsStore>((set, get) => ({
     set({ isLoading: true, error: null });
     try {
       const payload = await notificationsApi.list();
-      // 304: backend returns an empty list with `fromCache=true`. Don't
-      // overwrite the cached items — keep showing what the user already
-      // sees, but refresh `lastFetchedAt` so the UI knows the poll
-      // succeeded.
-      if (payload.fromCache) {
-        set({
-          isLoading: false,
-          lastFetchedAt: new Date().toISOString(),
-        });
-        return;
-      }
+      // The backend serves cached items on 304 (`fromCache=true`), so we
+      // can replace the local list either way — `items` is always the
+      // canonical view. The `fromCache` flag is preserved for diagnostics
+      // but doesn't change the update logic.
       set({
         items: payload.items,
         unreadCount: payload.unreadCount,
@@ -69,22 +64,34 @@ export const useNotifications = create<NotificationsStore>((set, get) => ({
     }
   },
 
+  setFromEvent: (items, unreadCount) => {
+    set({
+      items,
+      unreadCount,
+      error: null,
+      lastFetchedAt: new Date().toISOString(),
+    });
+  },
+
   markRead: async (threadId: string) => {
     // Optimistic update: mark the row read locally before the API call so
-    // the bell badge reacts instantly. Roll back if the API rejects.
+    // the bell badge reacts instantly.
     const prev = get().items;
     const updated = prev.map((n) => (n.id === threadId ? { ...n, unread: false } : n));
-    const newUnread = updated.filter((n) => n.unread).length;
-    set({ items: updated, unreadCount: newUnread });
+    set({ items: updated, unreadCount: updated.filter((n) => n.unread).length });
 
     try {
       await notificationsApi.markRead(threadId);
     } catch (e) {
+      // Don't blanket-restore `prev` — a concurrent successful fetch may
+      // have replaced the list with newer data, and rolling back to the
+      // pre-click snapshot would clobber it. Surface the error and let a
+      // re-fetch reconcile the truth from the backend (which is also
+      // serving from its own cache, so this is cheap).
       set({
-        items: prev,
-        unreadCount: prev.filter((n) => n.unread).length,
         error: typeof e === 'string' ? e : (e as Error).message ?? 'Failed to mark as read',
       });
+      void get().fetch();
     }
   },
 }));

--- a/src/stores/notificationsStore.ts
+++ b/src/stores/notificationsStore.ts
@@ -128,10 +128,15 @@ export const useNotifications = create<NotificationsStore>((set, get) => ({
   },
 
   markRead: async (threadId: string) => {
-    // Optimistic update: mark the row read locally before the API call so
-    // the bell badge reacts instantly.
+    // Optimistic update: drop the row from the list locally so the
+    // dropdown matches the backend's unread-only contract immediately
+    // (the next `notifications.list()` calls `list_notifications(...,
+    // false)` server-side, which already filters out read threads).
+    // Toggling `unread: false` while keeping the row visible would
+    // leave a "read but still in the list" zombie until the next
+    // refresh.
     const prev = get().items;
-    const updated = prev.map((n) => (n.id === threadId ? { ...n, unread: false } : n));
+    const updated = prev.filter((n) => n.id !== threadId);
     set((s) => ({
       items: updated,
       unreadCount: updated.filter((n) => n.unread).length,

--- a/src/stores/notificationsStore.ts
+++ b/src/stores/notificationsStore.ts
@@ -68,7 +68,13 @@ export const useNotifications = create<NotificationsStore>((set, get) => ({
     set({ isLoading: true, error: null });
     try {
       const payload = await notificationsApi.list();
-      if (get().sessionGen !== launchGen) return;
+      if (get().sessionGen !== launchGen) {
+        // Stale: newer data is already in the store. Clear `isLoading`
+        // so the spinner stops — `setFromEvent` / `markRead` only bump
+        // `sessionGen`, they don't reset `isLoading`.
+        set({ isLoading: false });
+        return;
+      }
       set({
         items: payload.items,
         unreadCount: payload.unreadCount,
@@ -76,7 +82,10 @@ export const useNotifications = create<NotificationsStore>((set, get) => ({
         lastFetchedAt: new Date().toISOString(),
       });
     } catch (e) {
-      if (get().sessionGen !== launchGen) return;
+      if (get().sessionGen !== launchGen) {
+        set({ isLoading: false });
+        return;
+      }
       set({
         isLoading: false,
         error: typeof e === 'string' ? e : (e as Error).message ?? 'Failed to fetch notifications',

--- a/src/stores/notificationsStore.ts
+++ b/src/stores/notificationsStore.ts
@@ -94,9 +94,16 @@ export const useNotifications = create<NotificationsStore>((set, get) => ({
   },
 
   setFromEvent: (items, unreadCount) => {
+    // Setting `isLoading: false` here is belt-and-suspenders: fetch()'s
+    // stale-discard branches already clear the spinner when their
+    // response comes back to a bumped sessionGen, but if a render
+    // happens in the brief window between this update and that
+    // discard, the user would otherwise see the new items rendered
+    // alongside a stale spinner.
     set((s) => ({
       items,
       unreadCount,
+      isLoading: false,
       error: null,
       lastFetchedAt: new Date().toISOString(),
       sessionGen: s.sessionGen + 1,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,6 +9,7 @@ export * from './challenge';
 export * from './gamification';
 export * from './issue';
 export * from './network';
+export * from './notifications';
 export * from './settings';
 export * from './ui';
 

--- a/src/types/notifications.ts
+++ b/src/types/notifications.ts
@@ -43,7 +43,15 @@ export interface NotificationsPayload {
 /// Includes the freshly-fetched items so the UI can replace its local
 /// list directly. A re-fetch in response to this event would race the
 /// just-persisted ETag and come back as 304, leaving the UI stale.
+///
+/// `userId` is the DB id of the user the scheduler captured before
+/// awaiting GitHub. The UI compares it against the currently logged-in
+/// user and drops mismatches — if an account switch happens mid-flight
+/// the event still fires for the *previous* user, and applying its
+/// items to the new account would leak unread counts and repo titles
+/// across users.
 export interface NotificationsUpdatedEvent {
+  userId: number;
   unreadCount: number;
   newCount: number;
   items: NotificationItem[];

--- a/src/types/notifications.ts
+++ b/src/types/notifications.ts
@@ -1,0 +1,70 @@
+/**
+ * GitHub Notifications Types
+ *
+ * Mirrors `commands::notifications::NotificationItem` /
+ * `NotificationsPayload` on the backend.
+ *
+ * Related Issue: https://github.com/otomatty/development-tools/issues/186
+ */
+
+/// One row in the notifications dropdown / list.
+export interface NotificationItem {
+  id: string;
+  unread: boolean;
+  /// `mention` / `review_requested` / `assign` / `comment` / etc.
+  reason: string;
+  title: string;
+  /// `Issue` / `PullRequest` / `Commit` / `Discussion`.
+  subjectType: string;
+  repoFullName: string;
+  repoUrl: string;
+  /// Browser URL (already translated from the API URL by the backend).
+  htmlUrl: string;
+  /// ISO8601.
+  updatedAt: string;
+  /// ISO8601 or null when never read.
+  lastReadAt: string | null;
+}
+
+/// Aggregated payload returned by `get_notifications`.
+export interface NotificationsPayload {
+  items: NotificationItem[];
+  unreadCount: number;
+  /// True when GitHub returned 304 — the items list is empty and the caller
+  /// should keep showing whatever it already had.
+  fromCache: boolean;
+  /// `x-poll-interval` (seconds) hint from GitHub. The scheduler honours
+  /// this; the UI surfaces it for diagnostics.
+  pollIntervalSeconds: number | null;
+}
+
+/// Event payload emitted when the backend observes new notification activity.
+export interface NotificationsUpdatedEvent {
+  unreadCount: number;
+  newCount: number;
+}
+
+/// Display label for the notification's `reason` field.
+export function notificationReasonLabel(reason: string): string {
+  switch (reason) {
+    case 'mention':
+    case 'team_mention':
+      return 'メンション';
+    case 'review_requested':
+      return 'レビュー依頼';
+    case 'assign':
+      return 'アサイン';
+    case 'author':
+      return '作成者';
+    case 'comment':
+      return 'コメント';
+    case 'subscribed':
+      return 'ウォッチ';
+    case 'state_change':
+      return '状態変更';
+    case 'ci_activity':
+      return 'CI';
+    default:
+      return reason;
+  }
+}

--- a/src/types/notifications.ts
+++ b/src/types/notifications.ts
@@ -30,8 +30,8 @@ export interface NotificationItem {
 export interface NotificationsPayload {
   items: NotificationItem[];
   unreadCount: number;
-  /// True when GitHub returned 304 — the items list is empty and the caller
-  /// should keep showing whatever it already had.
+  /// True when the backend served the list from its local cache rather
+  /// than a fresh GitHub fetch (e.g. GitHub responded 304).
   fromCache: boolean;
   /// `x-poll-interval` (seconds) hint from GitHub. The scheduler honours
   /// this; the UI surfaces it for diagnostics.
@@ -39,9 +39,14 @@ export interface NotificationsPayload {
 }
 
 /// Event payload emitted when the backend observes new notification activity.
+///
+/// Includes the freshly-fetched items so the UI can replace its local
+/// list directly. A re-fetch in response to this event would race the
+/// just-persisted ETag and come back as 304, leaving the UI stale.
 export interface NotificationsUpdatedEvent {
   unreadCount: number;
   newCount: number;
+  items: NotificationItem[];
 }
 
 /// Display label for the notification's `reason` field.


### PR DESCRIPTION
## Summary

Implements GitHub Notifications support (Issue #186) with a sidebar bell icon that displays unread mentions, review requests, and assignments. Uses ETag-based conditional requests to poll at zero rate-limit cost when nothing has changed, and integrates with the background scheduler for automatic updates.

## Key Changes

### Backend (Rust/Tauri)
- **New `src-tauri/src/commands/notifications.rs`**: Core notifications command handlers
  - `get_notifications`: Fetches user notifications with ETag-based conditional requests (returns 304 when unchanged)
  - `mark_notification_read`: Marks a single thread as read on GitHub
  - `run_notifications_sync`: Background scheduler integration that emits `notifications-updated` events
  - OS notification support for high-signal reasons (mentions, review requests, assignments) with Japanese labels
  - Metadata persistence using `sync_metadata` table with ETag and cursor tracking

- **New `src-tauri/src/github/notifications.rs`**: GitHub Notifications API client
  - `NotificationsClient`: REST API wrapper for `GET /notifications` and `PATCH /notifications/threads/{id}`
  - `build_html_url`: Translates API URLs (`api.github.com/repos/.../pulls/N`) to browser URLs (`github.com/.../pull/N`)
  - Proper handling of 304 Not Modified responses and rate-limit headers
  - Comprehensive unit tests for URL translation edge cases

- **Integration with sync scheduler** (`src-tauri/src/sync_scheduler/runner.rs`):
  - Added `run_notifications_sync` to the background polling loop
  - Respects GitHub's `x-poll-interval` header for adaptive throttling

### Frontend (TypeScript/React)
- **New `src/stores/notificationsStore.ts`**: Zustand store for notifications state
  - Manages items list, unread count, loading/error states
  - Optimistic updates for mark-as-read operations
  - Subscribes to backend `notifications-updated` events

- **New `src/components/features/notifications/`**: UI components
  - `NotificationsButton`: Sidebar bell icon with unread badge (caps at 99+)
  - `NotificationsDropdown`: Scrollable list of notifications with:
    - Unread indicator (cyan dot)
    - Reason labels (メンション, レビュー依頼, etc.)
    - Repository name and relative timestamps
    - Click-to-open behavior that marks as read and opens in browser

- **New `src/types/notifications.ts`**: Type definitions
  - `NotificationItem`, `NotificationsPayload`, `NotificationsUpdatedEvent`
  - `notificationReasonLabel()` helper for Japanese reason labels

- **Integration points**:
  - Updated `src/lib/tauri/commands.ts` with `notifications.list()` and `notifications.markRead()`
  - Updated `src/lib/tauri/events.ts` with `onNotificationsUpdated()` listener
  - Integrated `NotificationsButton` into sidebar layout

## Notable Implementation Details

- **ETag-based polling**: Persists ETags in `sync_metadata` so repeated polls with no changes cost zero API quota
- **Cursor tracking**: Stores the latest `updated_at` timestamp to detect genuinely-new items on next poll
- **304 handling**: When GitHub returns 304, the payload has `fromCache=true` and empty items—UI keeps showing cached data
- **Optimistic updates**: Mark-as-read operations update UI immediately, rolling back on API failure
- **Rate-limit aware**: Mirrors the stats sync's 0-remaining → RateLimited mapping for consistent scheduler behavior
- **Japanese localization**: OS notifications and UI labels use Japanese text (メンション, レビュー依頼, etc.)
- **Graceful degradation**: Notification toast failures are logged but don't fail the sync; metadata write failures are best-effort

Related audit: 監査レポート §1 ギャップ表 / §8 G-05

https://claude.ai/code/session_01Y6XsoFftu9e5WSS4Zd2TFB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * GitHub通知機能を追加：サイドバーの通知ボタンとドロップダウンで一覧表示。
  * 未読バッジ（99+表示）、通知クリックで外部表示後に楽観的に既読化。
  * 初回自動取得・手動更新、エラー／空状態表示、相対時刻表示（日本語）。
  * OSネイティブのトースト通知（上限あり）とバックグラウンド同期（差分取得・レート制限対応）。
  * フロントエンド向けコマンドと通知更新イベントを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->