### PR TITLE
Add realtime today's commit count for daily quest UI (Issue #188)

### DIFF
--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -1608,6 +1608,14 @@ pub async fn get_today_commits_with_cache(
     // Falls back to UTC midnight when no daily/commits challenge is
     // active, which keeps the command useful outside the gamification
     // path.
+    //
+    // Filter on `end_date > now` because `get_active_challenges` only
+    // checks `status = 'active'` — when the app is open across a UTC
+    // midnight rollover, yesterday's daily/commits row can still be
+    // `active` until `fail_expired_challenges` sweeps it. Without this
+    // filter we'd pick yesterday's `start_date` as `since` and count
+    // commits from the wrong window.
+    let now = chrono::Utc::now();
     let challenge_start = state
         .db
         .get_active_challenges(user.id)
@@ -1615,11 +1623,12 @@ pub async fn get_today_commits_with_cache(
         .ok()
         .and_then(|chs| {
             chs.into_iter()
-                .find(|c| c.challenge_type == "daily" && c.target_metric == "commits")
+                .find(|c| {
+                    c.challenge_type == "daily" && c.target_metric == "commits" && c.end_date > now
+                })
                 .map(|c| c.start_date)
         });
 
-    let now = chrono::Utc::now();
     let since_dt = challenge_start.unwrap_or_else(|| {
         now.date_naive()
             .and_hms_opt(0, 0, 0)

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -1615,19 +1615,23 @@ pub async fn get_today_commits_with_cache(
     // `active` until `fail_expired_challenges` sweeps it. Without this
     // filter we'd pick yesterday's `start_date` as `since` and count
     // commits from the wrong window.
+    //
+    // Surface DB errors instead of silently treating them as "no active
+    // challenge". A swallowed error would reset `since` to UTC midnight
+    // even when a daily challenge is genuinely in progress, producing
+    // the exact LIVE-vs-backend mismatch this anchoring is meant to
+    // prevent. The frontend falls back to the persisted `currentValue`
+    // when the realtime query errors, so the user just loses the LIVE
+    // badge — never sees an inflated bar.
     let now = chrono::Utc::now();
     let challenge_start = state
         .db
         .get_active_challenges(user.id)
         .await
-        .ok()
-        .and_then(|chs| {
-            chs.into_iter()
-                .find(|c| {
-                    c.challenge_type == "daily" && c.target_metric == "commits" && c.end_date > now
-                })
-                .map(|c| c.start_date)
-        });
+        .map_err(|e| format!("Failed to load active challenges: {}", e))?
+        .into_iter()
+        .find(|c| c.challenge_type == "daily" && c.target_metric == "commits" && c.end_date > now)
+        .map(|c| c.start_date);
 
     let since_dt = challenge_start.unwrap_or_else(|| {
         now.date_naive()

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -1563,3 +1563,128 @@ pub async fn cleanup_expired_cache(state: State<'_, AppState>) -> Result<u64, St
 
     Ok(deleted)
 }
+
+// ============================================================================
+// Today's Commits realtime command (Issue #188 — G-01)
+// ============================================================================
+
+/// Cap on repositories scanned per `get_today_commits_with_cache` call.
+///
+/// 30 covers the realistic "active in the last week or two" window for
+/// most users while keeping the GraphQL cost low (the query is `O(repos)`
+/// in the new lightweight form, not `O(repos × commits)`). Users with
+/// more than 30 active repos in a single day are vanishingly rare.
+const TODAY_COMMITS_MAX_REPOS: i32 = 30;
+
+/// Realtime "今日のコミット数" with a 3-minute SQLite cache.
+///
+/// `contributionCalendar` lags by minutes-to-tens-of-minutes which makes
+/// the gamification today-quest UI feel stale right after a push. This
+/// thin GraphQL `history(since:) { totalCount }` query is the latency
+/// escape hatch — see Issue #188.
+///
+/// Behaviour mirrors the other `*_with_cache` commands:
+/// - Success → refresh cache, return `from_cache: false`.
+/// - Network / rate-limit error → fall back to last cached payload (any
+///   age), else surface the error.
+/// - 401 → trigger the central auth-expired flow.
+#[command]
+pub async fn get_today_commits_with_cache(
+    app: AppHandle,
+    state: State<'_, AppState>,
+) -> Result<CachedResponse<crate::github::types::TodayCommitsSummary>, String> {
+    let user = state
+        .token_manager
+        .get_current_user()
+        .await
+        .map_err(|e| e.to_string())?
+        .ok_or("Not logged in")?;
+
+    // UTC midnight matches how daily challenges are scoped
+    // (`compute_challenge_period`), so the count and the challenge target
+    // share the same day boundary. The `Z`-suffixed format mirrors the
+    // existing `get_code_stats` caller and is what GitHub's GraphQL
+    // `GitTimestamp` scalar parses most reliably.
+    let today_utc = chrono::Utc::now().date_naive();
+    let since = format!("{}T00:00:00Z", today_utc);
+
+    let api_result = async {
+        let token = state
+            .token_manager
+            .get_access_token()
+            .await
+            .map_err(|e| GitHubError::ApiError(e.to_string()))?;
+        let client = GitHubClient::new(token);
+        client
+            .get_today_commits(&user.username, &since, TODAY_COMMITS_MAX_REPOS)
+            .await
+    }
+    .await;
+
+    match api_result {
+        Ok(summary) => {
+            let payload_json = serde_json::to_string(&summary)
+                .map_err(|e| format!("Failed to serialize today commits: {}", e))?;
+
+            let now = chrono::Utc::now();
+            let expires_at =
+                now + chrono::Duration::minutes(crate::database::cache_durations::TODAY_COMMITS);
+
+            let _ = state
+                .db
+                .save_cache(
+                    user.id,
+                    cache_types::TODAY_COMMITS,
+                    &payload_json,
+                    expires_at,
+                )
+                .await;
+
+            Ok(CachedResponse {
+                data: summary,
+                from_cache: false,
+                cached_at: Some(now.to_rfc3339()),
+                expires_at: Some(expires_at.to_rfc3339()),
+            })
+        }
+        Err(GitHubError::Unauthorized) => {
+            handle_unauthorized(&app, state.inner(), reasons::GITHUB_UNAUTHORIZED).await;
+            Err(GitHubError::Unauthorized.to_string())
+        }
+        Err(api_error) => {
+            if !is_network_error(&api_error) {
+                return Err(format!("GitHub API error: {}", api_error));
+            }
+
+            eprintln!(
+                "Today commits fetch failed, attempting cache fallback: {}",
+                api_error
+            );
+
+            let cache_result = state
+                .db
+                .get_any_cache(user.id, cache_types::TODAY_COMMITS)
+                .await
+                .ok()
+                .flatten();
+
+            match cache_result {
+                Some((data_json, cached_at, expires_at)) => {
+                    let summary: crate::github::types::TodayCommitsSummary =
+                        serde_json::from_str(&data_json)
+                            .map_err(|e| format!("Failed to parse cached data: {}", e))?;
+                    Ok(CachedResponse {
+                        data: summary,
+                        from_cache: true,
+                        cached_at: Some(cached_at),
+                        expires_at: Some(expires_at),
+                    })
+                }
+                None => Err(format!(
+                    "GitHub APIにアクセスできず、キャッシュもありません: {}",
+                    api_error
+                )),
+            }
+        }
+    }
+}

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -1600,13 +1600,36 @@ pub async fn get_today_commits_with_cache(
         .map_err(|e| e.to_string())?
         .ok_or("Not logged in")?;
 
-    // UTC midnight matches how daily challenges are scoped
-    // (`compute_challenge_period`), so the count and the challenge target
-    // share the same day boundary. The `Z`-suffixed format mirrors the
-    // existing `get_code_stats` caller and is what GitHub's GraphQL
-    // `GitTimestamp` scalar parses most reliably.
-    let today_utc = chrono::Utc::now().date_naive();
-    let since = format!("{}T00:00:00Z", today_utc);
+    // Anchor the realtime window to the active daily commits challenge's
+    // `start_date` when one exists. The backend computes progress as
+    // `total_metric - start_stats.metric` (`run_github_sync` in this
+    // file), so counting commits made before the challenge was created
+    // would inflate the LIVE bar above what the backend will ever award.
+    // Falls back to UTC midnight when no daily/commits challenge is
+    // active, which keeps the command useful outside the gamification
+    // path.
+    let challenge_start = state
+        .db
+        .get_active_challenges(user.id)
+        .await
+        .ok()
+        .and_then(|chs| {
+            chs.into_iter()
+                .find(|c| c.challenge_type == "daily" && c.target_metric == "commits")
+                .map(|c| c.start_date)
+        });
+
+    let now = chrono::Utc::now();
+    let since_dt = challenge_start.unwrap_or_else(|| {
+        now.date_naive()
+            .and_hms_opt(0, 0, 0)
+            .expect("00:00:00 is always a valid time")
+            .and_utc()
+    });
+    // GitHub's `GitTimestamp` scalar accepts either `Z` or `+00:00`;
+    // RFC3339 is the safer round-trip format because `challenge.start_date`
+    // is also stored as RFC3339 in `challenges.start_date`.
+    let since = since_dt.to_rfc3339();
 
     let api_result = async {
         let token = state
@@ -1626,7 +1649,6 @@ pub async fn get_today_commits_with_cache(
             let payload_json = serde_json::to_string(&summary)
                 .map_err(|e| format!("Failed to serialize today commits: {}", e))?;
 
-            let now = chrono::Utc::now();
             let expires_at =
                 now + chrono::Duration::minutes(crate::database::cache_durations::TODAY_COMMITS);
 
@@ -1673,6 +1695,25 @@ pub async fn get_today_commits_with_cache(
                     let summary: crate::github::types::TodayCommitsSummary =
                         serde_json::from_str(&data_json)
                             .map_err(|e| format!("Failed to parse cached data: {}", e))?;
+
+                    // Reject the cache when its window doesn't align with
+                    // the one we'd request now. Without this guard, a UTC
+                    // day rollover (or a regenerated daily challenge with
+                    // a newer `start_date`) would surface yesterday's
+                    // count as today's data and inflate progress until a
+                    // fresh API hit succeeds. Compare by parsed date so
+                    // `Z` ↔ `+00:00` formatting differences don't
+                    // invalidate the cache.
+                    let cached_date = chrono::DateTime::parse_from_rfc3339(&summary.since)
+                        .map(|dt| dt.with_timezone(&chrono::Utc).date_naive())
+                        .ok();
+                    if cached_date != Some(since_dt.date_naive()) {
+                        return Err(format!(
+                            "GitHub APIにアクセスできず、キャッシュも当日のものではありません: {}",
+                            api_error
+                        ));
+                    }
+
                     Ok(CachedResponse {
                         data: summary,
                         from_cache: true,

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -1706,19 +1706,21 @@ pub async fn get_today_commits_with_cache(
                             .map_err(|e| format!("Failed to parse cached data: {}", e))?;
 
                     // Reject the cache when its window doesn't align with
-                    // the one we'd request now. Without this guard, a UTC
-                    // day rollover (or a regenerated daily challenge with
-                    // a newer `start_date`) would surface yesterday's
-                    // count as today's data and inflate progress until a
-                    // fresh API hit succeeds. Compare by parsed date so
-                    // `Z` ↔ `+00:00` formatting differences don't
-                    // invalidate the cache.
-                    let cached_date = chrono::DateTime::parse_from_rfc3339(&summary.since)
-                        .map(|dt| dt.with_timezone(&chrono::Utc).date_naive())
+                    // the one we'd request now. Compare against the full
+                    // timestamp rather than the calendar date because
+                    // daily challenges start at `now` (not midnight), so
+                    // a same-day challenge regeneration shifts `since`
+                    // forward without changing the date — a date-only
+                    // check would let the older, wider cache window
+                    // through and inflate progress. Parsed-DateTime
+                    // equality is also resilient to `Z` ↔ `+00:00`
+                    // formatting differences.
+                    let cached_since = chrono::DateTime::parse_from_rfc3339(&summary.since)
+                        .map(|dt| dt.with_timezone(&chrono::Utc))
                         .ok();
-                    if cached_date != Some(since_dt.date_naive()) {
+                    if cached_since != Some(since_dt) {
                         return Err(format!(
-                            "GitHub APIにアクセスできず、キャッシュも当日のものではありません: {}",
+                            "GitHub APIにアクセスできず、キャッシュも現在の集計窓と一致しません: {}",
                             api_error
                         ));
                     }

--- a/src-tauri/src/database/models/cache.rs
+++ b/src-tauri/src/database/models/cache.rs
@@ -46,6 +46,9 @@ pub mod cache_types {
     /// Recent activity feed payload backing the home timeline
     /// (`/users/{u}/events`). See Issue #187.
     pub const ACTIVITY_FEED: &str = "activity_feed";
+    /// Realtime "今日のコミット数" — thin commit-count query used by the
+    /// gamification today-quest UI. See Issue #188.
+    pub const TODAY_COMMITS: &str = "today_commits";
 }
 
 /// Default cache durations in minutes
@@ -81,4 +84,9 @@ pub mod cache_durations {
     /// REST budget is 5000 req/hr — even with revalidate-on-focus the
     /// 5-minute TTL keeps refresh load negligible.
     pub const ACTIVITY_FEED: i64 = 5;
+    /// Realtime today-commit-count cache duration (3 minutes).
+    /// The query is a thin GraphQL `history(since:) { totalCount }` — the
+    /// 3-minute TTL gives the gamification today-quest UI near-realtime
+    /// updates while keeping GraphQL spend trivial. See Issue #188.
+    pub const TODAY_COMMITS: i64 = 3;
 }

--- a/src-tauri/src/github/client.rs
+++ b/src-tauri/src/github/client.rs
@@ -743,6 +743,126 @@ impl GitHubClient {
         Ok(result)
     }
 
+    /// Get total commits authored by the user since `since` across their
+    /// `max_repos` most recently pushed repositories.
+    ///
+    /// Lightweight counterpart to [`get_code_stats`]: only requests
+    /// `history(since:) { totalCount }` per repo so the GraphQL cost stays
+    /// roughly proportional to `max_repos` instead of `max_repos × commits`.
+    /// Designed to back the gamification "今日のクエスト" UI where
+    /// `contributionCalendar`'s minutes-to-tens-of-minutes lag is too coarse.
+    ///
+    /// # Arguments
+    /// * `username` - GitHub username
+    /// * `since` - ISO8601 lower bound (e.g. `"2026-05-08T00:00:00Z"`)
+    /// * `max_repos` - Cap on repositories to scan (1..=100). The query orders
+    ///   by `PUSHED_AT DESC` so the cap drops cold repos first.
+    ///
+    /// # Returns
+    /// A [`TodayCommitsSummary`] with the aggregated total and the list of
+    /// repos that contributed at least one commit.
+    pub async fn get_today_commits(
+        &self,
+        username: &str,
+        since: &str,
+        max_repos: i32,
+    ) -> GitHubResult<TodayCommitsSummary> {
+        // Clamp to GitHub's documented `first: 1..=100` window. Callers pass
+        // a small value (default 30) so this is just defence-in-depth.
+        let capped = max_repos.clamp(1, 100);
+
+        // Resolve the user's node id with a one-off lightweight query so
+        // `history(author: {id: $author})` filters to commits actually
+        // authored by them rather than every commit on `defaultBranchRef`
+        // (which would over-count when collaborators push). The id query
+        // costs 1 GraphQL point and lets the main query stay author-scoped.
+        let id_query = r#"
+            query($login: String!) {
+                user(login: $login) { id }
+            }
+        "#;
+
+        #[derive(serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct UserIdResponse {
+            user: Option<UserId>,
+        }
+        #[derive(serde::Deserialize)]
+        struct UserId {
+            id: String,
+        }
+
+        let id_resp: UserIdResponse = self
+            .graphql(id_query, Some(serde_json::json!({ "login": username })))
+            .await?;
+        let author_id = id_resp
+            .user
+            .map(|u| u.id)
+            .ok_or_else(|| GitHubError::NotFound(format!("User {} not found", username)))?;
+
+        let query = r#"
+            query($login: String!, $since: GitTimestamp!, $maxRepos: Int!, $author: ID!) {
+                user(login: $login) {
+                    repositories(first: $maxRepos, orderBy: {field: PUSHED_AT, direction: DESC}, ownerAffiliations: [OWNER, COLLABORATOR, ORGANIZATION_MEMBER]) {
+                        nodes {
+                            nameWithOwner
+                            defaultBranchRef {
+                                target {
+                                    ... on Commit {
+                                        history(since: $since, author: {id: $author}) {
+                                            totalCount
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                rateLimit {
+                    cost
+                    remaining
+                }
+            }
+        "#;
+
+        let variables = serde_json::json!({
+            "login": username,
+            "since": since,
+            "maxRepos": capped,
+            "author": author_id,
+        });
+
+        let response: TodayCommitsQueryResponse = self.graphql(query, Some(variables)).await?;
+
+        let mut total: i32 = 0;
+        let mut scanned: i32 = 0;
+        let mut contributing: Vec<String> = Vec::new();
+
+        if let Some(user) = response.user {
+            for repo in user.repositories.nodes {
+                scanned += 1;
+                let count = repo
+                    .default_branch_ref
+                    .as_ref()
+                    .and_then(|r| r.target.as_ref())
+                    .and_then(|t| t.history.as_ref())
+                    .map(|h| h.total_count)
+                    .unwrap_or(0);
+                if count > 0 {
+                    total += count;
+                    contributing.push(repo.name_with_owner);
+                }
+            }
+        }
+
+        Ok(TodayCommitsSummary {
+            count: total,
+            since: since.to_string(),
+            repositories_scanned: scanned,
+            repositories_with_commits: contributing,
+        })
+    }
+
     /// Get detailed rate limit information for all API types
     pub async fn get_detailed_rate_limit(&self) -> GitHubResult<RateLimitDetailed> {
         // Get REST API rate limits

--- a/src-tauri/src/github/client.rs
+++ b/src-tauri/src/github/client.rs
@@ -752,6 +752,16 @@ impl GitHubClient {
     /// Designed to back the gamification "今日のクエスト" UI where
     /// `contributionCalendar`'s minutes-to-tens-of-minutes lag is too coarse.
     ///
+    /// # Coverage trade-offs
+    /// Only the **default branch** of each scanned repository is counted —
+    /// commits authored on a feature branch that hasn't been merged are
+    /// invisible to this query. This matches `get_code_stats`'s behaviour
+    /// and keeps the GraphQL cost flat, but does mean a developer pushing
+    /// to a long-lived feature branch will not see the LIVE bar move
+    /// until those commits land on the default branch. The persisted
+    /// daily snapshot (sourced from `contributionCalendar`) does cover
+    /// non-default branches, so the gap closes on the next sync.
+    ///
     /// # Arguments
     /// * `username` - GitHub username
     /// * `since` - ISO8601 lower bound (e.g. `"2026-05-08T00:00:00Z"`)

--- a/src-tauri/src/github/client.rs
+++ b/src-tauri/src/github/client.rs
@@ -762,6 +762,13 @@ impl GitHubClient {
     /// daily snapshot (sourced from `contributionCalendar`) does cover
     /// non-default branches, so the gap closes on the next sync.
     ///
+    /// **Forks are excluded** (`isFork: false`). GitHub's contribution
+    /// criteria explicitly omit commits made in fork repositories, and
+    /// the persisted challenge progress in `run_github_sync` is derived
+    /// from `contributionCalendar` totals — counting fork commits here
+    /// would inflate the LIVE bar above what the backend will ever
+    /// award.
+    ///
     /// # Arguments
     /// * `username` - GitHub username
     /// * `since` - ISO8601 lower bound (e.g. `"2026-05-08T00:00:00Z"`)
@@ -813,7 +820,7 @@ impl GitHubClient {
         let query = r#"
             query($login: String!, $since: GitTimestamp!, $maxRepos: Int!, $author: ID!) {
                 user(login: $login) {
-                    repositories(first: $maxRepos, orderBy: {field: PUSHED_AT, direction: DESC}, ownerAffiliations: [OWNER, COLLABORATOR, ORGANIZATION_MEMBER]) {
+                    repositories(first: $maxRepos, isFork: false, orderBy: {field: PUSHED_AT, direction: DESC}, ownerAffiliations: [OWNER, COLLABORATOR, ORGANIZATION_MEMBER]) {
                         nodes {
                             nameWithOwner
                             defaultBranchRef {

--- a/src-tauri/src/github/types.rs
+++ b/src-tauri/src/github/types.rs
@@ -299,6 +299,75 @@ pub struct DailyCodeStatsAggregated {
     pub repositories: Vec<String>,
 }
 
+// ============================================================================
+// Today's Commits Types (Issue #188 — G-01 realtime today commit count)
+// ============================================================================
+
+/// GraphQL response for the lightweight "today's commits" query.
+///
+/// Only requests `history(since:) { totalCount }` per repository, which is
+/// roughly an order of magnitude cheaper than the full code-stats query
+/// because no commit-level fields (additions / deletions / oid) are pulled.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TodayCommitsQueryResponse {
+    pub user: Option<TodayCommitsUser>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TodayCommitsUser {
+    pub repositories: TodayCommitsRepositoriesConnection,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TodayCommitsRepositoriesConnection {
+    pub nodes: Vec<TodayCommitsRepository>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TodayCommitsRepository {
+    pub name_with_owner: String,
+    pub default_branch_ref: Option<TodayCommitsDefaultBranchRef>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TodayCommitsDefaultBranchRef {
+    pub target: Option<TodayCommitsTarget>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TodayCommitsTarget {
+    pub history: Option<TodayCommitsHistory>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TodayCommitsHistory {
+    pub total_count: i32,
+}
+
+/// Aggregated "today's commits" response surfaced to the frontend.
+///
+/// `since` is the UTC midnight timestamp the count applies to so the UI
+/// can detect day rollovers without consulting the system clock.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct TodayCommitsSummary {
+    /// Total commit count across all scanned repositories since `since`.
+    pub count: i32,
+    /// ISO8601 UTC midnight that bounds the count window.
+    pub since: String,
+    /// How many repositories the query actually scanned (≤ requested cap).
+    pub repositories_scanned: i32,
+    /// Repositories that contributed at least one commit, for tooltip / debug.
+    pub repositories_with_commits: Vec<String>,
+}
+
 /// Rate limit information with detailed breakdown
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -65,6 +65,8 @@ use commands::{
     get_scheduler_status,
     get_settings,
     get_sync_intervals,
+    // Realtime "today's commits" command (Issue #188)
+    get_today_commits_with_cache,
     get_user_repositories,
     get_user_stats,
     get_user_stats_with_cache,
@@ -204,6 +206,8 @@ pub fn run() {
             sync_code_stats,
             get_code_stats_summary,
             get_rate_limit_info,
+            // Realtime "today's commits" command (Issue #188)
+            get_today_commits_with_cache,
             // Gamification commands
             get_level_info,
             add_xp,

--- a/src/components/features/gamification/ChallengeCard.tsx
+++ b/src/components/features/gamification/ChallengeCard.tsx
@@ -133,7 +133,7 @@ const ChallengeItem: React.FC<{
             {useRealtime && (
               <span
                 className="ml-2 text-[10px] font-medium uppercase tracking-wider text-gm-accent-cyan"
-                title="GitHubから直接取得した今日のコミット数"
+                title="GitHubから直接取得した今日のコミット数（各リポジトリのデフォルトブランチのみ）"
               >
                 LIVE
               </span>

--- a/src/components/features/gamification/ChallengeCard.tsx
+++ b/src/components/features/gamification/ChallengeCard.tsx
@@ -44,7 +44,15 @@ const ChallengeItem: React.FC<{
    *  realtime snapshot.
    */
   liveFromCache?: boolean;
-}> = ({ challenge, liveTodayCommits, liveFromCache }) => {
+  /** True when the most recent realtime fetch threw. `useCachedFetch` is
+   *  SWR-style: it keeps the previous successful `data` / `fromCache`
+   *  values when a revalidation fails, so without this flag a stale
+   *  count would continue to override `currentValue` and wear the LIVE
+   *  badge after the backend started rejecting our window. Treat any
+   *  error as "no realtime data" so the bar falls back to `currentValue`.
+   */
+  liveHasError?: boolean;
+}> = ({ challenge, liveTodayCommits, liveFromCache, liveHasError }) => {
   // For daily commits challenges, prefer the realtime count when it's
   // *higher* than the persisted current value. We never lower the bar:
   // the realtime query scans the most recent N repos so it can under-count
@@ -54,7 +62,8 @@ const ChallengeItem: React.FC<{
     challenge.challengeType === 'daily' &&
     challenge.targetMetric === 'commits' &&
     typeof liveTodayCommits === 'number' &&
-    !liveFromCache;
+    !liveFromCache &&
+    !liveHasError;
   const effectiveCurrent =
     useRealtime
       ? Math.max(liveTodayCommits as number, challenge.currentValue)
@@ -241,6 +250,12 @@ export const ChallengeCard: React.FC = () => {
   // payload (network / rate-limit failure). That data isn't fresh, so
   // we don't want to claim LIVE or use it to override `currentValue`.
   const liveFromCache = todayCommitsQuery.fromCache;
+  // `useCachedFetch` keeps the previous successful `data` on revalidation
+  // failure (SWR semantics). Surface the error flag so the UI suppresses
+  // the realtime path until a successful fetch lands — otherwise a
+  // backend-rejected stale-cache window or a transient error would
+  // continue presenting the old count as LIVE.
+  const liveHasError = todayCommitsQuery.error !== null;
 
   // Reload challenges function - only works when online
   const reloadChallenges = async () => {
@@ -304,6 +319,7 @@ export const ChallengeCard: React.FC = () => {
                   challenge={challenge}
                   liveTodayCommits={liveTodayCommits}
                   liveFromCache={liveFromCache}
+                  liveHasError={liveHasError}
                 />
               ))}
             </div>

--- a/src/components/features/gamification/ChallengeCard.tsx
+++ b/src/components/features/gamification/ChallengeCard.tsx
@@ -9,10 +9,12 @@
  *   - Original (Leptos): ./challenge_card.rs
  */
 
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { useNetworkStatus } from '../../../stores/networkStore';
+import { useCachedFetch } from '../../../hooks/useCachedFetch';
+import { useAuth } from '../../../stores/authStore';
 import { Icon } from '../../icons';
-import { challenges as challengeApi } from '../../../lib/tauri/commands';
+import { challenges as challengeApi, github } from '../../../lib/tauri/commands';
 import type { ChallengeInfo } from '../../../types';
 import {
   challengeTypeLabel,
@@ -21,10 +23,39 @@ import {
   remainingTimeLabel,
 } from '../../../types/challenge';
 
+// Today-commits cache TTL on the backend is 3 minutes (Issue #188); align
+// the staleTime so a focus revalidation kicks off right when the cache
+// expires rather than re-using stale data for another window.
+const TODAY_COMMITS_STALE_TIME_MS = 3 * 60 * 1000;
+
 // Single challenge item component
-const ChallengeItem: React.FC<{ challenge: ChallengeInfo }> = ({ challenge }) => {
-  const progress = Math.min(challenge.progressPercent, 100);
-  const isCompleted = challenge.isCompleted;
+const ChallengeItem: React.FC<{
+  challenge: ChallengeInfo;
+  /** Realtime today-commits count (Issue #188). When provided, overrides
+   *  the persisted `currentValue` for daily/commits challenges so a fresh
+   *  push reflects in the bar without waiting for the next sync.
+   */
+  liveTodayCommits?: number | null;
+}> = ({ challenge, liveTodayCommits }) => {
+  // For daily commits challenges, prefer the realtime count when it's
+  // *higher* than the persisted current value. We never lower the bar:
+  // the realtime query scans the most recent N repos so it can under-count
+  // when a user pushed to an older repo, and the persisted sync should
+  // catch that on its next run. Picking the max keeps the UI monotonic.
+  const useRealtime =
+    challenge.challengeType === 'daily' &&
+    challenge.targetMetric === 'commits' &&
+    typeof liveTodayCommits === 'number';
+  const effectiveCurrent =
+    useRealtime
+      ? Math.max(liveTodayCommits as number, challenge.currentValue)
+      : challenge.currentValue;
+  const effectiveProgress =
+    challenge.targetValue > 0
+      ? Math.min((effectiveCurrent / challenge.targetValue) * 100, 100)
+      : challenge.progressPercent;
+  const progress = Math.min(effectiveProgress, 100);
+  const isCompleted = challenge.isCompleted || effectiveCurrent >= challenge.targetValue;
   const isExpired = challenge.isExpired;
 
   // Determine colors based on status
@@ -95,10 +126,18 @@ const ChallengeItem: React.FC<{ challenge: ChallengeInfo }> = ({ challenge }) =>
         {/* Progress text */}
         <div className="flex items-baseline justify-between">
           <span className="text-2xl font-bold text-gm-text-primary">
-            {challenge.currentValue}
+            {effectiveCurrent}
             <span className="text-sm text-gm-text-secondary font-normal">
               {' '}/ {challenge.targetValue}
             </span>
+            {useRealtime && (
+              <span
+                className="ml-2 text-[10px] font-medium uppercase tracking-wider text-gm-accent-cyan"
+                title="GitHubから直接取得した今日のコミット数"
+              >
+                LIVE
+              </span>
+            )}
           </span>
           <span className="text-sm font-medium text-gm-accent-gold">+{challenge.rewardXp} XP</span>
         </div>
@@ -149,6 +188,7 @@ const ChallengeSkeleton: React.FC = () => {
 
 export const ChallengeCard: React.FC = () => {
   const isOnline = useNetworkStatus((s) => s.isOnline);
+  const isLoggedIn = useAuth((s) => s.state.isLoggedIn);
   const [challenges, setChallenges] = useState<ChallengeInfo[] | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -170,10 +210,32 @@ export const ChallengeCard: React.FC = () => {
     fetchChallenges();
   }, [fetchChallenges]);
 
+  // Realtime today's commit count — only fetched when there is at least one
+  // active daily/commits challenge to render. Avoids spending a GraphQL
+  // request on users without that challenge type.
+  const hasDailyCommitsChallenge = useMemo(
+    () =>
+      (challenges ?? []).some(
+        (c) =>
+          c.challengeType === 'daily' &&
+          c.targetMetric === 'commits' &&
+          !c.isExpired,
+      ),
+    [challenges],
+  );
+  const todayCommitsQuery = useCachedFetch(github.getTodayCommitsWithCache, {
+    enabled: isLoggedIn && hasDailyCommitsChallenge,
+    staleTime: TODAY_COMMITS_STALE_TIME_MS,
+  });
+  const liveTodayCommits = todayCommitsQuery.data?.count ?? null;
+
   // Reload challenges function - only works when online
   const reloadChallenges = async () => {
     if (!isOnline) return;
     fetchChallenges();
+    // Also kick the realtime today-commits query so the LIVE badge isn't
+    // strictly tied to its own focus / staleTime cycle.
+    void todayCommitsQuery.revalidate();
   };
 
   return (
@@ -224,7 +286,11 @@ export const ChallengeCard: React.FC = () => {
           {challenges && challenges.length > 0 ? (
             <div className="space-y-3">
               {challenges.map((challenge) => (
-                <ChallengeItem key={`${challenge.challengeType}-${challenge.targetMetric}`} challenge={challenge} />
+                <ChallengeItem
+                  key={`${challenge.challengeType}-${challenge.targetMetric}`}
+                  challenge={challenge}
+                  liveTodayCommits={liveTodayCommits}
+                />
               ))}
             </div>
           ) : (

--- a/src/components/features/gamification/ChallengeCard.tsx
+++ b/src/components/features/gamification/ChallengeCard.tsx
@@ -36,7 +36,15 @@ const ChallengeItem: React.FC<{
    *  push reflects in the bar without waiting for the next sync.
    */
   liveTodayCommits?: number | null;
-}> = ({ challenge, liveTodayCommits }) => {
+  /** True when `liveTodayCommits` came from the backend's cache fallback
+   *  (network / rate-limit failure) rather than a fresh GitHub fetch.
+   *  We deliberately suppress the LIVE badge and the realtime override
+   *  in that case — cached data isn't actually realtime, and the
+   *  persisted `currentValue` is already at least as good as a stale
+   *  realtime snapshot.
+   */
+  liveFromCache?: boolean;
+}> = ({ challenge, liveTodayCommits, liveFromCache }) => {
   // For daily commits challenges, prefer the realtime count when it's
   // *higher* than the persisted current value. We never lower the bar:
   // the realtime query scans the most recent N repos so it can under-count
@@ -45,7 +53,8 @@ const ChallengeItem: React.FC<{
   const useRealtime =
     challenge.challengeType === 'daily' &&
     challenge.targetMetric === 'commits' &&
-    typeof liveTodayCommits === 'number';
+    typeof liveTodayCommits === 'number' &&
+    !liveFromCache;
   const effectiveCurrent =
     useRealtime
       ? Math.max(liveTodayCommits as number, challenge.currentValue)
@@ -228,6 +237,10 @@ export const ChallengeCard: React.FC = () => {
     staleTime: TODAY_COMMITS_STALE_TIME_MS,
   });
   const liveTodayCommits = todayCommitsQuery.data?.count ?? null;
+  // `fromCache` is true when the backend served the cache-fallback
+  // payload (network / rate-limit failure). That data isn't fresh, so
+  // we don't want to claim LIVE or use it to override `currentValue`.
+  const liveFromCache = todayCommitsQuery.fromCache;
 
   // Reload challenges function - only works when online
   const reloadChallenges = async () => {
@@ -290,6 +303,7 @@ export const ChallengeCard: React.FC = () => {
                   key={`${challenge.challengeType}-${challenge.targetMetric}`}
                   challenge={challenge}
                   liveTodayCommits={liveTodayCommits}
+                  liveFromCache={liveFromCache}
                 />
               ))}
             </div>

--- a/src/lib/tauri/commands.ts
+++ b/src/lib/tauri/commands.ts
@@ -43,6 +43,7 @@ import type {
   CodeStatsResponse,
   RateLimitInfo,
   RateLimitDetailed,
+  TodayCommitsSummary,
   ContributionCalendar,
   BadgeWithProgress,
   CachedResponse,
@@ -482,6 +483,17 @@ export const github = {
    */
   getActivityFeedWithCache: (): Promise<CachedResponse<ActivityFeed>> =>
     invoke<CachedResponse<ActivityFeed>>('get_activity_feed_with_cache'),
+
+  /**
+   * Realtime "今日のコミット数" with a 3-minute SQLite cache.
+   *
+   * `contributionCalendar` lags by minutes-to-tens-of-minutes, which makes
+   * the gamification today-quest UI feel stale right after a push. This
+   * thin GraphQL `history(since:) { totalCount }` query is the latency
+   * escape hatch — see Issue #188.
+   */
+  getTodayCommitsWithCache: (): Promise<CachedResponse<TodayCommitsSummary>> =>
+    invoke<CachedResponse<TodayCommitsSummary>>('get_today_commits_with_cache'),
 };
 
 // ============================================================================

--- a/src/types/gamification.ts
+++ b/src/types/gamification.ts
@@ -364,6 +364,22 @@ export function graphqlUsagePercent(rateLimit: RateLimitInfo): number {
   return ((rateLimit.graphqlLimit - rateLimit.graphqlRemaining) / rateLimit.graphqlLimit) * 100.0;
 }
 
+/// 今日のコミット数（リアルタイム）— Issue #188
+///
+/// `contributionCalendar` のラグを回避するために、
+/// `repositories(history(since:) { totalCount })` の薄い GraphQL クエリで
+/// 当日のコミット数だけを取得する。
+export interface TodayCommitsSummary {
+  /// 走査した全リポジトリの当日コミット数合計
+  count: number;
+  /// 集計開始の UTC ISO8601 タイムスタンプ（その日の 00:00 UTC）
+  since: string;
+  /// 実際に走査したリポジトリ数（要求した上限以下）
+  repositoriesScanned: number;
+  /// 当日 1 件以上コミットがあったリポジトリ（`owner/repo`）
+  repositoriesWithCommits: string[];
+}
+
 /// コード統計同期結果
 export interface CodeStatsSyncResult {
   /// 同期した日数


### PR DESCRIPTION
`contributionCalendar` lags by minutes-to-tens-of-minutes which makes
the gamification today-quest progress feel stale right after a push.
This adds a thin GraphQL `repositories(history(since:) { totalCount })`
query, scoped to commits authored by the user, with a 3-minute SQLite
cache and the `*_with_cache` envelope used by the rest of the app.

ChallengeCard now uses the realtime count for daily/commits challenges
and renders a LIVE badge when it does. The bar is monotonic — we take
the max of the realtime and persisted values so a smaller scan window
never pushes progress backwards.

https://claude.ai/code/session_01NS6v4t3FBJPFhVrnw6AhWt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * デイリーチャレンジの進捗バーで「本日のコミット数」をリアルタイム反映し、増加時は表示値を上書き。隣に「LIVE」バッジを表示して最新状態を示します。
  * フロントエンド経由での短いキャッシュを利用し、頻繁な更新を抑えつつ再検証で最新値を取得します。

* **バグ修正**
  * ネットワーク障害時でも当日の有効なキャッシュがあれば進捗を表示し、不整合な日付のキャッシュは無効化します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->