### PR TITLE
Wire up activity timeline UI on home (Issue #187)

### DIFF
--- a/src-tauri/src/commands/activity.rs
+++ b/src-tauri/src/commands/activity.rs
@@ -1,0 +1,498 @@
+//! GitHub activity timeline commands for Tauri
+//!
+//! Surfaces the authenticated user's recent GitHub events
+//! (`GET /users/{username}/events`) as a normalised feed for the home
+//! activity timeline. The endpoint already caps the response at the
+//! last 90 days / 300 events; we just paginate, normalise, and cache.
+//!
+//! Related Issue: GitHub Issue #187 - GitHub連携 アクティビティ・タイムライン UI 配線
+
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tauri::{command, AppHandle, State};
+
+use super::auth::AppState;
+use super::github::CachedResponse;
+use crate::auth::{handle_unauthorized, reasons};
+use crate::database::{cache_durations, cache_types};
+use crate::github::client::GitHubError;
+use crate::github::types::ActivityEvent;
+use crate::github::GitHubClient;
+
+/// Default page size matches GitHub's documented maximum for the events
+/// endpoint. The 90-day / 300-event cap is enforced by GitHub itself, so
+/// asking for 100 keeps round-trip count to a minimum without going over.
+const DEFAULT_PER_PAGE: i32 = 100;
+
+/// Normalised activity feed row. Pre-extracts the fields the React UI
+/// renders so the frontend does not have to walk GitHub's polymorphic
+/// `payload` for every event type.
+///
+/// Anything the UI does not need (full commit list, full review body, etc.)
+/// is intentionally dropped to keep the cached payload small.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ActivityFeedItem {
+    /// GitHub event id — stable, used as React key.
+    pub id: String,
+    /// `PushEvent` / `PullRequestEvent` / `IssuesEvent` / etc. Forwarded
+    /// verbatim so the UI can decide on icon + copy per type.
+    pub event_type: String,
+    /// ISO8601.
+    pub created_at: String,
+    /// `owner/repo`.
+    pub repo_name: String,
+    /// `https://github.com/{owner}/{repo}` — pre-built so the UI does not
+    /// have to translate the `api.github.com` URL the API returns.
+    pub repo_url: String,
+    /// `opened` / `closed` / `started` / `created` / etc. when the event
+    /// type carries an `action`.
+    pub action: Option<String>,
+    /// PR / issue / release title, or for Create/Delete events the ref name.
+    pub title: Option<String>,
+    /// Browser URL of the artefact involved (PR, issue, release, comment).
+    /// Falls back to `repo_url` on the frontend when absent.
+    pub target_url: Option<String>,
+    /// PR or issue number, when applicable.
+    pub number: Option<i32>,
+    /// Branch / tag name for `PushEvent`, `CreateEvent`, `DeleteEvent`.
+    pub ref_name: Option<String>,
+    /// `branch` / `tag` / `repository` for `CreateEvent` / `DeleteEvent`.
+    pub ref_type: Option<String>,
+    /// Number of commits in a `PushEvent`.
+    pub commits_count: Option<i32>,
+}
+
+/// Aggregated payload returned by `get_activity_feed_with_cache`.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ActivityFeed {
+    pub items: Vec<ActivityFeedItem>,
+}
+
+/// Network-eligible error variants (worth a cache fallback).
+fn is_network_or_rate_limit_error(error: &GitHubError) -> bool {
+    matches!(
+        error,
+        GitHubError::HttpRequest(_) | GitHubError::RateLimited(_)
+    )
+}
+
+/// Map a raw `ActivityEvent` (the API shape) into the flat row the UI
+/// renders. Pure / stateless — exposed for unit tests.
+///
+/// The events endpoint sets `repo.url` to the api.github.com URL, so we
+/// always synthesise the browser URL from `owner/repo` instead.
+pub fn normalize_event(event: &ActivityEvent) -> ActivityFeedItem {
+    let payload = &event.payload;
+    let repo_url = format!("https://github.com/{}", event.repo.name);
+
+    let action = payload
+        .get("action")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+
+    let mut title: Option<String> = None;
+    let mut target_url: Option<String> = None;
+    let mut number: Option<i32> = None;
+    let mut ref_name: Option<String> = None;
+    let mut ref_type: Option<String> = None;
+    let mut commits_count: Option<i32> = None;
+
+    match event.event_type.as_str() {
+        "PushEvent" => {
+            ref_name = payload
+                .get("ref")
+                .and_then(Value::as_str)
+                .map(str::to_string);
+            commits_count = payload
+                .get("size")
+                .and_then(Value::as_i64)
+                .map(|v| v as i32);
+            target_url = Some(repo_url.clone());
+        }
+        "PullRequestEvent" | "PullRequestReviewEvent" | "PullRequestReviewCommentEvent" => {
+            if let Some(pr) = payload.get("pull_request") {
+                title = pr.get("title").and_then(Value::as_str).map(str::to_string);
+                target_url = pr
+                    .get("html_url")
+                    .and_then(Value::as_str)
+                    .map(str::to_string);
+                number = pr.get("number").and_then(Value::as_i64).map(|v| v as i32);
+            }
+            // Fall back to the top-level `number` when available
+            // (PullRequestEvent has it).
+            if number.is_none() {
+                number = payload
+                    .get("number")
+                    .and_then(Value::as_i64)
+                    .map(|v| v as i32);
+            }
+        }
+        "IssuesEvent" | "IssueCommentEvent" => {
+            if let Some(issue) = payload.get("issue") {
+                title = issue
+                    .get("title")
+                    .and_then(Value::as_str)
+                    .map(str::to_string);
+                target_url = issue
+                    .get("html_url")
+                    .and_then(Value::as_str)
+                    .map(str::to_string);
+                number = issue
+                    .get("number")
+                    .and_then(Value::as_i64)
+                    .map(|v| v as i32);
+            }
+            // For `IssueCommentEvent`, prefer the comment's html_url so the
+            // click drops the user at the comment anchor.
+            if event.event_type == "IssueCommentEvent" {
+                if let Some(comment_url) = payload
+                    .get("comment")
+                    .and_then(|c| c.get("html_url"))
+                    .and_then(Value::as_str)
+                {
+                    target_url = Some(comment_url.to_string());
+                }
+            }
+        }
+        "ReleaseEvent" => {
+            if let Some(release) = payload.get("release") {
+                title = release
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .filter(|s| !s.is_empty())
+                    .or_else(|| release.get("tag_name").and_then(Value::as_str))
+                    .map(str::to_string);
+                target_url = release
+                    .get("html_url")
+                    .and_then(Value::as_str)
+                    .map(str::to_string);
+            }
+        }
+        "CreateEvent" | "DeleteEvent" => {
+            ref_name = payload
+                .get("ref")
+                .and_then(Value::as_str)
+                .map(str::to_string);
+            ref_type = payload
+                .get("ref_type")
+                .and_then(Value::as_str)
+                .map(str::to_string);
+            target_url = Some(repo_url.clone());
+        }
+        "ForkEvent" => {
+            if let Some(forkee) = payload.get("forkee") {
+                title = forkee
+                    .get("full_name")
+                    .and_then(Value::as_str)
+                    .map(str::to_string);
+                target_url = forkee
+                    .get("html_url")
+                    .and_then(Value::as_str)
+                    .map(str::to_string);
+            }
+        }
+        "WatchEvent" | "PublicEvent" | "MemberEvent" => {
+            target_url = Some(repo_url.clone());
+        }
+        _ => {
+            // Unknown event types still render — the UI shows a generic
+            // "activity in {repo}" line. Set a safe target.
+            target_url = Some(repo_url.clone());
+        }
+    }
+
+    ActivityFeedItem {
+        id: event.id.clone(),
+        event_type: event.event_type.clone(),
+        created_at: event.created_at.to_rfc3339(),
+        repo_name: event.repo.name.clone(),
+        repo_url,
+        action,
+        title,
+        target_url,
+        number,
+        ref_name,
+        ref_type,
+        commits_count,
+    }
+}
+
+/// Fetch the authenticated user's recent GitHub events with a short
+/// SQLite cache fallback.
+///
+/// Behaviour mirrors `get_my_pr_progress_with_cache`:
+/// - Success → cache + return `from_cache: false`.
+/// - Network / rate-limit error → fall back to last cached payload (any age)
+///   if available, else surface the error.
+/// - 401 → trigger the central auth-expired flow; do not fall back to cache.
+///
+/// REST budget: 5000 req/hr. With a 5-minute TTL and one user, even
+/// pathological refresh loops stay nowhere near the limit.
+#[command]
+pub async fn get_activity_feed_with_cache(
+    app: AppHandle,
+    state: State<'_, AppState>,
+) -> Result<CachedResponse<ActivityFeed>, String> {
+    let token = state
+        .token_manager
+        .get_access_token()
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let user = state
+        .token_manager
+        .get_current_user()
+        .await
+        .map_err(|e| e.to_string())?
+        .ok_or("Not logged in")?;
+
+    let client = GitHubClient::new(token);
+
+    match client
+        .get_user_events(&user.username, DEFAULT_PER_PAGE, 1)
+        .await
+    {
+        Ok(events) => {
+            let items: Vec<ActivityFeedItem> = events.iter().map(normalize_event).collect();
+            let payload = ActivityFeed { items };
+
+            let payload_json = serde_json::to_string(&payload)
+                .map_err(|e| format!("Failed to serialize activity feed: {}", e))?;
+
+            let now = Utc::now();
+            let expires_at = now + chrono::Duration::minutes(cache_durations::ACTIVITY_FEED);
+
+            // Best-effort cache write — a failure here shouldn't block the
+            // response. Mirrors the other `*_with_cache` commands.
+            let _ = state
+                .db
+                .save_cache(
+                    user.id,
+                    cache_types::ACTIVITY_FEED,
+                    &payload_json,
+                    expires_at,
+                )
+                .await;
+
+            Ok(CachedResponse {
+                data: payload,
+                from_cache: false,
+                cached_at: Some(now.to_rfc3339()),
+                expires_at: Some(expires_at.to_rfc3339()),
+            })
+        }
+        Err(GitHubError::Unauthorized) => {
+            handle_unauthorized(&app, state.inner(), reasons::GITHUB_UNAUTHORIZED).await;
+            Err(GitHubError::Unauthorized.to_string())
+        }
+        Err(api_error) => {
+            if !is_network_or_rate_limit_error(&api_error) {
+                return Err(format!("GitHub API error: {}", api_error));
+            }
+
+            eprintln!(
+                "Activity feed fetch failed, attempting cache fallback: {}",
+                api_error
+            );
+
+            let cache_result = state
+                .db
+                .get_any_cache(user.id, cache_types::ACTIVITY_FEED)
+                .await
+                .map_err(|e| format!("Failed to read activity_feed cache: {}", e))?;
+
+            match cache_result {
+                Some((data_json, cached_at, expires_at)) => {
+                    let payload: ActivityFeed = serde_json::from_str(&data_json)
+                        .map_err(|e| format!("Failed to parse cached data: {}", e))?;
+                    Ok(CachedResponse {
+                        data: payload,
+                        from_cache: true,
+                        cached_at: Some(cached_at),
+                        expires_at: Some(expires_at),
+                    })
+                }
+                None => Err(format!(
+                    "GitHub APIにアクセスできず、キャッシュもありません: {}",
+                    api_error
+                )),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::github::types::EventRepo;
+    use chrono::TimeZone;
+    use serde_json::json;
+
+    fn make_event(event_type: &str, payload: Value) -> ActivityEvent {
+        ActivityEvent {
+            id: "12345".into(),
+            event_type: event_type.into(),
+            created_at: Utc.with_ymd_and_hms(2026, 4, 1, 12, 0, 0).unwrap(),
+            repo: EventRepo {
+                id: 1,
+                name: "octo/test".into(),
+            },
+            payload,
+        }
+    }
+
+    #[test]
+    fn normalize_push_event_extracts_ref_and_size() {
+        let event = make_event(
+            "PushEvent",
+            json!({
+                "ref": "refs/heads/main",
+                "size": 3,
+                "commits": [],
+            }),
+        );
+        let item = normalize_event(&event);
+
+        assert_eq!(item.event_type, "PushEvent");
+        assert_eq!(item.repo_name, "octo/test");
+        assert_eq!(item.repo_url, "https://github.com/octo/test");
+        assert_eq!(item.ref_name.as_deref(), Some("refs/heads/main"));
+        assert_eq!(item.commits_count, Some(3));
+        assert_eq!(
+            item.target_url.as_deref(),
+            Some("https://github.com/octo/test")
+        );
+        assert!(item.title.is_none());
+    }
+
+    #[test]
+    fn normalize_pull_request_event_extracts_pr_title_and_url() {
+        let event = make_event(
+            "PullRequestEvent",
+            json!({
+                "action": "opened",
+                "number": 42,
+                "pull_request": {
+                    "title": "Fix bug",
+                    "html_url": "https://github.com/octo/test/pull/42",
+                    "number": 42,
+                },
+            }),
+        );
+        let item = normalize_event(&event);
+
+        assert_eq!(item.action.as_deref(), Some("opened"));
+        assert_eq!(item.title.as_deref(), Some("Fix bug"));
+        assert_eq!(
+            item.target_url.as_deref(),
+            Some("https://github.com/octo/test/pull/42")
+        );
+        assert_eq!(item.number, Some(42));
+    }
+
+    #[test]
+    fn normalize_issues_event_extracts_issue_fields() {
+        let event = make_event(
+            "IssuesEvent",
+            json!({
+                "action": "closed",
+                "issue": {
+                    "title": "Crash on launch",
+                    "html_url": "https://github.com/octo/test/issues/7",
+                    "number": 7,
+                },
+            }),
+        );
+        let item = normalize_event(&event);
+
+        assert_eq!(item.action.as_deref(), Some("closed"));
+        assert_eq!(item.title.as_deref(), Some("Crash on launch"));
+        assert_eq!(
+            item.target_url.as_deref(),
+            Some("https://github.com/octo/test/issues/7")
+        );
+        assert_eq!(item.number, Some(7));
+    }
+
+    #[test]
+    fn normalize_issue_comment_event_prefers_comment_url() {
+        let event = make_event(
+            "IssueCommentEvent",
+            json!({
+                "action": "created",
+                "issue": {
+                    "title": "Feature request",
+                    "html_url": "https://github.com/octo/test/issues/3",
+                    "number": 3,
+                },
+                "comment": {
+                    "html_url": "https://github.com/octo/test/issues/3#issuecomment-99",
+                },
+            }),
+        );
+        let item = normalize_event(&event);
+
+        // Title still comes from the issue, but the URL drops at the comment.
+        assert_eq!(item.title.as_deref(), Some("Feature request"));
+        assert_eq!(
+            item.target_url.as_deref(),
+            Some("https://github.com/octo/test/issues/3#issuecomment-99")
+        );
+    }
+
+    #[test]
+    fn normalize_release_event_falls_back_to_tag_when_name_missing() {
+        let event = make_event(
+            "ReleaseEvent",
+            json!({
+                "action": "published",
+                "release": {
+                    "name": "",
+                    "tag_name": "v1.2.3",
+                    "html_url": "https://github.com/octo/test/releases/tag/v1.2.3",
+                },
+            }),
+        );
+        let item = normalize_event(&event);
+
+        assert_eq!(item.title.as_deref(), Some("v1.2.3"));
+        assert_eq!(
+            item.target_url.as_deref(),
+            Some("https://github.com/octo/test/releases/tag/v1.2.3")
+        );
+    }
+
+    #[test]
+    fn normalize_create_event_extracts_ref_type_and_name() {
+        let event = make_event(
+            "CreateEvent",
+            json!({
+                "ref": "feature/x",
+                "ref_type": "branch",
+            }),
+        );
+        let item = normalize_event(&event);
+
+        assert_eq!(item.ref_name.as_deref(), Some("feature/x"));
+        assert_eq!(item.ref_type.as_deref(), Some("branch"));
+        assert_eq!(
+            item.target_url.as_deref(),
+            Some("https://github.com/octo/test")
+        );
+    }
+
+    #[test]
+    fn normalize_unknown_event_type_still_yields_a_row_with_repo_target() {
+        let event = make_event("FutureEventType", json!({}));
+        let item = normalize_event(&event);
+
+        assert_eq!(item.event_type, "FutureEventType");
+        assert_eq!(
+            item.target_url.as_deref(),
+            Some("https://github.com/octo/test")
+        );
+    }
+}

--- a/src-tauri/src/commands/activity.rs
+++ b/src-tauri/src/commands/activity.rs
@@ -25,6 +25,11 @@ use crate::github::GitHubClient;
 /// asking for 100 keeps round-trip count to a minimum without going over.
 const DEFAULT_PER_PAGE: i32 = 100;
 
+/// Maximum number of pages to walk. GitHub caps the events endpoint at
+/// 300 events / 90 days, so 3 pages × 100 events covers the full range.
+/// We break early when a page comes back short.
+const MAX_EVENT_PAGES: i32 = 3;
+
 /// Normalised activity feed row. Pre-extracts the fields the React UI
 /// renders so the frontend does not have to walk GitHub's polymorphic
 /// `payload` for every event type.
@@ -120,6 +125,18 @@ pub fn normalize_event(event: &ActivityEvent) -> ActivityFeedItem {
                     .and_then(Value::as_str)
                     .map(str::to_string);
                 number = pr.get("number").and_then(Value::as_i64).map(|v| v as i32);
+            }
+            // Prefer the specific review / review-comment URL so the click
+            // drops the user at the right anchor — mirrors `IssueCommentEvent`.
+            let specific_url = match event.event_type.as_str() {
+                "PullRequestReviewEvent" => payload.get("review"),
+                "PullRequestReviewCommentEvent" => payload.get("comment"),
+                _ => None,
+            }
+            .and_then(|o| o.get("html_url"))
+            .and_then(Value::as_str);
+            if let Some(url) = specific_url {
+                target_url = Some(url.to_string());
             }
             // Fall back to the top-level `number` when available
             // (PullRequestEvent has it).
@@ -251,10 +268,27 @@ pub async fn get_activity_feed_with_cache(
 
     let client = GitHubClient::new(token);
 
-    match client
-        .get_user_events(&user.username, DEFAULT_PER_PAGE, 1)
-        .await
-    {
+    // GitHub serves the events endpoint as up to 3 × 100-event pages —
+    // we walk pages until either the cap is hit or a short page tells us
+    // we've drained the user's recent activity. Errors short-circuit the
+    // whole fetch; the cache fallback below catches transient failures.
+    let events_result: Result<Vec<ActivityEvent>, GitHubError> = async {
+        let mut all_events: Vec<ActivityEvent> = Vec::new();
+        for page in 1..=MAX_EVENT_PAGES {
+            let mut page_events = client
+                .get_user_events(&user.username, DEFAULT_PER_PAGE, page)
+                .await?;
+            let page_len = page_events.len();
+            all_events.append(&mut page_events);
+            if page_len < DEFAULT_PER_PAGE as usize {
+                break;
+            }
+        }
+        Ok(all_events)
+    }
+    .await;
+
+    match events_result {
         Ok(events) => {
             let items: Vec<ActivityFeedItem> = events.iter().map(normalize_event).collect();
             let payload = ActivityFeed { items };
@@ -440,6 +474,57 @@ mod tests {
         assert_eq!(
             item.target_url.as_deref(),
             Some("https://github.com/octo/test/issues/3#issuecomment-99")
+        );
+    }
+
+    #[test]
+    fn normalize_pull_request_review_event_prefers_review_url() {
+        let event = make_event(
+            "PullRequestReviewEvent",
+            json!({
+                "action": "submitted",
+                "pull_request": {
+                    "title": "Fix bug",
+                    "html_url": "https://github.com/octo/test/pull/42",
+                    "number": 42,
+                },
+                "review": {
+                    "html_url": "https://github.com/octo/test/pull/42#pullrequestreview-7",
+                },
+            }),
+        );
+        let item = normalize_event(&event);
+
+        assert_eq!(
+            item.target_url.as_deref(),
+            Some("https://github.com/octo/test/pull/42#pullrequestreview-7")
+        );
+        assert_eq!(item.title.as_deref(), Some("Fix bug"));
+        assert_eq!(item.number, Some(42));
+    }
+
+    #[test]
+    fn normalize_pull_request_review_comment_event_prefers_comment_url() {
+        let event = make_event(
+            "PullRequestReviewCommentEvent",
+            json!({
+                "action": "created",
+                "pull_request": {
+                    "title": "Refactor",
+                    "html_url": "https://github.com/octo/test/pull/42",
+                    "number": 42,
+                },
+                "comment": {
+                    "html_url":
+                        "https://github.com/octo/test/pull/42#discussion_r1",
+                },
+            }),
+        );
+        let item = normalize_event(&event);
+
+        assert_eq!(
+            item.target_url.as_deref(),
+            Some("https://github.com/octo/test/pull/42#discussion_r1")
         );
     }
 

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod activity;
 pub mod auth;
 pub mod challenge;
 pub mod gamification;
@@ -7,6 +8,7 @@ pub mod notifications;
 pub mod scheduler;
 pub mod settings;
 
+pub use activity::*;
 pub use auth::*;
 pub use challenge::*;
 pub use gamification::*;

--- a/src-tauri/src/database/models/cache.rs
+++ b/src-tauri/src/database/models/cache.rs
@@ -43,6 +43,9 @@ pub mod cache_types {
     /// GitHub Notifications list (cached so a 304 response can still serve
     /// the UI without forcing a re-fetch). See Issue #186.
     pub const GITHUB_NOTIFICATIONS: &str = "github_notifications";
+    /// Recent activity feed payload backing the home timeline
+    /// (`/users/{u}/events`). See Issue #187.
+    pub const ACTIVITY_FEED: &str = "activity_feed";
 }
 
 /// Default cache durations in minutes
@@ -74,4 +77,8 @@ pub mod cache_durations {
     /// Notifications data isn't sensitive enough to justify a short TTL,
     /// and the row is overwritten on every successful sync.
     pub const GITHUB_NOTIFICATIONS: i64 = 60 * 24 * 365;
+    /// Activity timeline cache duration (5 minutes).
+    /// REST budget is 5000 req/hr — even with revalidate-on-focus the
+    /// 5-minute TTL keeps refresh load negligible.
+    pub const ACTIVITY_FEED: i64 = 5;
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -28,6 +28,8 @@ use commands::{
     delete_project,
     export_data,
     get_active_challenges,
+    // Activity timeline command (Issue #187)
+    get_activity_feed_with_cache,
     get_all_challenges,
     get_app_info,
     get_auth_state,
@@ -249,6 +251,8 @@ pub fn run() {
             // GitHub Notifications commands (Issue #186)
             get_notifications,
             mark_notification_read,
+            // Activity timeline command (Issue #187)
+            get_activity_feed_with_cache,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/components/features/activity/ActivityTimeline.tsx
+++ b/src/components/features/activity/ActivityTimeline.tsx
@@ -153,7 +153,9 @@ function formatRelativeTime(iso: string): string {
   const date = new Date(iso);
   if (Number.isNaN(date.getTime())) return iso;
 
-  const diffMs = Date.now() - date.getTime();
+  // Clamp negative deltas to 0 so client clock skew (event timestamp from
+  // GitHub vs. local `Date.now()`) never produces strings like "-1秒前".
+  const diffMs = Math.max(0, Date.now() - date.getTime());
   const diffSec = Math.floor(diffMs / 1000);
   if (diffSec < 60) return `${diffSec}秒前`;
   const diffMin = Math.floor(diffSec / 60);
@@ -165,8 +167,29 @@ function formatRelativeTime(iso: string): string {
   return date.toLocaleDateString('ja-JP');
 }
 
+/**
+ * Whitelist GitHub-only `https` URLs before handing them to the system
+ * browser. The activity feed payload is server-controlled, but defense in
+ * depth: if a future event type leaks a non-GitHub URL we'd rather no-op
+ * than open it.
+ */
+function isSafeGitHubUrl(raw: string): boolean {
+  try {
+    const u = new URL(raw);
+    if (u.protocol !== 'https:') return false;
+    const host = u.hostname.toLowerCase();
+    return host === 'github.com' || host.endsWith('.github.com');
+  } catch {
+    return false;
+  }
+}
+
 const handleOpen = async (url: string | null) => {
   if (!url) return;
+  if (!isSafeGitHubUrl(url)) {
+    console.warn('Refusing to open non-GitHub URL from activity feed:', url);
+    return;
+  }
   try {
     await settingsApi.openExternalUrl(url);
   } catch (e) {

--- a/src/components/features/activity/ActivityTimeline.tsx
+++ b/src/components/features/activity/ActivityTimeline.tsx
@@ -1,0 +1,310 @@
+/**
+ * Activity Timeline Component
+ *
+ * Renders the authenticated user's recent GitHub activity in a scrollable
+ * timeline. Each row links out to the relevant artefact (PR, issue,
+ * release, repo) via the system browser.
+ *
+ * Related Documentation:
+ *   - Issue: https://github.com/otomatty/development-tools/issues/187
+ */
+
+import React, { useMemo } from 'react';
+import { Icon } from '@/components/icons';
+import { settings as settingsApi } from '@/lib/tauri/commands';
+import type { ActivityFeedItem } from '@/types';
+
+interface ActivityTimelineProps {
+  items: ActivityFeedItem[] | null;
+  isLoading?: boolean;
+  isRevalidating?: boolean;
+  error?: Error | null;
+  onRetry?: () => void;
+}
+
+/**
+ * Map an event type / action pair to (icon name, accent class).
+ * Uses the same lucide names already exposed by the shared `Icon` component.
+ */
+function getEventVisual(
+  eventType: string,
+  action: string | null,
+): { icon: string; tone: string } {
+  switch (eventType) {
+    case 'PushEvent':
+      return { icon: 'git-branch', tone: 'text-gm-accent-cyan' };
+    case 'PullRequestEvent':
+      if (action === 'closed') return { icon: 'git-merge', tone: 'text-gm-accent-purple' };
+      return { icon: 'git-pull-request', tone: 'text-gm-accent-purple' };
+    case 'PullRequestReviewEvent':
+    case 'PullRequestReviewCommentEvent':
+      return { icon: 'check-square', tone: 'text-gm-accent-pink' };
+    case 'IssuesEvent':
+    case 'IssueCommentEvent':
+      return { icon: 'alert-circle', tone: 'text-gm-success' };
+    case 'ReleaseEvent':
+      return { icon: 'star', tone: 'text-badge-gold' };
+    case 'ForkEvent':
+      return { icon: 'git-branch', tone: 'text-gm-accent-cyan' };
+    case 'WatchEvent':
+      return { icon: 'star', tone: 'text-badge-gold' };
+    case 'CreateEvent':
+      return { icon: 'plus', tone: 'text-gm-success' };
+    case 'DeleteEvent':
+      return { icon: 'trash', tone: 'text-gm-error' };
+    default:
+      return { icon: 'github', tone: 'text-dt-text-sub' };
+  }
+}
+
+/**
+ * Strip the `refs/heads/` / `refs/tags/` prefix that the events API returns.
+ * Falls back to the original string when the prefix is unknown so we never
+ * silently drop information.
+ */
+function shortRef(ref: string): string {
+  if (ref.startsWith('refs/heads/')) return ref.slice('refs/heads/'.length);
+  if (ref.startsWith('refs/tags/')) return ref.slice('refs/tags/'.length);
+  return ref;
+}
+
+/**
+ * Build the human-readable description for a single activity row.
+ *
+ * Returns plain text — the JSX wraps it with the title element, so this
+ * stays easy to unit-test.
+ */
+export function describeEvent(item: ActivityFeedItem): string {
+  switch (item.eventType) {
+    case 'PushEvent': {
+      const branch = item.refName ? shortRef(item.refName) : 'unknown';
+      const count = item.commitsCount ?? 0;
+      if (count === 1) return `${branch} に 1 件のコミットをプッシュ`;
+      return `${branch} に ${count} 件のコミットをプッシュ`;
+    }
+    case 'PullRequestEvent': {
+      const verb = (() => {
+        switch (item.action) {
+          case 'opened':
+            return 'オープン';
+          case 'closed':
+            return 'クローズ';
+          case 'reopened':
+            return '再オープン';
+          case 'edited':
+            return '編集';
+          default:
+            return item.action ?? '更新';
+        }
+      })();
+      return `Pull Request を${verb}`;
+    }
+    case 'PullRequestReviewEvent':
+      return 'Pull Request をレビュー';
+    case 'PullRequestReviewCommentEvent':
+      return 'レビューコメントを投稿';
+    case 'IssuesEvent': {
+      const verb = (() => {
+        switch (item.action) {
+          case 'opened':
+            return 'オープン';
+          case 'closed':
+            return 'クローズ';
+          case 'reopened':
+            return '再オープン';
+          default:
+            return item.action ?? '更新';
+        }
+      })();
+      return `Issue を${verb}`;
+    }
+    case 'IssueCommentEvent':
+      return 'Issue にコメント';
+    case 'ReleaseEvent':
+      return 'リリースを公開';
+    case 'CreateEvent': {
+      const what = item.refType ?? 'something';
+      return `${what} を作成${item.refName ? `: ${shortRef(item.refName)}` : ''}`;
+    }
+    case 'DeleteEvent': {
+      const what = item.refType ?? 'something';
+      return `${what} を削除${item.refName ? `: ${shortRef(item.refName)}` : ''}`;
+    }
+    case 'ForkEvent':
+      return 'リポジトリをフォーク';
+    case 'WatchEvent':
+      return 'リポジトリにスターを付けた';
+    case 'PublicEvent':
+      return 'リポジトリを公開';
+    case 'MemberEvent':
+      return 'コラボレーターの更新';
+    default:
+      return item.eventType;
+  }
+}
+
+/**
+ * "5分前" / "2時間前" / fallback to localized date.
+ *
+ * Identical contract to the formatter in NotificationsDropdown — kept local
+ * to avoid creating a tiny shared util before there's a third caller.
+ */
+function formatRelativeTime(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+
+  const diffMs = Date.now() - date.getTime();
+  const diffSec = Math.floor(diffMs / 1000);
+  if (diffSec < 60) return `${diffSec}秒前`;
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) return `${diffMin}分前`;
+  const diffHour = Math.floor(diffMin / 60);
+  if (diffHour < 24) return `${diffHour}時間前`;
+  const diffDay = Math.floor(diffHour / 24);
+  if (diffDay < 7) return `${diffDay}日前`;
+  return date.toLocaleDateString('ja-JP');
+}
+
+const handleOpen = async (url: string | null) => {
+  if (!url) return;
+  try {
+    await settingsApi.openExternalUrl(url);
+  } catch (e) {
+    console.error('Failed to open URL', e);
+  }
+};
+
+const TimelineSkeleton: React.FC = () => (
+  <ul className="divide-y divide-slate-800 animate-pulse">
+    {Array.from({ length: 5 }).map((_, i) => (
+      <li key={i} className="flex items-start gap-3 px-4 py-3">
+        <div className="w-5 h-5 bg-slate-700 rounded-full mt-1" />
+        <div className="flex-1 space-y-2">
+          <div className="h-4 w-2/3 bg-slate-700 rounded" />
+          <div className="h-3 w-1/2 bg-slate-700 rounded" />
+        </div>
+      </li>
+    ))}
+  </ul>
+);
+
+interface ActivityRowProps {
+  item: ActivityFeedItem;
+}
+
+const ActivityRow: React.FC<ActivityRowProps> = ({ item }) => {
+  const visual = getEventVisual(item.eventType, item.action);
+  const description = describeEvent(item);
+  const target = item.targetUrl ?? item.repoUrl;
+
+  return (
+    <li className="border-b border-slate-800 last:border-b-0">
+      <div className="flex items-start gap-3 px-4 py-3 hover:bg-slate-800/40 transition-colors">
+        <Icon
+          name={visual.icon}
+          className={`w-5 h-5 mt-0.5 flex-shrink-0 ${visual.tone}`}
+        />
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-0.5 text-xs">
+            <button
+              type="button"
+              onClick={() => void handleOpen(item.repoUrl)}
+              className="text-slate-400 hover:text-gm-accent-cyan font-medium truncate transition-colors"
+            >
+              {item.repoName}
+            </button>
+            <span className="text-slate-600">·</span>
+            <span className="text-slate-500" title={item.createdAt}>
+              {formatRelativeTime(item.createdAt)}
+            </span>
+          </div>
+          <div className="text-sm text-dt-text-sub">{description}</div>
+          {item.title && (
+            <button
+              type="button"
+              onClick={() => void handleOpen(target)}
+              className="block w-full text-left mt-0.5 text-sm text-dt-text hover:text-gm-accent-cyan truncate transition-colors"
+            >
+              {item.number !== null ? (
+                <span className="text-slate-500 mr-1">#{item.number}</span>
+              ) : null}
+              {item.title}
+            </button>
+          )}
+        </div>
+      </div>
+    </li>
+  );
+};
+
+export const ActivityTimeline: React.FC<ActivityTimelineProps> = ({
+  items,
+  isLoading = false,
+  isRevalidating = false,
+  error,
+  onRetry,
+}) => {
+  // Defensive de-dupe: GitHub occasionally repeats event ids across pages
+  // when activity straddles a refresh window. Render each id only once.
+  const dedupedItems = useMemo(() => {
+    if (!items) return null;
+    const seen = new Set<string>();
+    return items.filter(item => {
+      if (seen.has(item.id)) return false;
+      seen.add(item.id);
+      return true;
+    });
+  }, [items]);
+
+  return (
+    <div className="bg-gm-bg-card/80 backdrop-blur-sm rounded-2xl border border-gm-accent-purple/20 overflow-hidden">
+      <div className="flex items-center justify-between px-6 py-4 border-b border-slate-800">
+        <h3 className="text-xl font-gaming font-bold text-gm-accent-purple flex items-center gap-2">
+          <Icon name="clock" className="w-5 h-5" />
+          最近のアクティビティ
+        </h3>
+        {isRevalidating && (
+          <span className="text-xs text-slate-500 flex items-center gap-1">
+            <Icon name="refresh-cw" className="w-3 h-3 animate-spin" />
+            更新中
+          </span>
+        )}
+      </div>
+
+      <div className="max-h-[480px] overflow-y-auto">
+        {error && (
+          <div className="px-6 py-4 text-sm text-red-400 bg-red-500/10 border-b border-red-500/20 flex items-center justify-between">
+            <span>アクティビティを取得できませんでした: {error.message}</span>
+            {onRetry && (
+              <button
+                type="button"
+                onClick={onRetry}
+                className="text-xs px-2 py-1 rounded bg-red-500/20 hover:bg-red-500/30 transition-colors"
+              >
+                再試行
+              </button>
+            )}
+          </div>
+        )}
+
+        {isLoading && !dedupedItems && <TimelineSkeleton />}
+
+        {dedupedItems && dedupedItems.length === 0 && !error && (
+          <div className="px-6 py-12 text-center text-sm text-slate-400">
+            最近のアクティビティはありません
+          </div>
+        )}
+
+        {dedupedItems && dedupedItems.length > 0 && (
+          <ul role="list" className="divide-y divide-slate-800">
+            {dedupedItems.map(item => (
+              <ActivityRow key={item.id} item={item} />
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ActivityTimeline;

--- a/src/components/features/activity/index.ts
+++ b/src/components/features/activity/index.ts
@@ -1,0 +1,1 @@
+export { ActivityTimeline, describeEvent } from './ActivityTimeline';

--- a/src/lib/tauri/commands.ts
+++ b/src/lib/tauri/commands.ts
@@ -49,6 +49,7 @@ import type {
   CacheStats,
   SchedulerStatus,
   NotificationsPayload,
+  ActivityFeed,
 } from '@/types';
 
 // ============================================================================
@@ -469,6 +470,18 @@ export const github = {
    */
   getUserStatsWithCache: (): Promise<CachedResponse<UserStats>> =>
     invoke<CachedResponse<UserStats>>('get_user_stats_with_cache'),
+
+  /**
+   * Recent activity timeline backed by GitHub `/users/{u}/events`.
+   *
+   * GitHub's endpoint already caps the response at the last 90 days /
+   * 300 events; the backend normalises each event into a flat row and
+   * applies a 5-minute SQLite cache.
+   *
+   * Related: Issue #187
+   */
+  getActivityFeedWithCache: (): Promise<CachedResponse<ActivityFeed>> =>
+    invoke<CachedResponse<ActivityFeed>>('get_activity_feed_with_cache'),
 };
 
 // ============================================================================

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -95,10 +95,12 @@ export const Home = () => {
 
   const githubRevalidate = githubStatsQuery.revalidate;
   const userRevalidate = userStatsQuery.revalidate;
+  const activityRevalidate = activityQuery.revalidate;
   const handleRetry = useCallback(() => {
     void githubRevalidate();
     void userRevalidate();
-  }, [githubRevalidate, userRevalidate]);
+    void activityRevalidate();
+  }, [githubRevalidate, userRevalidate, activityRevalidate]);
 
   // Initial loading: wait for auth restore and the first data fetch when
   // logged in. Cached data short-circuits this — once any cached value is
@@ -119,16 +121,30 @@ export const Home = () => {
 
   const isLoading = authLoading || initialDataLoading;
 
-  const fromCache = githubStatsQuery.fromCache || userStatsQuery.fromCache;
-  const hasError = githubStatsQuery.error !== null || userStatsQuery.error !== null;
+  const fromCache =
+    githubStatsQuery.fromCache ||
+    userStatsQuery.fromCache ||
+    activityQuery.fromCache;
+  const hasError =
+    githubStatsQuery.error !== null ||
+    userStatsQuery.error !== null ||
+    activityQuery.error !== null;
   const hasData =
-    githubStatsQuery.data !== null || userStatsQuery.data !== null;
+    githubStatsQuery.data !== null ||
+    userStatsQuery.data !== null ||
+    activityQuery.data !== null;
   const isRevalidating =
-    githubStatsQuery.isRevalidating || userStatsQuery.isRevalidating;
-  // Surface the older of the two cache timestamps so the user sees the
-  // worst-case staleness rather than the freshest sub-component's.
+    githubStatsQuery.isRevalidating ||
+    userStatsQuery.isRevalidating ||
+    activityQuery.isRevalidating;
+  // Surface the older of the cache timestamps across all sources so the
+  // user sees the worst-case staleness rather than the freshest one.
   const bannerCachedAt =
-    [githubStatsQuery.cachedAt, userStatsQuery.cachedAt]
+    [
+      githubStatsQuery.cachedAt,
+      userStatsQuery.cachedAt,
+      activityQuery.cachedAt,
+    ]
       .filter((value): value is string => value !== null)
       .sort()[0] ?? null;
 

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -15,6 +15,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { LoginCard } from '../../components/features/auth';
+import { ActivityTimeline } from '../../components/features/activity';
 import { DashboardContent, XpNotification } from '../../components/features/gamification';
 import { useAuth } from '../../stores/authStore';
 import { useCachedFetch } from '../../hooks/useCachedFetch';
@@ -24,6 +25,9 @@ import { CacheStatusBanner } from './CacheStatusBanner';
 
 const STATS_STALE_TIME_MS = 30 * 60 * 1000; // 30 minutes
 const USER_STATS_STALE_TIME_MS = 60 * 60 * 1000; // 60 minutes
+// Backend caches the events payload for 5 minutes — match it on the client
+// so a focus-revalidation triggers a fresh fetch instead of replaying cache.
+const ACTIVITY_STALE_TIME_MS = 5 * 60 * 1000;
 
 // Home skeleton loader
 const HomeSkeleton = () => (
@@ -53,6 +57,11 @@ export const Home = () => {
   const userStatsQuery = useCachedFetch(github.getUserStatsWithCache, {
     enabled,
     staleTime: USER_STATS_STALE_TIME_MS,
+  });
+
+  const activityQuery = useCachedFetch(github.getActivityFeedWithCache, {
+    enabled,
+    staleTime: ACTIVITY_STALE_TIME_MS,
   });
 
   // `level_info` does not yet have a `_with_cache` variant — it is computed
@@ -143,6 +152,15 @@ export const Home = () => {
             githubStats={githubStatsQuery.data}
             statsDiff={null}
           />
+          <div className="mt-6">
+            <ActivityTimeline
+              items={activityQuery.data?.items ?? null}
+              isLoading={activityQuery.isLoading}
+              isRevalidating={activityQuery.isRevalidating}
+              error={activityQuery.error}
+              onRetry={() => void activityQuery.revalidate()}
+            />
+          </div>
         </>
       ) : (
         <LoginCard />

--- a/src/types/activity.ts
+++ b/src/types/activity.ts
@@ -1,0 +1,61 @@
+/**
+ * Activity Timeline Types
+ *
+ * Mirrors `commands::activity::ActivityFeedItem` /
+ * `ActivityFeed` on the backend.
+ *
+ * Related Issue: https://github.com/otomatty/development-tools/issues/187
+ */
+
+/// Known event types we render with bespoke copy. Extra strings are tolerated
+/// (the `(string & {})` trick) so a future GitHub event type still gets a
+/// generic row instead of a runtime cast error.
+export type ActivityEventType =
+  | 'PushEvent'
+  | 'PullRequestEvent'
+  | 'PullRequestReviewEvent'
+  | 'PullRequestReviewCommentEvent'
+  | 'IssuesEvent'
+  | 'IssueCommentEvent'
+  | 'ReleaseEvent'
+  | 'CreateEvent'
+  | 'DeleteEvent'
+  | 'ForkEvent'
+  | 'WatchEvent'
+  | 'PublicEvent'
+  | 'MemberEvent';
+
+/// One row in the home activity timeline.
+///
+/// Mirrors `commands::activity::ActivityFeedItem` on the backend.
+export interface ActivityFeedItem {
+  id: string;
+  /// `PushEvent` / `PullRequestEvent` / etc. Forwarded verbatim.
+  eventType: ActivityEventType | (string & {});
+  /// ISO8601.
+  createdAt: string;
+  /// `owner/repo`.
+  repoName: string;
+  /// `https://github.com/{owner}/{repo}`.
+  repoUrl: string;
+  /// `opened` / `closed` / `started` / etc., when the event carries an action.
+  action: string | null;
+  /// PR / issue / release title (or branch name as a fallback).
+  title: string | null;
+  /// Browser URL of the artefact (PR / issue / release / comment). Falls back
+  /// to `repoUrl` when missing.
+  targetUrl: string | null;
+  /// PR or issue number.
+  number: number | null;
+  /// Branch / tag name for `PushEvent` / `CreateEvent` / `DeleteEvent`.
+  refName: string | null;
+  /// `branch` / `tag` / `repository` for `CreateEvent` / `DeleteEvent`.
+  refType: string | null;
+  /// Number of commits in a `PushEvent`.
+  commitsCount: number | null;
+}
+
+/// Aggregated payload returned by `get_activity_feed_with_cache`.
+export interface ActivityFeed {
+  items: ActivityFeedItem[];
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,6 +4,7 @@
 // Split into submodules for better maintainability.
 
 // Re-export all types from submodules
+export * from './activity';
 export * from './auth';
 export * from './challenge';
 export * from './gamification';


### PR DESCRIPTION
Surface the authenticated user's recent GitHub events
(`/users/{u}/events`, capped at 90 days / 300 events by GitHub) in a
scrollable home-page timeline. The endpoint had a backend client method
already; this adds the Tauri command, normalisation layer, and the
React component.

- New `commands::activity::get_activity_feed_with_cache` Tauri command
  that fetches `get_user_events`, flattens each event into a
  `ActivityFeedItem` (id / type / repo / title / target URL / etc.),
  and applies a 5-minute SQLite cache with the same fallback / 401
  semantics as the other `*_with_cache` commands.
- New `cache_types::ACTIVITY_FEED` / `cache_durations::ACTIVITY_FEED`
  entries.
- New `ActivityTimeline` React component with per-event-type icons and
  Japanese copy, scrollable container, error/retry, and click-through
  to GitHub via the system browser.
- Hooked into `Home.tsx` via `useCachedFetch` for SWR-style refresh.

Includes seven unit tests for the event normaliser covering Push /
PullRequest / Issues / IssueComment / Release / Create / unknown
event types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ホームに時系列のGitHubアクティビティタイムラインを追加（各イベントの説明・アイコン・相対時刻表示）
  * イベントの重複排除、タイトル/リンクの優先表示、リポジトリと件名からの直接遷移をサポート
* **パフォーマンス**
  * 5分間のローカルキャッシュで高速表示、フェール時は既存キャッシュを活用
* **信頼性**
  * 外部リンクの安全検証、読み込みスケルトン、エラー表示と再試行を追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->