### PR TITLE
Consolidate GitHub stats baseline into snapshots (Issue #189)

### DIFF
--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -12,6 +12,27 @@ use crate::database::{
 use crate::github::{GitHubClient, GitHubStats, GitHubUser};
 use crate::utils::notifications::send_notification;
 
+/// Saturating, sign-safe difference between two cumulative i32 counters.
+///
+/// `XpBreakdown::calculate` requires `u64`. Cumulative counters in
+/// `GitHubStats` are stored as `i32` and should never go negative in
+/// practice — but if the GitHub API ever returns one (or a count
+/// regresses, e.g. a star is lost) we want the XP delta to clamp to 0,
+/// not panic or wrap. This is the single helper both the diff and the
+/// "first sync" branches funnel through.
+fn diff_count(current: i32, previous: i32) -> u64 {
+    clamp_to_u64(current).saturating_sub(clamp_to_u64(previous))
+}
+
+/// Clamp a possibly-negative `i32` count to a `u64` (negative → 0).
+fn clamp_to_u64(value: i32) -> u64 {
+    if value < 0 {
+        0
+    } else {
+        value as u64
+    }
+}
+
 /// Get GitHub user profile
 #[command]
 pub async fn get_github_user(
@@ -219,7 +240,7 @@ pub async fn sync_github_stats(
 /// Concurrency: this function takes `state.sync_lock` for the duration of the
 /// run so a manual "sync now" cannot race a scheduler-driven sync. Without
 /// the lock, both invocations would read the same pre-sync snapshot via
-/// `get_previous_github_stats` and each apply the diff independently,
+/// `get_latest_github_stats_snapshot` and each apply the diff independently,
 /// double-counting XP and badges.
 pub async fn run_github_sync(
     app: &tauri::AppHandle,
@@ -244,10 +265,13 @@ pub async fn run_github_sync(
     let github_stats =
         map_github_result(app, state, client.get_user_stats(&user.username).await).await?;
 
-    // Get previous stats for diff calculation
-    let previous_stats_json = state
+    // Single source of truth for "previous GitHub stats" — the most recent
+    // `github_stats_snapshots` row for this user (Issue #189). When the
+    // user has already synced earlier today, this returns *today's* row,
+    // so successive syncs in the same day don't double-count activity.
+    let previous_snapshot_for_xp = state
         .db
-        .get_previous_github_stats(user.id)
+        .get_latest_github_stats_snapshot(user.id)
         .await
         .map_err(|e| e.to_string())?;
 
@@ -260,50 +284,46 @@ pub async fn run_github_sync(
         .map(|s| s.current_streak)
         .unwrap_or(0);
 
-    // Calculate diff and XP
-    let (xp_breakdown, xp_gained) = if let Some(prev_json) = previous_stats_json {
-        if let Ok(prev_stats) = serde_json::from_str::<GitHubStats>(&prev_json) {
+    // Calculate diff and XP. `XpBreakdown::calculate` takes `u64` so each
+    // diff is computed via `saturating_sub` — a regression in any
+    // cumulative metric (e.g. losing a star) clamps to 0 instead of
+    // turning into negative XP. (DoD: `XpBreakdown` の各フィールドが非負)
+    let (xp_breakdown, xp_gained) = match &previous_snapshot_for_xp {
+        Some(prev) => {
             let breakdown = xp::XpBreakdown::calculate(
-                github_stats.total_commits - prev_stats.total_commits,
-                github_stats.total_prs - prev_stats.total_prs,
-                github_stats.total_prs_merged - prev_stats.total_prs_merged,
-                github_stats.total_issues - prev_stats.total_issues,
-                github_stats.total_issues_closed - prev_stats.total_issues_closed,
-                github_stats.total_reviews - prev_stats.total_reviews,
-                github_stats.total_stars_received - prev_stats.total_stars_received,
-                current_streak,
-            );
-            let total = breakdown.total_xp;
-            (breakdown, total)
-        } else {
-            // First sync - calculate full XP
-            let breakdown = xp::XpBreakdown::calculate(
-                github_stats.total_commits,
-                github_stats.total_prs,
-                github_stats.total_prs_merged,
-                github_stats.total_issues,
-                github_stats.total_issues_closed,
-                github_stats.total_reviews,
-                github_stats.total_stars_received,
+                diff_count(github_stats.total_commits, prev.total_commits),
+                diff_count(github_stats.total_prs, prev.total_prs),
+                diff_count(github_stats.total_prs_merged, prev.total_prs_merged),
+                diff_count(github_stats.total_issues, prev.total_issues),
+                diff_count(github_stats.total_issues_closed, prev.total_issues_closed),
+                diff_count(github_stats.total_reviews, prev.total_reviews),
+                diff_count(
+                    github_stats.total_stars_received,
+                    prev.total_stars_received,
+                ),
                 current_streak,
             );
             let total = breakdown.total_xp;
             (breakdown, total)
         }
-    } else {
-        // First sync - calculate full XP (streak is 0 for initial sync)
-        let breakdown = xp::XpBreakdown::calculate(
-            github_stats.total_commits,
-            github_stats.total_prs,
-            github_stats.total_prs_merged,
-            github_stats.total_issues,
-            github_stats.total_issues_closed,
-            github_stats.total_reviews,
-            github_stats.total_stars_received,
-            0, // Initial sync has no streak bonus
-        );
-        let total = breakdown.total_xp;
-        (breakdown, total)
+        None => {
+            // No baseline — fresh user. Award XP for the full lifetime
+            // totals exactly like the old `previous_github_stats == None`
+            // branch did, with `streak = 0` (no bonus on the very first
+            // sync).
+            let breakdown = xp::XpBreakdown::calculate(
+                clamp_to_u64(github_stats.total_commits),
+                clamp_to_u64(github_stats.total_prs),
+                clamp_to_u64(github_stats.total_prs_merged),
+                clamp_to_u64(github_stats.total_issues),
+                clamp_to_u64(github_stats.total_issues_closed),
+                clamp_to_u64(github_stats.total_reviews),
+                clamp_to_u64(github_stats.total_stars_received),
+                0,
+            );
+            let total = breakdown.total_xp;
+            (breakdown, total)
+        }
     };
 
     // Get current stats for level comparison and streak update
@@ -437,19 +457,16 @@ pub async fn run_github_sync(
     let new_level = level::level_from_xp(updated_stats.total_xp);
     let level_up = new_level > old_level;
 
-    // Save current GitHub stats as previous for next diff
-    let stats_json = serde_json::to_string(&github_stats).map_err(|e| e.to_string())?;
-    state
-        .db
-        .save_previous_github_stats(user.id, &stats_json)
-        .await
-        .map_err(|e| e.to_string())?;
-
-    // Also prime the activity cache so subsequent `get_github_stats_with_cache`
+    // Prime the activity cache so subsequent `get_github_stats_with_cache`
     // calls can serve the freshly-synced data without re-hitting the API. The
     // cache is best-effort: a write failure is logged but does not fail the
     // sync. (Audit §9.2: ensure non-fallback paths populate the cache too.)
+    //
+    // Note: the legacy `previous_github_stats` KV that used to live here
+    // was retired by Issue #189 — `github_stats_snapshots` is now the
+    // single source of truth for the XP-diff baseline.
     {
+        let stats_json = serde_json::to_string(&github_stats).map_err(|e| e.to_string())?;
         let now = chrono::Utc::now();
         let expires_at =
             now + chrono::Duration::minutes(crate::database::cache_durations::GITHUB_STATS);
@@ -802,10 +819,16 @@ pub async fn run_github_sync(
         eprintln!("Failed to check expired challenges: {}", e);
     }
 
-    // Save today's snapshot and calculate diff from previous day
+    // Save today's snapshot and calculate diff for the daily-comparison UI.
+    //
+    // After Issue #189, the snapshot also serves as the XP-diff baseline,
+    // but here we only need the *previous-day* row (for the "+5 commits
+    // vs yesterday" bubble). The XP baseline was already loaded above
+    // via `get_latest_github_stats_snapshot` (which may legitimately be
+    // today's row when the user already synced earlier today).
     let today = chrono::Utc::now().date_naive().to_string();
     let stats_diff = {
-        // Get previous snapshot for diff calculation
+        // Get previous-day snapshot for the daily-comparison display.
         let previous_snapshot = state
             .db
             .get_previous_github_stats_snapshot(user.id, &today)
@@ -817,14 +840,19 @@ pub async fn run_github_sync(
             user.id,
             github_stats.total_commits,
             github_stats.total_prs,
+            github_stats.total_prs_merged,
             github_stats.total_reviews,
             github_stats.total_issues,
+            github_stats.total_issues_closed,
             github_stats.total_stars_received,
             github_stats.total_contributions,
             &today,
         );
 
-        // Save current snapshot (UPSERT)
+        // Save current snapshot (UPSERT). Failure here is logged but does
+        // not fail the sync — the user-visible XP gain has already been
+        // persisted. The next sync will rebuild the baseline from
+        // whatever snapshot row remains.
         if let Err(e) = state.db.save_github_stats_snapshot(&current_snapshot).await {
             eprintln!("Failed to save github stats snapshot: {}", e);
         }

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -297,10 +297,7 @@ pub async fn run_github_sync(
                 diff_count(github_stats.total_issues, prev.total_issues),
                 diff_count(github_stats.total_issues_closed, prev.total_issues_closed),
                 diff_count(github_stats.total_reviews, prev.total_reviews),
-                diff_count(
-                    github_stats.total_stars_received,
-                    prev.total_stars_received,
-                ),
+                diff_count(github_stats.total_stars_received, prev.total_stars_received),
                 current_streak,
             );
             let total = breakdown.total_xp;
@@ -325,6 +322,33 @@ pub async fn run_github_sync(
             (breakdown, total)
         }
     };
+
+    // Persist the new XP-diff baseline *before* awarding any XP. Without
+    // a transaction API we can't make the two writes atomic, so we pick
+    // the safer ordering: if the snapshot save fails we return early
+    // (no XP awarded, retry sees the same diff and tries again); if the
+    // snapshot save succeeds and a later step fails we lose this sync's
+    // XP but never double-award on retry. The opposite order — XP first,
+    // snapshot last — would re-award the same activity on every retry
+    // until the snapshot finally lands.
+    let today = chrono::Utc::now().date_naive().to_string();
+    let current_snapshot = GitHubStatsSnapshot::new(
+        user.id,
+        github_stats.total_commits,
+        github_stats.total_prs,
+        github_stats.total_prs_merged,
+        github_stats.total_reviews,
+        github_stats.total_issues,
+        github_stats.total_issues_closed,
+        github_stats.total_stars_received,
+        github_stats.total_contributions,
+        &today,
+    );
+    state
+        .db
+        .save_github_stats_snapshot(&current_snapshot)
+        .await
+        .map_err(|e| format!("Failed to persist XP-diff baseline snapshot: {}", e))?;
 
     // Get current stats for level comparison and streak update
     let current_stats = state
@@ -819,45 +843,17 @@ pub async fn run_github_sync(
         eprintln!("Failed to check expired challenges: {}", e);
     }
 
-    // Save today's snapshot and calculate diff for the daily-comparison UI.
-    //
-    // After Issue #189, the snapshot also serves as the XP-diff baseline,
-    // but here we only need the *previous-day* row (for the "+5 commits
-    // vs yesterday" bubble). The XP baseline was already loaded above
-    // via `get_latest_github_stats_snapshot` (which may legitimately be
-    // today's row when the user already synced earlier today).
-    let today = chrono::Utc::now().date_naive().to_string();
+    // Daily-comparison diff for the UI bubble ("+5 commits vs yesterday").
+    // The current snapshot was already persisted upfront as the XP-diff
+    // baseline, so we only need to read the *previous-day* row here and
+    // diff against the in-memory `current_snapshot`.
     let stats_diff = {
-        // Get previous-day snapshot for the daily-comparison display.
         let previous_snapshot = state
             .db
             .get_previous_github_stats_snapshot(user.id, &today)
             .await
             .map_err(|e| e.to_string())?;
 
-        // Create current snapshot for diff calculation and saving
-        let current_snapshot = GitHubStatsSnapshot::new(
-            user.id,
-            github_stats.total_commits,
-            github_stats.total_prs,
-            github_stats.total_prs_merged,
-            github_stats.total_reviews,
-            github_stats.total_issues,
-            github_stats.total_issues_closed,
-            github_stats.total_stars_received,
-            github_stats.total_contributions,
-            &today,
-        );
-
-        // Save current snapshot (UPSERT). Failure here is logged but does
-        // not fail the sync — the user-visible XP gain has already been
-        // persisted. The next sync will rebuild the baseline from
-        // whatever snapshot row remains.
-        if let Err(e) = state.db.save_github_stats_snapshot(&current_snapshot).await {
-            eprintln!("Failed to save github stats snapshot: {}", e);
-        }
-
-        // Calculate diff and convert to StatsDiffResult using From trait
         let diff = current_snapshot.calculate_diff(previous_snapshot.as_ref());
         if diff.comparison_date.is_some() {
             Some(diff.into())

--- a/src-tauri/src/database/migrations.rs
+++ b/src-tauri/src/database/migrations.rs
@@ -328,6 +328,53 @@ ALTER TABLE sync_metadata ADD COLUMN last_skipped_reason TEXT;
 ALTER TABLE sync_metadata ADD COLUMN scheduler_baseline_at DATETIME;
 "#,
     },
+    Migration {
+        version: 12,
+        name: "consolidate_previous_github_stats_into_snapshots",
+        sql: r#"
+-- Consolidate the two stores of "previous GitHub stats" into
+-- `github_stats_snapshots` so XP diffs and the daily-comparison UI share
+-- a single source of truth.
+-- Related Issue: GitHub Issue #189 / Audit §9.2
+--
+-- 1. Extend `github_stats_snapshots` so it can serve as the XP base — we
+--    need `total_prs_merged` and `total_issues_closed` to compute the
+--    same XP breakdown the legacy KV path produced.
+ALTER TABLE github_stats_snapshots ADD COLUMN total_prs_merged INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE github_stats_snapshots ADD COLUMN total_issues_closed INTEGER NOT NULL DEFAULT 0;
+
+-- 2. Backfill the new columns on each user's most-recent snapshot from the
+--    legacy `previous_github_stats` KV (JSON, camelCase keys). Without
+--    this step, the first post-migration sync would diff against
+--    `prs_merged = 0` / `issues_closed = 0` and award XP for every
+--    historical merged PR / closed issue — a level-spamming regression
+--    for active users. Older snapshots stay at the default 0 because they
+--    are only used when even more recent rows are absent, and the diff
+--    UI doesn't surface these two metrics anyway.
+UPDATE github_stats_snapshots
+SET total_prs_merged = COALESCE(
+        (SELECT CAST(json_extract(ac.data_json, '$.totalPrsMerged') AS INTEGER)
+         FROM activity_cache ac
+         WHERE ac.user_id = github_stats_snapshots.user_id
+           AND ac.data_type = 'previous_github_stats'),
+        total_prs_merged
+    ),
+    total_issues_closed = COALESCE(
+        (SELECT CAST(json_extract(ac.data_json, '$.totalIssuesClosed') AS INTEGER)
+         FROM activity_cache ac
+         WHERE ac.user_id = github_stats_snapshots.user_id
+           AND ac.data_type = 'previous_github_stats'),
+        total_issues_closed
+    )
+WHERE id IN (
+    SELECT MAX(id) FROM github_stats_snapshots GROUP BY user_id
+);
+
+-- 3. Drop the legacy `previous_github_stats` KV now that snapshots carry
+--    the same information.
+DELETE FROM activity_cache WHERE data_type = 'previous_github_stats';
+"#,
+    },
 ];
 
 /// Create the migrations tracking table
@@ -450,6 +497,119 @@ mod tests {
         assert!(tables.contains(&"activity_cache".to_string()));
         assert!(tables.contains(&"app_settings".to_string()));
         assert!(tables.contains(&"_migrations".to_string()));
+    }
+
+    /// Issue #189 / migration v12: when an existing user has both a
+    /// `previous_github_stats` KV and a `github_stats_snapshots` row at
+    /// the time the migration runs, the new `total_prs_merged` and
+    /// `total_issues_closed` columns must be backfilled from the KV's
+    /// JSON onto the user's most-recent snapshot — otherwise the next
+    /// sync would compute the diff against `0` and award a one-time XP
+    /// burst for every historical merged PR / closed issue.
+    ///
+    /// The test re-runs the v12 backfill+delete block (which is
+    /// idempotent) on a freshly migrated DB seeded with a v11-shape
+    /// snapshot (prs_merged=0, issues_closed=0) plus a legacy KV.
+    #[tokio::test]
+    async fn test_migration_v12_backfills_prs_merged_and_issues_closed() {
+        let pool = create_test_pool().await;
+        run_migrations(&pool)
+            .await
+            .expect("Migrations should run cleanly");
+
+        sqlx::query(
+            "INSERT INTO users (github_id, username, access_token_encrypted) VALUES (?, ?, ?)",
+        )
+        .bind(12345_i64)
+        .bind("testuser")
+        .bind("encrypted")
+        .execute(&pool)
+        .await
+        .expect("Should insert user");
+
+        sqlx::query(
+            r#"INSERT INTO github_stats_snapshots
+               (user_id, total_commits, total_prs, total_prs_merged, total_reviews,
+                total_issues, total_issues_closed, total_stars_received,
+                total_contributions, snapshot_date)
+               VALUES (1, 100, 20, 0, 30, 15, 0, 50, 200, '2025-11-30')"#,
+        )
+        .execute(&pool)
+        .await
+        .expect("Should insert pre-v12-shape snapshot");
+
+        sqlx::query(
+            r#"INSERT INTO activity_cache
+               (user_id, data_type, data_json, fetched_at, expires_at)
+               VALUES (1, 'previous_github_stats',
+                       '{"totalPrsMerged":12,"totalIssuesClosed":8}',
+                       '2025-11-30T00:00:00Z', '2125-11-30T00:00:00Z')"#,
+        )
+        .execute(&pool)
+        .await
+        .expect("Should insert legacy KV");
+
+        // Re-apply the v12 backfill+delete tail. Both statements are
+        // idempotent (UPDATE COALESCEs to current value when the
+        // subquery returns NULL; DELETE on an empty result set is a
+        // no-op), so this also proves the v12 SQL itself is safe to
+        // re-run accidentally.
+        sqlx::query(
+            r#"
+            UPDATE github_stats_snapshots
+            SET total_prs_merged = COALESCE(
+                    (SELECT CAST(json_extract(ac.data_json, '$.totalPrsMerged') AS INTEGER)
+                     FROM activity_cache ac
+                     WHERE ac.user_id = github_stats_snapshots.user_id
+                       AND ac.data_type = 'previous_github_stats'),
+                    total_prs_merged
+                ),
+                total_issues_closed = COALESCE(
+                    (SELECT CAST(json_extract(ac.data_json, '$.totalIssuesClosed') AS INTEGER)
+                     FROM activity_cache ac
+                     WHERE ac.user_id = github_stats_snapshots.user_id
+                       AND ac.data_type = 'previous_github_stats'),
+                    total_issues_closed
+                )
+            WHERE id IN (
+                SELECT MAX(id) FROM github_stats_snapshots GROUP BY user_id
+            );
+            "#,
+        )
+        .execute(&pool)
+        .await
+        .expect("Backfill UPDATE should succeed");
+
+        sqlx::query("DELETE FROM activity_cache WHERE data_type = 'previous_github_stats'")
+            .execute(&pool)
+            .await
+            .expect("KV cleanup should succeed");
+
+        let (prs_merged, issues_closed): (i32, i32) = sqlx::query_as(
+            r#"SELECT total_prs_merged, total_issues_closed
+               FROM github_stats_snapshots
+               WHERE user_id = 1 AND snapshot_date = '2025-11-30'"#,
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("Snapshot should be queryable");
+
+        assert_eq!(
+            prs_merged, 12,
+            "total_prs_merged must be backfilled from the legacy KV"
+        );
+        assert_eq!(
+            issues_closed, 8,
+            "total_issues_closed must be backfilled from the legacy KV"
+        );
+
+        let kv_count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM activity_cache WHERE data_type = 'previous_github_stats'",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("Should count remaining KV rows");
+        assert_eq!(kv_count, 0, "Legacy KV must be deleted");
     }
 
     #[tokio::test]

--- a/src-tauri/src/database/migrations.rs
+++ b/src-tauri/src/database/migrations.rs
@@ -343,14 +343,46 @@ ALTER TABLE sync_metadata ADD COLUMN scheduler_baseline_at DATETIME;
 ALTER TABLE github_stats_snapshots ADD COLUMN total_prs_merged INTEGER NOT NULL DEFAULT 0;
 ALTER TABLE github_stats_snapshots ADD COLUMN total_issues_closed INTEGER NOT NULL DEFAULT 0;
 
--- 2. Backfill the new columns on each user's most-recent snapshot from the
---    legacy `previous_github_stats` KV (JSON, camelCase keys). Without
---    this step, the first post-migration sync would diff against
---    `prs_merged = 0` / `issues_closed = 0` and award XP for every
---    historical merged PR / closed issue — a level-spamming regression
---    for active users. Older snapshots stay at the default 0 because they
---    are only used when even more recent rows are absent, and the diff
---    UI doesn't surface these two metrics anyway.
+-- 2. Seed a snapshot for users who only have the legacy KV but no
+--    snapshot row. Without this fallback, step 4's DELETE would strip
+--    their only baseline and the first post-migration sync would treat
+--    them as a fresh user — re-awarding XP for their entire lifetime
+--    of activity. The JSON keys are camelCase (`#[serde(rename_all =
+--    "camelCase")]` on `GitHubStats`); `DATE(ac.fetched_at)` anchors
+--    the seed row to when the KV was last written, which approximates
+--    the user's last sync.
+INSERT INTO github_stats_snapshots (
+    user_id, total_commits, total_prs, total_prs_merged, total_reviews,
+    total_issues, total_issues_closed, total_stars_received,
+    total_contributions, snapshot_date
+)
+SELECT
+    ac.user_id,
+    COALESCE(CAST(json_extract(ac.data_json, '$.totalCommits')        AS INTEGER), 0),
+    COALESCE(CAST(json_extract(ac.data_json, '$.totalPrs')            AS INTEGER), 0),
+    COALESCE(CAST(json_extract(ac.data_json, '$.totalPrsMerged')      AS INTEGER), 0),
+    COALESCE(CAST(json_extract(ac.data_json, '$.totalReviews')        AS INTEGER), 0),
+    COALESCE(CAST(json_extract(ac.data_json, '$.totalIssues')         AS INTEGER), 0),
+    COALESCE(CAST(json_extract(ac.data_json, '$.totalIssuesClosed')   AS INTEGER), 0),
+    COALESCE(CAST(json_extract(ac.data_json, '$.totalStarsReceived')  AS INTEGER), 0),
+    COALESCE(CAST(json_extract(ac.data_json, '$.totalContributions')  AS INTEGER), 0),
+    DATE(ac.fetched_at)
+FROM activity_cache ac
+WHERE ac.data_type = 'previous_github_stats'
+  AND NOT EXISTS (
+      SELECT 1 FROM github_stats_snapshots s WHERE s.user_id = ac.user_id
+  );
+
+-- 3. Backfill `prs_merged` / `issues_closed` on each user's *latest*
+--    snapshot from the legacy KV. Picking by `MAX(snapshot_date)` (not
+--    `MAX(id)`) is required because `id` only reflects insert order —
+--    if a user backfilled an older date later, `MAX(id)` would land on
+--    that backdated row while the actual latest row stayed at default
+--    `0`, leaving the next sync to re-award XP for every historical
+--    merged PR / closed issue.
+--    Older snapshots stay at the default 0 because they are only used
+--    when even more recent rows are absent, and the diff UI doesn't
+--    surface these two metrics anyway.
 UPDATE github_stats_snapshots
 SET total_prs_merged = COALESCE(
         (SELECT CAST(json_extract(ac.data_json, '$.totalPrsMerged') AS INTEGER)
@@ -366,12 +398,16 @@ SET total_prs_merged = COALESCE(
            AND ac.data_type = 'previous_github_stats'),
         total_issues_closed
     )
-WHERE id IN (
-    SELECT MAX(id) FROM github_stats_snapshots GROUP BY user_id
+WHERE snapshot_date = (
+    SELECT MAX(s2.snapshot_date)
+    FROM github_stats_snapshots s2
+    WHERE s2.user_id = github_stats_snapshots.user_id
 );
 
--- 3. Drop the legacy `previous_github_stats` KV now that snapshots carry
---    the same information.
+-- 4. Drop the legacy `previous_github_stats` KV now that snapshots carry
+--    the same information. Safe because steps 2–3 guarantee every user
+--    that had a KV now has at least one snapshot row populated with
+--    that KV's `prs_merged` / `issues_closed` values.
 DELETE FROM activity_cache WHERE data_type = 'previous_github_stats';
 "#,
     },
@@ -571,8 +607,10 @@ mod tests {
                        AND ac.data_type = 'previous_github_stats'),
                     total_issues_closed
                 )
-            WHERE id IN (
-                SELECT MAX(id) FROM github_stats_snapshots GROUP BY user_id
+            WHERE snapshot_date = (
+                SELECT MAX(s2.snapshot_date)
+                FROM github_stats_snapshots s2
+                WHERE s2.user_id = github_stats_snapshots.user_id
             );
             "#,
         )
@@ -610,6 +648,202 @@ mod tests {
         .await
         .expect("Should count remaining KV rows");
         assert_eq!(kv_count, 0, "Legacy KV must be deleted");
+    }
+
+    /// Issue #189 / migration v12: when a user has older snapshots that
+    /// were inserted *after* the most recent one (e.g. a gap-fill
+    /// backfill writes a `2025-11-01` row long after `2025-11-30` was
+    /// already saved), the backfill must still target the row with the
+    /// latest `snapshot_date`. Picking `MAX(id)` would land on the
+    /// backdated row and leave the actual latest row at the default 0
+    /// — letting the next sync re-award lifetime XP.
+    #[tokio::test]
+    async fn test_migration_v12_targets_latest_snapshot_by_date_not_id() {
+        let pool = create_test_pool().await;
+        run_migrations(&pool)
+            .await
+            .expect("Migrations should run cleanly");
+
+        sqlx::query(
+            "INSERT INTO users (github_id, username, access_token_encrypted) VALUES (?, ?, ?)",
+        )
+        .bind(54321_i64)
+        .bind("backdater")
+        .bind("encrypted")
+        .execute(&pool)
+        .await
+        .expect("Should insert user");
+
+        // Insert "today" first (lower id, latest date), then a backdated
+        // older row (higher id, earlier date). MAX(id) would pick the
+        // backdated row; MAX(snapshot_date) correctly picks today.
+        sqlx::query(
+            r#"INSERT INTO github_stats_snapshots
+               (user_id, total_commits, total_prs, total_prs_merged, total_reviews,
+                total_issues, total_issues_closed, total_stars_received,
+                total_contributions, snapshot_date)
+               VALUES (1, 100, 20, 0, 30, 15, 0, 50, 200, '2025-11-30')"#,
+        )
+        .execute(&pool)
+        .await
+        .expect("Should insert today snapshot");
+
+        sqlx::query(
+            r#"INSERT INTO github_stats_snapshots
+               (user_id, total_commits, total_prs, total_prs_merged, total_reviews,
+                total_issues, total_issues_closed, total_stars_received,
+                total_contributions, snapshot_date)
+               VALUES (1, 50, 10, 0, 15, 8, 0, 25, 100, '2025-11-01')"#,
+        )
+        .execute(&pool)
+        .await
+        .expect("Should insert backdated snapshot");
+
+        sqlx::query(
+            r#"INSERT INTO activity_cache
+               (user_id, data_type, data_json, fetched_at, expires_at)
+               VALUES (1, 'previous_github_stats',
+                       '{"totalPrsMerged":12,"totalIssuesClosed":8}',
+                       '2025-11-30T00:00:00Z', '2125-11-30T00:00:00Z')"#,
+        )
+        .execute(&pool)
+        .await
+        .expect("Should insert legacy KV");
+
+        sqlx::query(
+            r#"
+            UPDATE github_stats_snapshots
+            SET total_prs_merged = COALESCE(
+                    (SELECT CAST(json_extract(ac.data_json, '$.totalPrsMerged') AS INTEGER)
+                     FROM activity_cache ac
+                     WHERE ac.user_id = github_stats_snapshots.user_id
+                       AND ac.data_type = 'previous_github_stats'),
+                    total_prs_merged
+                ),
+                total_issues_closed = COALESCE(
+                    (SELECT CAST(json_extract(ac.data_json, '$.totalIssuesClosed') AS INTEGER)
+                     FROM activity_cache ac
+                     WHERE ac.user_id = github_stats_snapshots.user_id
+                       AND ac.data_type = 'previous_github_stats'),
+                    total_issues_closed
+                )
+            WHERE snapshot_date = (
+                SELECT MAX(s2.snapshot_date)
+                FROM github_stats_snapshots s2
+                WHERE s2.user_id = github_stats_snapshots.user_id
+            );
+            "#,
+        )
+        .execute(&pool)
+        .await
+        .expect("Backfill UPDATE should succeed");
+
+        let (today_pm, today_ic): (i32, i32) = sqlx::query_as(
+            "SELECT total_prs_merged, total_issues_closed FROM github_stats_snapshots WHERE user_id = 1 AND snapshot_date = '2025-11-30'"
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("Should query today snapshot");
+
+        let (back_pm, back_ic): (i32, i32) = sqlx::query_as(
+            "SELECT total_prs_merged, total_issues_closed FROM github_stats_snapshots WHERE user_id = 1 AND snapshot_date = '2025-11-01'"
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("Should query backdated snapshot");
+
+        assert_eq!(today_pm, 12, "Latest-by-date row must be backfilled");
+        assert_eq!(today_ic, 8, "Latest-by-date row must be backfilled");
+        assert_eq!(back_pm, 0, "Backdated row must remain untouched");
+        assert_eq!(back_ic, 0, "Backdated row must remain untouched");
+    }
+
+    /// Issue #189 / migration v12: when a user has a `previous_github_stats`
+    /// KV but no snapshot row at all (possible if a prior snapshot save
+    /// failed and the error was swallowed), the migration must seed a
+    /// fallback snapshot from the KV's JSON before deleting the KV —
+    /// otherwise that user loses their only XP baseline and the first
+    /// post-migration sync re-awards lifetime XP.
+    #[tokio::test]
+    async fn test_migration_v12_seeds_snapshot_when_only_kv_exists() {
+        let pool = create_test_pool().await;
+        run_migrations(&pool)
+            .await
+            .expect("Migrations should run cleanly");
+
+        sqlx::query(
+            "INSERT INTO users (github_id, username, access_token_encrypted) VALUES (?, ?, ?)",
+        )
+        .bind(99999_i64)
+        .bind("kvonly")
+        .bind("encrypted")
+        .execute(&pool)
+        .await
+        .expect("Should insert user");
+
+        sqlx::query(
+            r#"INSERT INTO activity_cache
+               (user_id, data_type, data_json, fetched_at, expires_at)
+               VALUES (1, 'previous_github_stats',
+                       '{"totalCommits":50,"totalPrs":7,"totalPrsMerged":4,"totalReviews":11,"totalIssues":3,"totalIssuesClosed":2,"totalStarsReceived":18,"totalContributions":80}',
+                       '2025-11-29T12:00:00Z', '2125-11-29T12:00:00Z')"#,
+        )
+        .execute(&pool)
+        .await
+        .expect("Should insert legacy KV");
+
+        // Re-run the v12 seed step (idempotent: NOT EXISTS guards a re-insert).
+        sqlx::query(
+            r#"
+            INSERT INTO github_stats_snapshots (
+                user_id, total_commits, total_prs, total_prs_merged, total_reviews,
+                total_issues, total_issues_closed, total_stars_received,
+                total_contributions, snapshot_date
+            )
+            SELECT
+                ac.user_id,
+                COALESCE(CAST(json_extract(ac.data_json, '$.totalCommits')        AS INTEGER), 0),
+                COALESCE(CAST(json_extract(ac.data_json, '$.totalPrs')            AS INTEGER), 0),
+                COALESCE(CAST(json_extract(ac.data_json, '$.totalPrsMerged')      AS INTEGER), 0),
+                COALESCE(CAST(json_extract(ac.data_json, '$.totalReviews')        AS INTEGER), 0),
+                COALESCE(CAST(json_extract(ac.data_json, '$.totalIssues')         AS INTEGER), 0),
+                COALESCE(CAST(json_extract(ac.data_json, '$.totalIssuesClosed')   AS INTEGER), 0),
+                COALESCE(CAST(json_extract(ac.data_json, '$.totalStarsReceived')  AS INTEGER), 0),
+                COALESCE(CAST(json_extract(ac.data_json, '$.totalContributions')  AS INTEGER), 0),
+                DATE(ac.fetched_at)
+            FROM activity_cache ac
+            WHERE ac.data_type = 'previous_github_stats'
+              AND NOT EXISTS (
+                  SELECT 1 FROM github_stats_snapshots s WHERE s.user_id = ac.user_id
+              );
+            "#,
+        )
+        .execute(&pool)
+        .await
+        .expect("Seed INSERT should succeed");
+
+        let row: (i32, i32, i32, i32, i32, i32, i32, i32, String) = sqlx::query_as(
+            r#"SELECT total_commits, total_prs, total_prs_merged, total_reviews,
+                      total_issues, total_issues_closed, total_stars_received,
+                      total_contributions, snapshot_date
+               FROM github_stats_snapshots WHERE user_id = 1"#,
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("Seeded snapshot should exist");
+
+        assert_eq!(row.0, 50);
+        assert_eq!(row.1, 7);
+        assert_eq!(row.2, 4);
+        assert_eq!(row.3, 11);
+        assert_eq!(row.4, 3);
+        assert_eq!(row.5, 2);
+        assert_eq!(row.6, 18);
+        assert_eq!(row.7, 80);
+        assert_eq!(
+            row.8, "2025-11-29",
+            "snapshot_date must come from DATE(fetched_at)"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/database/models/github_stats_snapshot.rs
+++ b/src-tauri/src/database/models/github_stats_snapshot.rs
@@ -17,7 +17,10 @@ use serde::{Deserialize, Serialize};
 /// GitHub statistics snapshot for a specific date
 ///
 /// Stores a point-in-time snapshot of user's GitHub statistics.
-/// Used for calculating day-over-day differences.
+/// Used for both calculating day-over-day differences (display) and
+/// computing XP diffs across syncs (Issue #189 — single source of truth
+/// for "previous GitHub stats", replacing the legacy
+/// `previous_github_stats` KV in `activity_cache`).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GitHubStatsSnapshot {
@@ -25,8 +28,14 @@ pub struct GitHubStatsSnapshot {
     pub user_id: i64,
     pub total_commits: i32,
     pub total_prs: i32,
+    /// Cumulative merged PRs. Required for XP calculation; not surfaced
+    /// in the daily-comparison UI.
+    pub total_prs_merged: i32,
     pub total_reviews: i32,
     pub total_issues: i32,
+    /// Cumulative closed issues. Required for XP calculation; not surfaced
+    /// in the daily-comparison UI.
+    pub total_issues_closed: i32,
     pub total_stars_received: i32,
     pub total_contributions: i32,
     /// Snapshot date in YYYY-MM-DD format
@@ -53,12 +62,15 @@ pub struct StatsDiff {
 
 impl GitHubStatsSnapshot {
     /// Create a new snapshot from current GitHub stats
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         user_id: i64,
         total_commits: i32,
         total_prs: i32,
+        total_prs_merged: i32,
         total_reviews: i32,
         total_issues: i32,
+        total_issues_closed: i32,
         total_stars_received: i32,
         total_contributions: i32,
         snapshot_date: &str,
@@ -68,8 +80,10 @@ impl GitHubStatsSnapshot {
             user_id,
             total_commits,
             total_prs,
+            total_prs_merged,
             total_reviews,
             total_issues,
+            total_issues_closed,
             total_stars_received,
             total_contributions,
             snapshot_date: snapshot_date.to_string(),
@@ -130,8 +144,10 @@ mod tests {
             1,   // user_id
             100, // commits
             20,  // prs
+            12,  // prs_merged
             30,  // reviews
             15,  // issues
+            8,   // issues_closed
             50,  // stars
             200, // contributions
             "2025-11-30",
@@ -140,8 +156,10 @@ mod tests {
         assert_eq!(snapshot.user_id, 1);
         assert_eq!(snapshot.total_commits, 100);
         assert_eq!(snapshot.total_prs, 20);
+        assert_eq!(snapshot.total_prs_merged, 12);
         assert_eq!(snapshot.total_reviews, 30);
         assert_eq!(snapshot.total_issues, 15);
+        assert_eq!(snapshot.total_issues_closed, 8);
         assert_eq!(snapshot.total_stars_received, 50);
         assert_eq!(snapshot.total_contributions, 200);
         assert_eq!(snapshot.snapshot_date, "2025-11-30");
@@ -155,8 +173,10 @@ mod tests {
             user_id: 1,
             total_commits: 90,
             total_prs: 18,
+            total_prs_merged: 10,
             total_reviews: 25,
             total_issues: 12,
+            total_issues_closed: 6,
             total_stars_received: 45,
             total_contributions: 180,
             snapshot_date: "2025-11-29".to_string(),
@@ -167,8 +187,10 @@ mod tests {
             1,
             100, // +10 commits
             20,  // +2 prs
+            12,  // +2 prs_merged
             30,  // +5 reviews
             15,  // +3 issues
+            8,   // +2 issues_closed
             50,  // +5 stars
             200, // +20 contributions
             "2025-11-30",
@@ -188,7 +210,7 @@ mod tests {
     // TC-003: calculate_diff without previous snapshot
     #[test]
     fn test_calculate_diff_without_previous() {
-        let current = GitHubStatsSnapshot::new(1, 100, 20, 30, 15, 50, 200, "2025-11-30");
+        let current = GitHubStatsSnapshot::new(1, 100, 20, 12, 30, 15, 8, 50, 200, "2025-11-30");
 
         let diff = current.calculate_diff(None);
 
@@ -255,8 +277,10 @@ mod tests {
             user_id: 1,
             total_commits: 100,
             total_prs: 20,
+            total_prs_merged: 12,
             total_reviews: 30,
             total_issues: 15,
+            total_issues_closed: 8,
             total_stars_received: 50,
             total_contributions: 200,
             snapshot_date: "2025-11-29".to_string(),
@@ -268,8 +292,10 @@ mod tests {
             1,
             100, // no change
             20,  // no change
+            12,  // no change
             30,  // no change
             15,  // no change
+            8,   // no change
             45,  // -5 stars
             200, // no change
             "2025-11-30",

--- a/src-tauri/src/database/models/github_stats_snapshot.spec.md
+++ b/src-tauri/src/database/models/github_stats_snapshot.spec.md
@@ -3,40 +3,60 @@
 ## Related Files
 
 - Implementation: `src-tauri/src/database/models/github_stats_snapshot.rs`
-- Migration: `src-tauri/src/database/migrations.rs` (version 6)
+- Migration: `src-tauri/src/database/migrations.rs` (version 6 = テーブル作成 / version 12 = `prs_merged`・`issues_closed` 追加 + 旧 `previous_github_stats` KV 廃止)
 - Repository: `src-tauri/src/database/repository/github_stats_snapshot.rs`
+- Caller: `src-tauri/src/commands/github.rs` (`run_github_sync`)
 - Model Tests: `src-tauri/src/database/models/github_stats_snapshot.rs` (tests module)
 - Repository Tests: `src-tauri/src/database/repository/github_stats_snapshot.rs` (tests module)
 
 ## Related Documentation
 
 - Issue: `docs/01_issues/open/2025_11/20251129_02_github-stats-daily-comparison.md`
-- GitHub Issue: #35
+- GitHub Issue: #35（初版）, #189（旧 `previous_github_stats` KV との統合）
+- 監査レポート: `docs/02_research/2026_04/20260425_github_integration_audit.md` §9.2
 
 ## Requirements
 
 ### 責務
 
 - GitHub 統計の日次スナップショットを保存・管理
-- 前日比（差分）計算のための基準データを提供
+- 前日比（差分）計算のための基準データを提供（UI 表示）
+- **同期間の XP 差分計算の基準データを提供**（Issue #189 で `previous_github_stats` KV から統合された責務）
 - ユーザーごとの統計履歴を追跡
+
+### 「前回値」の単一情報源 (SSoT)
+
+Issue #189 までは「前回値」を 2 箇所に保持していた：
+
+- `previous_github_stats`（`activity_cache` 内の KV、JSON 文字列） — XP 算出用
+- `github_stats_snapshots`（本テーブル、日次 unique） — 前日比表示用
+
+整合性事故の温床になっていたため、Issue #189 で本テーブルに統合した。
+KV は migration v12 で削除済み。
+
+XP 差分の取得方法は呼び出し側で 2 通りに分かれる:
+
+- **XP 算出用ベース**: `get_latest_github_stats_snapshot(user_id)` — 日付に関係なく最新行を返す。同日中に複数回 sync しても 2 回目以降は同日の更新済み行と差分を取るため、二重加算を防ぐ。
+- **前日比表示用ベース**: `get_previous_github_stats_snapshot(user_id, today)` — 「今日より前」の最新行を返す。同日中に何度 sync しても表示は「昨日との差分」で安定する。
 
 ### 状態構造
 
 #### GitHubStatsSnapshot
 
-| フィールド           | 型     | 説明                              |
-| -------------------- | ------ | --------------------------------- |
-| id                   | i64    | プライマリキー                    |
-| user_id              | i64    | ユーザー ID（外部キー）           |
-| total_commits        | i32    | 累計コミット数                    |
-| total_prs            | i32    | 累計 PR 数                        |
-| total_reviews        | i32    | 累計レビュー数                    |
-| total_issues         | i32    | 累計 Issue 数                     |
-| total_stars_received | i32    | 累計獲得スター数                  |
-| total_contributions  | i32    | 累計コントリビューション数        |
-| snapshot_date        | String | スナップショット日付 (YYYY-MM-DD) |
-| created_at           | String | 作成日時                          |
+| フィールド            | 型     | 説明                                                                             |
+| --------------------- | ------ | -------------------------------------------------------------------------------- |
+| id                    | i64    | プライマリキー                                                                   |
+| user_id               | i64    | ユーザー ID（外部キー）                                                          |
+| total_commits         | i32    | 累計コミット数                                                                   |
+| total_prs             | i32    | 累計 PR 数                                                                       |
+| total_prs_merged      | i32    | 累計マージ済み PR 数 — XP 算出用 (Issue #189)。前日比 UI には出ない              |
+| total_reviews         | i32    | 累計レビュー数                                                                   |
+| total_issues          | i32    | 累計 Issue 数                                                                    |
+| total_issues_closed   | i32    | 累計クローズ済み Issue 数 — XP 算出用 (Issue #189)。前日比 UI には出ない         |
+| total_stars_received  | i32    | 累計獲得スター数                                                                 |
+| total_contributions   | i32    | 累計コントリビューション数                                                       |
+| snapshot_date         | String | スナップショット日付 (YYYY-MM-DD)                                                |
+| created_at            | String | 作成日時                                                                         |
 
 #### StatsDiff
 
@@ -54,8 +74,15 @@
 
 #### GitHubStatsSnapshot
 
-- `new(user_id, total_commits, total_prs, total_reviews, total_issues, total_stars_received, total_contributions, snapshot_date)`: 各統計値からスナップショットを作成
-- `calculate_diff(previous)`: 前のスナップショットとの差分を計算
+- `new(user_id, total_commits, total_prs, total_prs_merged, total_reviews, total_issues, total_issues_closed, total_stars_received, total_contributions, snapshot_date)`: 各統計値からスナップショットを作成
+- `calculate_diff(previous)`: 前のスナップショットとの差分（前日比 UI 用）を計算
+
+#### Repository (`Database`)
+
+- `save_github_stats_snapshot(snapshot)`: UPSERT で日次スナップショットを保存
+- `get_previous_github_stats_snapshot(user_id, before_date)`: 指定日より前の最新行を返す（前日比表示用）
+- `get_latest_github_stats_snapshot(user_id)`: 日付に関係なく最新行を返す（XP 算出用）
+- `get_github_stats_snapshot_for_date(user_id, date)`: 特定日のスナップショットを取得
 
 #### StatsDiff
 

--- a/src-tauri/src/database/models/xp.rs
+++ b/src-tauri/src/database/models/xp.rs
@@ -148,6 +148,16 @@ pub struct XpBreakdown {
 impl XpBreakdown {
     /// 同期で得た差分活動量から XP 内訳を算出する。
     ///
+    /// # 引数の型について
+    ///
+    /// 各カウント引数は意味的に「非負の差分」であり、`u64` を要求する。
+    /// 呼び出し側（`run_github_sync`）は `u64::saturating_sub` で前回値からの
+    /// 差分を取り、累計値が同期間に減少したケース（例: スターを失う、
+    /// repository 削除）でも 0 にクランプする。これにより
+    /// `XpBreakdown` の各フィールドが常に非負になる（Issue #189 / DoD）。
+    /// 旧 `i32` シグネチャの時代は `XpBreakdown` 内部に負値が現れる可能性が
+    /// 残っており、`if xp_gained > 0` の DB 加算ガードに依存していた。
+    ///
     /// # 戻り値の `total_xp` について
     ///
     /// `total_xp = (各活動 XP の合計) + streak_bonus_xp` であり、**ここで計算する
@@ -160,57 +170,65 @@ impl XpBreakdown {
     /// - 表示用合計を作る際は `total_xp + 外部ボーナス` と明示的に組み立てる
     ///
     /// 二重計上を避けるため、本関数の戻り値の `streak_bonus_xp` を再度足さないこと。
+    #[allow(clippy::too_many_arguments)]
     pub fn calculate(
-        commits: i32,
-        prs_created: i32,
-        prs_merged: i32,
-        issues_created: i32,
-        issues_closed: i32,
-        reviews: i32,
-        stars: i32,
+        commits: u64,
+        prs_created: u64,
+        prs_merged: u64,
+        issues_created: u64,
+        issues_closed: u64,
+        reviews: u64,
+        stars: u64,
         streak: i32,
     ) -> Self {
-        // 入力カウントが極端に大きいケース（API 側に上限がない、または将来の拡張）でも
-        // 個別積・合計でラップアラウンドしないよう、内部計算はすべて i64 で行う。
-        // 構造体フィールドは i32 のため、最後に saturating でクランプして格納する。
-        let saturate = |v: i64| v.clamp(i32::MIN as i64, i32::MAX as i64) as i32;
+        // 入力カウントが極端に大きいケースでも個別積・合計でラップアラウンド
+        // しないよう、内部計算はすべて u64 + saturating で行う。
+        // 構造体フィールドは i32 のため、最後に i32::MAX で飽和して格納する。
+        let saturate_u64_to_i32 = |v: u64| {
+            if v > i32::MAX as u64 {
+                i32::MAX
+            } else {
+                v as i32
+            }
+        };
 
-        let commits_xp_i64 = commits as i64 * COMMIT_XP as i64;
-        let prs_created_xp_i64 = prs_created as i64 * PR_XP as i64;
-        let prs_merged_xp_i64 = prs_merged as i64 * PR_MERGED_XP as i64;
-        let issues_created_xp_i64 = issues_created as i64 * ISSUE_XP as i64;
-        let issues_closed_xp_i64 = issues_closed as i64 * ISSUE_CLOSED_XP as i64;
-        let reviews_xp_i64 = reviews as i64 * REVIEW_XP as i64;
-        let stars_xp_i64 = stars as i64 * STAR_XP as i64;
+        // XP 定数は正の小整数なので u64 へキャストしても情報落ちはない。
+        let commits_xp = commits.saturating_mul(COMMIT_XP as u64);
+        let prs_created_xp = prs_created.saturating_mul(PR_XP as u64);
+        let prs_merged_xp = prs_merged.saturating_mul(PR_MERGED_XP as u64);
+        let issues_created_xp = issues_created.saturating_mul(ISSUE_XP as u64);
+        let issues_closed_xp = issues_closed.saturating_mul(ISSUE_CLOSED_XP as u64);
+        let reviews_xp = reviews.saturating_mul(REVIEW_XP as u64);
+        let stars_xp = stars.saturating_mul(STAR_XP as u64);
 
-        let base_total_i64 = commits_xp_i64
-            + prs_created_xp_i64
-            + prs_merged_xp_i64
-            + issues_created_xp_i64
-            + issues_closed_xp_i64
-            + reviews_xp_i64
-            + stars_xp_i64;
+        let base_total = commits_xp
+            .saturating_add(prs_created_xp)
+            .saturating_add(prs_merged_xp)
+            .saturating_add(issues_created_xp)
+            .saturating_add(issues_closed_xp)
+            .saturating_add(reviews_xp)
+            .saturating_add(stars_xp);
 
         // ストリークボーナス: `base_total * min(streak, STREAK_BONUS_CAP_DAYS) / 100`。
         // 1 日あたり +1%、上限 `STREAK_BONUS_CAP_DAYS`% (= 10%)。
-        let streak_bonus_xp_i64 = if streak > 0 {
-            (base_total_i64 * streak.min(STREAK_BONUS_CAP_DAYS) as i64) / 100
-        } else {
-            0
-        };
+        // streak は `streak.max(0)` 相当に正規化したうえで掛け算する。
+        let capped_streak_days = streak.clamp(0, STREAK_BONUS_CAP_DAYS) as u64;
+        let streak_bonus_xp = base_total
+            .saturating_mul(capped_streak_days)
+            / 100;
 
-        let total_xp_i64 = base_total_i64 + streak_bonus_xp_i64;
+        let total_xp = base_total.saturating_add(streak_bonus_xp);
 
         Self {
-            commits_xp: saturate(commits_xp_i64),
-            prs_created_xp: saturate(prs_created_xp_i64),
-            prs_merged_xp: saturate(prs_merged_xp_i64),
-            issues_created_xp: saturate(issues_created_xp_i64),
-            issues_closed_xp: saturate(issues_closed_xp_i64),
-            reviews_xp: saturate(reviews_xp_i64),
-            stars_xp: saturate(stars_xp_i64),
-            streak_bonus_xp: saturate(streak_bonus_xp_i64),
-            total_xp: saturate(total_xp_i64),
+            commits_xp: saturate_u64_to_i32(commits_xp),
+            prs_created_xp: saturate_u64_to_i32(prs_created_xp),
+            prs_merged_xp: saturate_u64_to_i32(prs_merged_xp),
+            issues_created_xp: saturate_u64_to_i32(issues_created_xp),
+            issues_closed_xp: saturate_u64_to_i32(issues_closed_xp),
+            reviews_xp: saturate_u64_to_i32(reviews_xp),
+            stars_xp: saturate_u64_to_i32(stars_xp),
+            streak_bonus_xp: saturate_u64_to_i32(streak_bonus_xp),
+            total_xp: saturate_u64_to_i32(total_xp),
         }
     }
 }
@@ -293,9 +311,72 @@ mod tests {
     #[test]
     fn test_breakdown_saturates_on_overflow() {
         // i32::MAX 個のコミット × COMMIT_XP(=10) は i32 範囲を大きく超えるが、
-        // 内部 i64 計算 → 末端 saturating cast によってラップアラウンドせず i32::MAX に丸まる。
-        let bd = XpBreakdown::calculate(i32::MAX, 0, 0, 0, 0, 0, 0, 0);
+        // 内部 u64 計算 → 末端 saturating cast によってラップアラウンドせず i32::MAX に丸まる。
+        let bd = XpBreakdown::calculate(i32::MAX as u64, 0, 0, 0, 0, 0, 0, 0);
         assert_eq!(bd.commits_xp, i32::MAX);
         assert_eq!(bd.total_xp, i32::MAX);
+    }
+
+    // Issue #189 / DoD: `XpBreakdown` の各フィールドが非負であることを保証する。
+    // u64 シグネチャに変更したため、入力レベルで負値が表現できず、
+    // 内部計算（`saturating_mul` / `saturating_add`）も非負を保つ。
+    #[test]
+    fn test_breakdown_fields_are_non_negative() {
+        // ゼロ入力
+        let zero = XpBreakdown::calculate(0, 0, 0, 0, 0, 0, 0, 0);
+        for field in [
+            zero.commits_xp,
+            zero.prs_created_xp,
+            zero.prs_merged_xp,
+            zero.issues_created_xp,
+            zero.issues_closed_xp,
+            zero.reviews_xp,
+            zero.stars_xp,
+            zero.streak_bonus_xp,
+            zero.total_xp,
+        ] {
+            assert!(field >= 0, "XpBreakdown field must be >= 0 (got {})", field);
+        }
+
+        // 中間的な入力
+        let typical = XpBreakdown::calculate(7, 3, 2, 5, 4, 6, 1, 5);
+        for field in [
+            typical.commits_xp,
+            typical.prs_created_xp,
+            typical.prs_merged_xp,
+            typical.issues_created_xp,
+            typical.issues_closed_xp,
+            typical.reviews_xp,
+            typical.stars_xp,
+            typical.streak_bonus_xp,
+            typical.total_xp,
+        ] {
+            assert!(field >= 0, "XpBreakdown field must be >= 0 (got {})", field);
+        }
+
+        // 飽和入力でも非負
+        let saturated = XpBreakdown::calculate(u64::MAX, u64::MAX, u64::MAX, u64::MAX, u64::MAX, u64::MAX, u64::MAX, 100);
+        for field in [
+            saturated.commits_xp,
+            saturated.prs_created_xp,
+            saturated.prs_merged_xp,
+            saturated.issues_created_xp,
+            saturated.issues_closed_xp,
+            saturated.reviews_xp,
+            saturated.stars_xp,
+            saturated.streak_bonus_xp,
+            saturated.total_xp,
+        ] {
+            assert!(field >= 0, "XpBreakdown field must be >= 0 (got {})", field);
+        }
+    }
+
+    // Issue #189: 負のストリーク値が混入しても 0 にクランプされ、
+    // streak_bonus_xp が負にならない。
+    #[test]
+    fn test_breakdown_negative_streak_clamped_to_zero_bonus() {
+        let bd = XpBreakdown::calculate(1, 1, 1, 1, 1, 1, 1, -42);
+        assert_eq!(bd.streak_bonus_xp, 0);
+        assert_eq!(bd.total_xp, 175);
     }
 }

--- a/src-tauri/src/database/models/xp.rs
+++ b/src-tauri/src/database/models/xp.rs
@@ -213,9 +213,7 @@ impl XpBreakdown {
         // 1 日あたり +1%、上限 `STREAK_BONUS_CAP_DAYS`% (= 10%)。
         // streak は `streak.max(0)` 相当に正規化したうえで掛け算する。
         let capped_streak_days = streak.clamp(0, STREAK_BONUS_CAP_DAYS) as u64;
-        let streak_bonus_xp = base_total
-            .saturating_mul(capped_streak_days)
-            / 100;
+        let streak_bonus_xp = base_total.saturating_mul(capped_streak_days) / 100;
 
         let total_xp = base_total.saturating_add(streak_bonus_xp);
 
@@ -355,7 +353,16 @@ mod tests {
         }
 
         // 飽和入力でも非負
-        let saturated = XpBreakdown::calculate(u64::MAX, u64::MAX, u64::MAX, u64::MAX, u64::MAX, u64::MAX, u64::MAX, 100);
+        let saturated = XpBreakdown::calculate(
+            u64::MAX,
+            u64::MAX,
+            u64::MAX,
+            u64::MAX,
+            u64::MAX,
+            u64::MAX,
+            u64::MAX,
+            100,
+        );
         for field in [
             saturated.commits_xp,
             saturated.prs_created_xp,

--- a/src-tauri/src/database/models/xp.spec.md
+++ b/src-tauri/src/database/models/xp.spec.md
@@ -11,8 +11,8 @@
 ## Related Documentation
 
 - 公式 XP 仕様: `docs/prd/home-gamification.md` §3.3.2 経験値（XP）テーブル
-- 監査レポート: `docs/02_research/2026_04/20260425_github_integration_audit.md` §6.1 / §8 G-14
-- GitHub Issue: #184
+- 監査レポート: `docs/02_research/2026_04/20260425_github_integration_audit.md` §6.1 / §8 G-14 / §9.2
+- GitHub Issue: #184（XP ルール固定化）, #189（`XpBreakdown::calculate` を `u64` 化し負値を排除）
 
 ## 責務
 
@@ -75,7 +75,10 @@ streak_bonus_xp = base_total * min(streak, STREAK_BONUS_CAP_DAYS) / 100
 - `XpActionType` — DB の `xp_history.action_type` 文字列にマッピングされる enum
 - `XpHistoryEntry` — 履歴 1 行のドメインモデル
 - `XpBreakdown` — sync 結果に含まれる XP 内訳
-  - `XpBreakdown::calculate(commits, prs_created, prs_merged, issues_created, issues_closed, reviews, stars, streak)` で生成
+  - `XpBreakdown::calculate(commits: u64, prs_created: u64, prs_merged: u64, issues_created: u64, issues_closed: u64, reviews: u64, stars: u64, streak: i32)` で生成
+  - 各カウント引数は **意味的に「非負の差分」**。Issue #189 で旧 `i32` から `u64` に変更し、`XpBreakdown` 内部に負値が残らないことを型レベルで保証する。
+  - 呼び出し側 (`run_github_sync`) は `u64::saturating_sub` で前回値からの差分を取り、累計値が同期間に減少したケース（例: スターを失う、repository 削除）でも 0 にクランプする。
+  - `streak` だけは `i32` のまま — 負値が混入しても内部で `0` にクランプされ `streak_bonus_xp = 0` になる。
 
 ## マイグレーション方針
 
@@ -91,6 +94,13 @@ streak_bonus_xp = base_total * min(streak, STREAK_BONUS_CAP_DAYS) / 100
   などの累計カウント** を参照しており、XP 値そのものには依存していない。
 - したがって、本変更によるバッジ獲得条件の動作変更はない。
 
+## 「前回値」の単一情報源 (SSoT)
+
+XP 算出は `github_stats_snapshots` の最新行（`get_latest_github_stats_snapshot`）から
+`u64::saturating_sub` で差分を取る。Issue #189 で旧 `previous_github_stats` KV を
+廃止し、本テーブルへ統合した。詳細は
+`src-tauri/src/database/models/github_stats_snapshot.spec.md` を参照。
+
 ## テスト観点
 
 - `tests::test_xp_constants_match_spec` — 定数値が仕様表と一致することを保証
@@ -98,4 +108,6 @@ streak_bonus_xp = base_total * min(streak, STREAK_BONUS_CAP_DAYS) / 100
 - `tests::test_breakdown_with_streak` — ストリーク 5 日のときのボーナス計算
 - `tests::test_breakdown_streak_capped_at_10_days` — ストリーク 10 日超でも 10 日でキャップ
 - `tests::test_breakdown_uses_constants_not_hardcoded` — `XpBreakdown::calculate` がハードコードでなく定数を参照することを保証
-- `tests::test_breakdown_saturates_on_overflow` — `i32::MAX` 入力でラップアラウンドせず `i32::MAX` に飽和することを保証
+- `tests::test_breakdown_saturates_on_overflow` — `u64::MAX` 相当の入力でラップアラウンドせず `i32::MAX` に飽和することを保証
+- `tests::test_breakdown_fields_are_non_negative` — `XpBreakdown` の全フィールドが非負であることを保証（Issue #189 / DoD）
+- `tests::test_breakdown_negative_streak_clamped_to_zero_bonus` — 負のストリークでも `streak_bonus_xp = 0` にクランプされ、負値にならないことを保証

--- a/src-tauri/src/database/repository/cache.rs
+++ b/src-tauri/src/database/repository/cache.rs
@@ -72,32 +72,6 @@ impl Database {
         Ok(result.rows_affected())
     }
 
-    /// Save previous GitHub stats (for diff calculation)
-    /// Uses activity_cache with a very long expiry to persist stats
-    pub async fn save_previous_github_stats(&self, user_id: i64, stats_json: &str) -> DbResult<()> {
-        // Set expiry to 100 years in the future (effectively permanent)
-        let expires = Utc::now() + chrono::Duration::days(36500);
-        self.save_cache(user_id, "previous_github_stats", stats_json, expires)
-            .await
-    }
-
-    /// Get previous GitHub stats (for diff calculation)
-    pub async fn get_previous_github_stats(&self, user_id: i64) -> DbResult<Option<String>> {
-        // Get cache without expiry check (we use a very long expiry)
-        let result: Option<String> = sqlx::query_scalar(
-            r#"
-            SELECT data_json FROM activity_cache
-            WHERE user_id = ? AND data_type = 'previous_github_stats'
-            "#,
-        )
-        .bind(user_id)
-        .fetch_optional(self.pool())
-        .await
-        .map_err(|e| DatabaseError::Query(e.to_string()))?;
-
-        Ok(result)
-    }
-
     /// Get cache size for a user
     pub async fn get_user_cache_size(&self, user_id: i64) -> DbResult<u64> {
         let result: i64 = sqlx::query_scalar(

--- a/src-tauri/src/database/repository/github_stats_snapshot.rs
+++ b/src-tauri/src/database/repository/github_stats_snapshot.rs
@@ -27,15 +27,18 @@ impl Database {
         sqlx::query(
             r#"
             INSERT INTO github_stats_snapshots (
-                user_id, total_commits, total_prs, total_reviews, 
-                total_issues, total_stars_received, total_contributions, snapshot_date
+                user_id, total_commits, total_prs, total_prs_merged, total_reviews,
+                total_issues, total_issues_closed, total_stars_received,
+                total_contributions, snapshot_date
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(user_id, snapshot_date) DO UPDATE SET
                 total_commits = excluded.total_commits,
                 total_prs = excluded.total_prs,
+                total_prs_merged = excluded.total_prs_merged,
                 total_reviews = excluded.total_reviews,
                 total_issues = excluded.total_issues,
+                total_issues_closed = excluded.total_issues_closed,
                 total_stars_received = excluded.total_stars_received,
                 total_contributions = excluded.total_contributions
             "#,
@@ -43,8 +46,10 @@ impl Database {
         .bind(snapshot.user_id)
         .bind(snapshot.total_commits)
         .bind(snapshot.total_prs)
+        .bind(snapshot.total_prs_merged)
         .bind(snapshot.total_reviews)
         .bind(snapshot.total_issues)
+        .bind(snapshot.total_issues_closed)
         .bind(snapshot.total_stars_received)
         .bind(snapshot.total_contributions)
         .bind(&snapshot.snapshot_date)
@@ -56,8 +61,8 @@ impl Database {
 
     /// Get the most recent snapshot before a given date
     ///
-    /// Used for calculating day-over-day differences.
-    /// Returns None if no previous snapshot exists.
+    /// Used for the daily-comparison UI (e.g. "+5 commits vs yesterday").
+    /// Returns None if no previous-day snapshot exists.
     pub async fn get_previous_github_stats_snapshot(
         &self,
         user_id: i64,
@@ -65,8 +70,9 @@ impl Database {
     ) -> DbResult<Option<GitHubStatsSnapshot>> {
         let row = sqlx::query(
             r#"
-            SELECT id, user_id, total_commits, total_prs, total_reviews,
-                   total_issues, total_stars_received, total_contributions,
+            SELECT id, user_id, total_commits, total_prs, total_prs_merged,
+                   total_reviews, total_issues, total_issues_closed,
+                   total_stars_received, total_contributions,
                    snapshot_date, created_at
             FROM github_stats_snapshots
             WHERE user_id = ? AND snapshot_date < ?
@@ -79,18 +85,36 @@ impl Database {
         .fetch_optional(self.pool())
         .await?;
 
-        Ok(row.map(|r| GitHubStatsSnapshot {
-            id: r.get("id"),
-            user_id: r.get("user_id"),
-            total_commits: r.get("total_commits"),
-            total_prs: r.get("total_prs"),
-            total_reviews: r.get("total_reviews"),
-            total_issues: r.get("total_issues"),
-            total_stars_received: r.get("total_stars_received"),
-            total_contributions: r.get("total_contributions"),
-            snapshot_date: r.get("snapshot_date"),
-            created_at: r.get("created_at"),
-        }))
+        Ok(row.map(map_snapshot_row))
+    }
+
+    /// Get the most recent snapshot for a user, regardless of date.
+    ///
+    /// Used as the XP-diff base by `run_github_sync` (Issue #189). When the
+    /// user has already synced earlier today, this returns *today's* row
+    /// rather than yesterday's, so successive syncs don't double-count
+    /// activity that's already been awarded XP.
+    pub async fn get_latest_github_stats_snapshot(
+        &self,
+        user_id: i64,
+    ) -> DbResult<Option<GitHubStatsSnapshot>> {
+        let row = sqlx::query(
+            r#"
+            SELECT id, user_id, total_commits, total_prs, total_prs_merged,
+                   total_reviews, total_issues, total_issues_closed,
+                   total_stars_received, total_contributions,
+                   snapshot_date, created_at
+            FROM github_stats_snapshots
+            WHERE user_id = ?
+            ORDER BY snapshot_date DESC
+            LIMIT 1
+            "#,
+        )
+        .bind(user_id)
+        .fetch_optional(self.pool())
+        .await?;
+
+        Ok(row.map(map_snapshot_row))
     }
 
     /// Get a snapshot for a specific date
@@ -103,8 +127,9 @@ impl Database {
     ) -> DbResult<Option<GitHubStatsSnapshot>> {
         let row = sqlx::query(
             r#"
-            SELECT id, user_id, total_commits, total_prs, total_reviews,
-                   total_issues, total_stars_received, total_contributions,
+            SELECT id, user_id, total_commits, total_prs, total_prs_merged,
+                   total_reviews, total_issues, total_issues_closed,
+                   total_stars_received, total_contributions,
                    snapshot_date, created_at
             FROM github_stats_snapshots
             WHERE user_id = ? AND snapshot_date = ?
@@ -115,18 +140,24 @@ impl Database {
         .fetch_optional(self.pool())
         .await?;
 
-        Ok(row.map(|r| GitHubStatsSnapshot {
-            id: r.get("id"),
-            user_id: r.get("user_id"),
-            total_commits: r.get("total_commits"),
-            total_prs: r.get("total_prs"),
-            total_reviews: r.get("total_reviews"),
-            total_issues: r.get("total_issues"),
-            total_stars_received: r.get("total_stars_received"),
-            total_contributions: r.get("total_contributions"),
-            snapshot_date: r.get("snapshot_date"),
-            created_at: r.get("created_at"),
-        }))
+        Ok(row.map(map_snapshot_row))
+    }
+}
+
+fn map_snapshot_row(r: sqlx::sqlite::SqliteRow) -> GitHubStatsSnapshot {
+    GitHubStatsSnapshot {
+        id: r.get("id"),
+        user_id: r.get("user_id"),
+        total_commits: r.get("total_commits"),
+        total_prs: r.get("total_prs"),
+        total_prs_merged: r.get("total_prs_merged"),
+        total_reviews: r.get("total_reviews"),
+        total_issues: r.get("total_issues"),
+        total_issues_closed: r.get("total_issues_closed"),
+        total_stars_received: r.get("total_stars_received"),
+        total_contributions: r.get("total_contributions"),
+        snapshot_date: r.get("snapshot_date"),
+        created_at: r.get("created_at"),
     }
 }
 
@@ -148,6 +179,7 @@ mod tests {
         db
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn create_snapshot(
         user_id: i64,
         commits: i32,
@@ -158,12 +190,16 @@ mod tests {
         contributions: i32,
         date: &str,
     ) -> GitHubStatsSnapshot {
+        // Tests written before Issue #189 didn't track prs_merged /
+        // issues_closed; default to 0 to keep existing assertions stable.
         GitHubStatsSnapshot::new(
             user_id,
             commits,
             prs,
+            0,
             reviews,
             issues,
+            0,
             stars,
             contributions,
             date,
@@ -291,6 +327,78 @@ mod tests {
             .expect("Should query without error");
 
         assert!(snapshot.is_none(), "Should have no snapshot for this date");
+    }
+
+    // TC-107: Latest snapshot ignores date and returns the most recent row.
+    // Used as the XP-diff base by `run_github_sync` after Issue #189.
+    #[tokio::test]
+    async fn test_get_latest_snapshot_returns_most_recent() {
+        let db = setup_test_db().await;
+
+        let yesterday = create_snapshot(1, 90, 18, 25, 12, 45, 180, "2025-11-29");
+        db.save_github_stats_snapshot(&yesterday)
+            .await
+            .expect("Should save yesterday snapshot");
+
+        let today = create_snapshot(1, 100, 20, 30, 15, 50, 200, "2025-11-30");
+        db.save_github_stats_snapshot(&today)
+            .await
+            .expect("Should save today snapshot");
+
+        let latest = db
+            .get_latest_github_stats_snapshot(1)
+            .await
+            .expect("Should query latest snapshot")
+            .expect("Latest snapshot should exist");
+
+        assert_eq!(latest.snapshot_date, "2025-11-30");
+        assert_eq!(latest.total_commits, 100);
+    }
+
+    // TC-108: Latest snapshot returns None when the user has no snapshots
+    // (fresh install path — `run_github_sync` falls back to "first sync").
+    #[tokio::test]
+    async fn test_get_latest_snapshot_returns_none_when_empty() {
+        let db = setup_test_db().await;
+
+        let latest = db
+            .get_latest_github_stats_snapshot(1)
+            .await
+            .expect("Should query without error");
+
+        assert!(latest.is_none(), "Should have no snapshots for fresh user");
+    }
+
+    // TC-109: Save and retrieve preserves total_prs_merged / total_issues_closed
+    // (the two columns added by Issue #189 / migration v12).
+    #[tokio::test]
+    async fn test_snapshot_persists_prs_merged_and_issues_closed() {
+        let db = setup_test_db().await;
+
+        let snapshot = GitHubStatsSnapshot::new(
+            1,
+            100,
+            20,
+            12, // prs_merged
+            30,
+            15,
+            8, // issues_closed
+            50,
+            200,
+            "2025-11-30",
+        );
+        db.save_github_stats_snapshot(&snapshot)
+            .await
+            .expect("Should save snapshot");
+
+        let saved = db
+            .get_github_stats_snapshot_for_date(1, "2025-11-30")
+            .await
+            .expect("Should query")
+            .expect("Snapshot should exist");
+
+        assert_eq!(saved.total_prs_merged, 12);
+        assert_eq!(saved.total_issues_closed, 8);
     }
 
     // TC-106: Multiple users have separate snapshots

--- a/src-tauri/src/sync_scheduler/sync_scheduler.spec.md
+++ b/src-tauri/src/sync_scheduler/sync_scheduler.spec.md
@@ -78,8 +78,9 @@ RateLimited { reason, seconds }      - レート制限解除を待つ
 重なっても、片方が完了するまでもう片方はブロックされる。
 
 Mutex を取らないと、両者が同じ pre-sync snapshot
-（`get_previous_github_stats`）を読んで XP / バッジ / チャレンジ進捗を
+（`get_latest_github_stats_snapshot`）を読んで XP / バッジ / チャレンジ進捗を
 それぞれ適用してしまい、ユーザーの XP が二重加算される。
+（旧 `get_previous_github_stats` KV は Issue #189 で廃止し、`github_stats_snapshots` に統合済み。）
 
 ### スリープのクランプ理由
 


### PR DESCRIPTION
## Summary

Unifies the two separate stores of "previous GitHub stats" into `github_stats_snapshots` as a single source of truth. Previously, XP diffs were computed against a legacy `previous_github_stats` KV in `activity_cache`, while the daily-comparison UI used `github_stats_snapshots`. This consolidation eliminates consistency risks and enables proper handling of same-day multiple syncs.

## Key Changes

### Database & Schema
- **Migration v12**: Adds `total_prs_merged` and `total_issues_closed` columns to `github_stats_snapshots` (required for XP calculation)
- Backfills new columns from legacy KV onto each user's most-recent snapshot to prevent XP burst on first post-migration sync
- Deletes the legacy `previous_github_stats` KV entries after backfill

### Repository Layer
- Adds `get_latest_github_stats_snapshot(user_id)` — returns the most recent snapshot regardless of date, used as the XP-diff baseline
- Updates `get_previous_github_stats_snapshot()` to use the new columns in SELECT
- Extracts row-mapping logic into a reusable `map_snapshot_row()` helper function
- Removes legacy `save_previous_github_stats()` and `get_previous_github_stats()` from cache repository

### XP Calculation
- Changes `XpBreakdown::calculate()` signature from `i32` to `u64` for all activity counts
  - Ensures `XpBreakdown` fields are always non-negative (type-level guarantee)
  - Uses `saturating_mul` and `saturating_add` to prevent overflow
  - Clamps negative streak values to 0 internally
- Updates saturation logic to handle `u64 → i32` conversion safely

### Sync Logic (`run_github_sync`)
- Replaces `get_previous_github_stats()` KV lookup with `get_latest_github_stats_snapshot()`
- Introduces `diff_count()` and `clamp_to_u64()` helpers for safe counter diffing
  - Handles negative or regressed counters by clamping to 0
  - Prevents negative XP from API anomalies or data regressions
- Removes the legacy `save_previous_github_stats()` call
- Keeps activity cache population for non-XP paths (best-effort, non-blocking)

### Model Updates
- `GitHubStatsSnapshot` struct gains `total_prs_merged` and `total_issues_closed` fields
- `GitHubStatsSnapshot::new()` updated to accept the two new parameters
- Test helper `create_snapshot()` defaults new fields to 0 for backward compatibility

## Notable Implementation Details

- **Same-day sync safety**: `get_latest_github_stats_snapshot()` returns today's row if the user already synced earlier, preventing double-counting in successive syncs
- **Idempotent migration**: The v12 backfill+delete SQL is idempotent (UPDATE COALESCEs, DELETE on empty set is no-op)
- **Comprehensive test coverage**: Adds tests for the new snapshot query, migration backfill, and `XpBreakdown` non-negativity guarantees
- **Documentation**: Spec files updated to reflect the new SSoT model and Issue #189 context

https://claude.ai/code/session_01UFkRLa7etWaLLfFzLrhMaw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * GitHub同期で日内に二重加算される問題を解消し、XP付与の正確性を改善
  * XP算出でのオーバーフローや負の差分を防止して結果を常に非負に安定化
  * 日次比較UIの差分表示を安定化し、当日のスナップショット保存が表示側で上書きされないよう修正
* **改善 / 移行**
  * 旧キャッシュ形式から統合されたスナップショットへデータを移行・削除して一元化

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otomatty/development-tools/pull/212)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->