### PR TITLE
Cache GitHub aggregates on user_stats to eliminate badge API calls

### DIFF
--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -7,7 +7,8 @@ use tauri::{command, AppHandle, Emitter, State};
 use super::auth::AppState;
 use crate::auth::map_github_result;
 use crate::database::{
-    badge, challenge, level, streak, xp, GitHubStatsSnapshot, UserStats, XpActionType,
+    badge, challenge, level, streak, xp, GitHubStatsSnapshot, UserStats,
+    UserStatsGitHubAggregates, XpActionType,
 };
 use crate::github::{GitHubClient, GitHubStats, GitHubUser};
 use crate::utils::notifications::send_notification;
@@ -615,6 +616,32 @@ pub async fn run_github_sync(
         }
     }
 
+    // Mirror the GitHub-derived aggregates onto `user_stats` so the badge
+    // evaluator (`get_badges_with_progress`) can build its
+    // `BadgeEvalContext` purely from the local DB on subsequent calls.
+    // Without this, every badge-grid render would re-call
+    // `client.get_user_stats` (REST 4 + GraphQL 1) and burn the Search
+    // 30 req/min budget. See Issue #191 / Audit §6.3 / §9.1.
+    //
+    // Best-effort: a write failure is logged but does not fail the sync
+    // — the next sync will retry, and badge progress just stays at the
+    // previous snapshot's values until then.
+    let aggregates = github_stats_aggregates(&github_stats);
+    let updated_stats = match state
+        .db
+        .update_github_aggregates(user.id, &aggregates)
+        .await
+    {
+        Ok(stats) => stats,
+        Err(e) => {
+            eprintln!(
+                "Failed to mirror GitHub aggregates onto user_stats: {}",
+                e
+            );
+            updated_stats
+        }
+    };
+
     // Badge evaluation
     let badge_context = badge::BadgeEvalContext {
         total_commits: github_stats.total_commits,
@@ -966,12 +993,51 @@ pub async fn get_contribution_calendar(
     serde_json::to_value(contributions.contribution_calendar).map_err(|e| e.to_string())
 }
 
-/// Helper function to build badge evaluation context
-///
-/// Consolidates the common logic for building BadgeEvalContext used by
-/// both `get_badges_with_progress` and `get_near_completion_badges`.
-async fn build_badge_context(
-    app: &AppHandle,
+/// Project a `GitHubStats` payload onto the subset of fields we mirror on
+/// `user_stats` (Issue #191). Defined as a free function so both
+/// `run_github_sync` (which already has fresh stats) and the explicit
+/// `refresh_badges_progress` path can derive the same `UserStats`-shaped
+/// aggregates.
+fn github_stats_aggregates(stats: &GitHubStats) -> UserStatsGitHubAggregates {
+    UserStatsGitHubAggregates {
+        total_commits: stats.total_commits,
+        total_prs: stats.total_prs,
+        total_reviews: stats.total_reviews,
+        total_issues: stats.total_issues,
+        total_prs_merged: stats.total_prs_merged,
+        total_issues_closed: stats.total_issues_closed,
+        weekly_streak: stats.weekly_streak,
+        monthly_streak: stats.monthly_streak,
+        languages_count: stats.languages_count,
+        total_stars_received: stats.total_stars_received,
+    }
+}
+
+/// Build a `BadgeEvalContext` purely from the locally-cached `user_stats`
+/// row. No GitHub API calls — Issue #191 (Audit §6.3) — so the badge UI
+/// renders without re-spending the Search 30 req/min budget on every
+/// view. Fresh values are written back during `sync_github_stats` (or
+/// the user-triggered `refresh_badges_progress`).
+fn badge_context_from_user_stats(stats: &UserStats) -> badge::BadgeEvalContext {
+    badge::BadgeEvalContext {
+        total_commits: stats.total_commits,
+        current_streak: stats.current_streak,
+        longest_streak: stats.longest_streak,
+        weekly_streak: stats.weekly_streak,
+        monthly_streak: stats.monthly_streak,
+        total_reviews: stats.total_reviews,
+        total_prs: stats.total_prs,
+        total_prs_merged: stats.total_prs_merged,
+        total_issues_closed: stats.total_issues_closed,
+        languages_count: stats.languages_count,
+        current_level: level::level_from_xp(stats.total_xp),
+        total_stars_received: stats.total_stars_received,
+    }
+}
+
+/// Helper: load the current user and their `user_stats` row, returning
+/// the badge evaluation context built from local DB only.
+async fn db_only_badge_context(
     state: &State<'_, AppState>,
 ) -> Result<(badge::BadgeEvalContext, crate::database::models::User), String> {
     let user = state
@@ -981,7 +1047,6 @@ async fn build_badge_context(
         .map_err(|e| e.to_string())?
         .ok_or("Not logged in")?;
 
-    // Get user stats
     let user_stats = state
         .db
         .get_user_stats(user.id)
@@ -989,50 +1054,19 @@ async fn build_badge_context(
         .map_err(|e| e.to_string())?
         .ok_or("User stats not found")?;
 
-    // Get GitHub stats for additional context
-    let token = state
-        .token_manager
-        .get_access_token()
-        .await
-        .map_err(|e| e.to_string())?;
-
-    let client = GitHubClient::new(token);
-    let github_stats = map_github_result(
-        app,
-        state.inner(),
-        client.get_user_stats(&user.username).await,
-    )
-    .await?;
-
-    // Calculate level
-    let current_level = level::level_from_xp(user_stats.total_xp);
-
-    // Build badge evaluation context
-    let badge_context = badge::BadgeEvalContext {
-        total_commits: github_stats.total_commits,
-        current_streak: user_stats.current_streak,
-        longest_streak: user_stats.longest_streak,
-        weekly_streak: github_stats.weekly_streak,
-        monthly_streak: github_stats.monthly_streak,
-        total_reviews: github_stats.total_reviews,
-        total_prs: github_stats.total_prs,
-        total_prs_merged: github_stats.total_prs_merged,
-        total_issues_closed: github_stats.total_issues_closed,
-        languages_count: github_stats.languages_count,
-        current_level: current_level as i32,
-        total_stars_received: github_stats.total_stars_received,
-    };
-
-    Ok((badge_context, user))
+    Ok((badge_context_from_user_stats(&user_stats), user))
 }
 
-/// Get badges with progress information
+/// Get badges with progress information.
+///
+/// Reads entirely from the local `user_stats` row — no GitHub API calls.
+/// `sync_github_stats` (and the user-triggered `refresh_badges_progress`)
+/// is the only writer of the underlying aggregates. See Issue #191.
 #[command]
 pub async fn get_badges_with_progress(
-    app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<Vec<badge::BadgeWithProgress>, String> {
-    let (badge_context, user) = build_badge_context(&app, &state).await?;
+    let (badge_context, user) = db_only_badge_context(&state).await?;
 
     // Get earned badges
     let earned_badges = state
@@ -1054,15 +1088,16 @@ pub async fn get_badges_with_progress(
     Ok(badges)
 }
 
-/// Get badges that are close to being earned
+/// Get badges that are close to being earned.
+///
+/// DB-only — see `get_badges_with_progress`.
 #[command]
 pub async fn get_near_completion_badges(
-    app: AppHandle,
     state: State<'_, AppState>,
     threshold_percent: Option<f32>,
 ) -> Result<Vec<badge::BadgeWithProgress>, String> {
     let threshold = threshold_percent.unwrap_or(50.0);
-    let (badge_context, user) = build_badge_context(&app, &state).await?;
+    let (badge_context, user) = db_only_badge_context(&state).await?;
 
     // Get earned badge IDs
     let earned_badges = state
@@ -1077,6 +1112,66 @@ pub async fn get_near_completion_badges(
     let badges = badge::get_near_completion_badges(&badge_context, &earned_badge_ids, threshold);
 
     Ok(badges)
+}
+
+/// Force-refresh the badge-evaluation aggregates on `user_stats` from
+/// GitHub and return the recomputed badge progress list.
+///
+/// `get_badges_with_progress` is intentionally DB-only (Issue #191) so
+/// it can run on every render without touching the GitHub API. This
+/// command is the explicit "I want fresh numbers" escape hatch — it
+/// re-runs the heavy `client.get_user_stats` query (REST 4 + GraphQL 1)
+/// and writes the result back to `user_stats` so the next badge-grid
+/// render also sees the refreshed values.
+#[command]
+pub async fn refresh_badges_progress(
+    app: AppHandle,
+    state: State<'_, AppState>,
+) -> Result<Vec<badge::BadgeWithProgress>, String> {
+    let user = state
+        .token_manager
+        .get_current_user()
+        .await
+        .map_err(|e| e.to_string())?
+        .ok_or("Not logged in")?;
+
+    let token = state
+        .token_manager
+        .get_access_token()
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let client = GitHubClient::new(token);
+    let github_stats = map_github_result(
+        &app,
+        state.inner(),
+        client.get_user_stats(&user.username).await,
+    )
+    .await?;
+
+    let aggregates = github_stats_aggregates(&github_stats);
+    let user_stats = state
+        .db
+        .update_github_aggregates(user.id, &aggregates)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let badge_context = badge_context_from_user_stats(&user_stats);
+
+    let earned_badges = state
+        .db
+        .get_user_badges(user.id)
+        .await
+        .map_err(|e| e.to_string())?;
+    let earned_badges_with_date: Vec<(String, Option<String>)> = earned_badges
+        .into_iter()
+        .map(|b| (b.badge_id, Some(b.earned_at.to_rfc3339())))
+        .collect();
+
+    Ok(badge::get_badges_with_progress(
+        &badge_context,
+        &earned_badges_with_date,
+    ))
 }
 
 // ============================================================================

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -1157,27 +1157,6 @@ pub async fn refresh_badges_progress(
     )
     .await?;
 
-    // Mirror the streak fields too — `badge_context_from_user_stats`
-    // pulls `current_streak` / `longest_streak` from `user_stats`, so
-    // without this step a "refresh" right after a streak change would
-    // still render streak badges against the previous sync's value
-    // even though we just made a fresh API call. Surfacing the error
-    // (rather than swallowing it) is consistent with `run_github_sync`
-    // and matches the user intent — they explicitly asked for fresh
-    // numbers, so a partial refresh is worse than an explicit failure.
-    if let Some(streak_info) = &github_stats.streak_info {
-        state
-            .db
-            .update_streak_from_github(
-                user.id,
-                streak_info.current_streak,
-                streak_info.longest_streak,
-                streak_info.last_activity_date.as_deref(),
-            )
-            .await
-            .map_err(|e| e.to_string())?;
-    }
-
     let aggregates = github_stats_aggregates(&github_stats);
     let user_stats = state
         .db
@@ -1185,7 +1164,22 @@ pub async fn refresh_badges_progress(
         .await
         .map_err(|e| e.to_string())?;
 
-    let badge_context = badge_context_from_user_stats(&user_stats);
+    // Build the badge context from the freshly-persisted aggregates,
+    // then *overlay* `current_streak` / `longest_streak` from the live
+    // GitHub response. We deliberately do NOT persist streak changes
+    // here: `sync_github_stats` reads `user_stats.current_streak` as
+    // its `old_streak` baseline before recomputing the streak bonus,
+    // so a refresh that wrote the new streak first would make the
+    // next sync see no delta and silently skip the daily / milestone
+    // streak XP. Keeping the persistence path single-owner
+    // (`run_github_sync` only) preserves XP correctness while still
+    // giving the badge UI the fresh values the user expects.
+    let mut badge_context = badge_context_from_user_stats(&user_stats);
+    if let Some(streak_info) = &github_stats.streak_info {
+        badge_context.current_streak = streak_info.current_streak;
+        badge_context.longest_streak = streak_info.longest_streak;
+    }
+
     badges_with_progress_for_user(&state, user.id, &badge_context).await
 }
 

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -1157,6 +1157,16 @@ pub async fn refresh_badges_progress(
     )
     .await?;
 
+    // Take `sync_lock` before persisting so a concurrent
+    // `run_github_sync` (manual or scheduler-triggered) can't race us.
+    // Both writers touch the same `user_stats` aggregate columns; the
+    // GitHub fetch above happened *outside* the lock, so without
+    // serialisation a refresh that fetched an older snapshot but
+    // completed after a fresh sync would clobber the newer totals
+    // (last-writer-wins) and silently regress badge progress until
+    // the next sync/refresh.
+    let _guard = state.sync_lock.lock().await;
+
     let aggregates = github_stats_aggregates(&github_stats);
     let user_stats = state
         .db

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -7,8 +7,8 @@ use tauri::{command, AppHandle, Emitter, State};
 use super::auth::AppState;
 use crate::auth::map_github_result;
 use crate::database::{
-    badge, challenge, level, streak, xp, GitHubStatsSnapshot, UserStats,
-    UserStatsGitHubAggregates, XpActionType,
+    badge, challenge, level, streak, xp, GitHubStatsSnapshot, UserStats, UserStatsGitHubAggregates,
+    XpActionType,
 };
 use crate::github::{GitHubClient, GitHubStats, GitHubUser};
 use crate::utils::notifications::send_notification;
@@ -634,10 +634,7 @@ pub async fn run_github_sync(
     {
         Ok(stats) => stats,
         Err(e) => {
-            eprintln!(
-                "Failed to mirror GitHub aggregates onto user_stats: {}",
-                e
-            );
+            eprintln!("Failed to mirror GitHub aggregates onto user_stats: {}", e);
             updated_stats
         }
     };

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -1054,6 +1054,35 @@ async fn db_only_badge_context(
     Ok((badge_context_from_user_stats(&user_stats), user))
 }
 
+/// Helper: read the user's earned badges from the DB and run them
+/// through `badge::get_badges_with_progress`. Shared between the
+/// DB-only `get_badges_with_progress` command and the GitHub-refreshing
+/// `refresh_badges_progress` command so both produce identically-shaped
+/// payloads from the same evaluator.
+async fn badges_with_progress_for_user(
+    state: &State<'_, AppState>,
+    user_id: i64,
+    badge_context: &badge::BadgeEvalContext,
+) -> Result<Vec<badge::BadgeWithProgress>, String> {
+    let earned_badges = state
+        .db
+        .get_user_badges(user_id)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    // `badge::get_badges_with_progress` expects (badge_id, earned_at?)
+    // tuples, with the timestamp serialised as RFC3339.
+    let earned_badges_with_date: Vec<(String, Option<String>)> = earned_badges
+        .into_iter()
+        .map(|b| (b.badge_id, Some(b.earned_at.to_rfc3339())))
+        .collect();
+
+    Ok(badge::get_badges_with_progress(
+        badge_context,
+        &earned_badges_with_date,
+    ))
+}
+
 /// Get badges with progress information.
 ///
 /// Reads entirely from the local `user_stats` row — no GitHub API calls.
@@ -1064,25 +1093,7 @@ pub async fn get_badges_with_progress(
     state: State<'_, AppState>,
 ) -> Result<Vec<badge::BadgeWithProgress>, String> {
     let (badge_context, user) = db_only_badge_context(&state).await?;
-
-    // Get earned badges
-    let earned_badges = state
-        .db
-        .get_user_badges(user.id)
-        .await
-        .map_err(|e| e.to_string())?;
-
-    // Convert to the format expected by get_badges_with_progress
-    // DateTime<Utc> -> String (ISO 8601 format)
-    let earned_badges_with_date: Vec<(String, Option<String>)> = earned_badges
-        .into_iter()
-        .map(|b| (b.badge_id, Some(b.earned_at.to_rfc3339())))
-        .collect();
-
-    // Get badges with progress
-    let badges = badge::get_badges_with_progress(&badge_context, &earned_badges_with_date);
-
-    Ok(badges)
+    badges_with_progress_for_user(&state, user.id, &badge_context).await
 }
 
 /// Get badges that are close to being earned.
@@ -1146,6 +1157,27 @@ pub async fn refresh_badges_progress(
     )
     .await?;
 
+    // Mirror the streak fields too — `badge_context_from_user_stats`
+    // pulls `current_streak` / `longest_streak` from `user_stats`, so
+    // without this step a "refresh" right after a streak change would
+    // still render streak badges against the previous sync's value
+    // even though we just made a fresh API call. Surfacing the error
+    // (rather than swallowing it) is consistent with `run_github_sync`
+    // and matches the user intent — they explicitly asked for fresh
+    // numbers, so a partial refresh is worse than an explicit failure.
+    if let Some(streak_info) = &github_stats.streak_info {
+        state
+            .db
+            .update_streak_from_github(
+                user.id,
+                streak_info.current_streak,
+                streak_info.longest_streak,
+                streak_info.last_activity_date.as_deref(),
+            )
+            .await
+            .map_err(|e| e.to_string())?;
+    }
+
     let aggregates = github_stats_aggregates(&github_stats);
     let user_stats = state
         .db
@@ -1154,21 +1186,7 @@ pub async fn refresh_badges_progress(
         .map_err(|e| e.to_string())?;
 
     let badge_context = badge_context_from_user_stats(&user_stats);
-
-    let earned_badges = state
-        .db
-        .get_user_badges(user.id)
-        .await
-        .map_err(|e| e.to_string())?;
-    let earned_badges_with_date: Vec<(String, Option<String>)> = earned_badges
-        .into_iter()
-        .map(|b| (b.badge_id, Some(b.earned_at.to_rfc3339())))
-        .collect();
-
-    Ok(badge::get_badges_with_progress(
-        &badge_context,
-        &earned_badges_with_date,
-    ))
+    badges_with_progress_for_user(&state, user.id, &badge_context).await
 }
 
 // ============================================================================

--- a/src-tauri/src/database/migrations.rs
+++ b/src-tauri/src/database/migrations.rs
@@ -443,6 +443,28 @@ ALTER TABLE cached_issues ADD COLUMN archived_at DATETIME;
 CREATE INDEX IF NOT EXISTS idx_projects_archived ON projects(user_id, is_archived);
 "#,
     },
+    Migration {
+        version: 14,
+        name: "add_user_stats_badge_eval_fields",
+        sql: r#"
+-- Extend `user_stats` with the aggregate fields the badge evaluator needs
+-- so `get_badges_with_progress` can run entirely against the local DB
+-- instead of re-fetching `client.get_user_stats` (REST 4 + GraphQL 1) on
+-- every render. See Issue #191 / Audit §6.3 / §9.1.
+--
+-- Older rows default to 0 — the next `sync_github_stats` run rewrites
+-- these from the freshly fetched `GitHubStats`, so the badge UI catches
+-- up after the first post-migration sync. Until then, badges that
+-- depend on these new metrics show 0 progress (never *spurious* progress),
+-- which is the same behaviour a brand-new user gets.
+ALTER TABLE user_stats ADD COLUMN weekly_streak INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE user_stats ADD COLUMN monthly_streak INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE user_stats ADD COLUMN total_prs_merged INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE user_stats ADD COLUMN total_issues_closed INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE user_stats ADD COLUMN languages_count INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE user_stats ADD COLUMN total_stars_received INTEGER NOT NULL DEFAULT 0;
+"#,
+    },
 ];
 
 /// Create the migrations tracking table

--- a/src-tauri/src/database/mod.rs
+++ b/src-tauri/src/database/mod.rs
@@ -19,6 +19,7 @@ pub use challenge::{
 };
 pub use connection::{Database, DatabaseError, DbResult};
 pub use models::*;
+pub use repository::UserStatsGitHubAggregates;
 
 // Re-export nested modules for backward compatibility (used as database::level::*, database::badge::*, etc.)
 // These re-export the inner modules that contain the actual functions

--- a/src-tauri/src/database/models/badge.spec.md
+++ b/src-tauri/src/database/models/badge.spec.md
@@ -1,0 +1,103 @@
+# Badge Evaluation Specification
+
+## Related Files
+
+- Model & evaluator: `src-tauri/src/database/models/badge.rs`
+- Tauri commands: `src-tauri/src/commands/github.rs`
+  (`get_badges_with_progress`, `get_near_completion_badges`,
+  `refresh_badges_progress`, `run_github_sync`)
+- Repository: `src-tauri/src/database/repository/user_stats.rs`
+  (`update_github_aggregates`, `UserStatsGitHubAggregates`)
+- Schema: `src-tauri/src/database/migrations.rs` (migration v14)
+- Frontend: `src/components/features/gamification/BadgeGrid.tsx`,
+  `src/lib/tauri/commands.ts` (`getBadgesWithProgress`,
+  `getNearCompletionBadges`, `refreshBadgesProgress`)
+
+## Related Documentation
+
+- 監査レポート: `docs/02_research/2026_04/20260425_github_integration_audit.md`
+  §6.3 / §9.1
+- GitHub Issue: #191（バッジ進捗計算の DB 完結化）
+
+## 責務
+
+1. ユーザーが獲得したバッジ・獲得目前のバッジを返す
+   (`get_badges_with_progress` / `get_near_completion_badges`)。
+2. これらの呼び出しが GitHub API を叩かないことを保証する。
+3. 「最新化したい」ユーザー操作のために
+   `refresh_badges_progress` を提供する（このコマンドだけが
+   `client.get_user_stats` を叩く）。
+
+## データフロー
+
+```
+sync_github_stats          ── get_user_stats(REST 4 + GraphQL 1) ──▶ GitHubStats
+        │
+        │ 1) update_github_aggregates(user.id, &agg)
+        ▼
+   user_stats (DB)  ◀────── (default DB-only writer)
+        ▲
+        │ 2) badge_context_from_user_stats(&user_stats)
+        │
+get_badges_with_progress / get_near_completion_badges
+        │  → BadgeEvalContext (no API calls)
+        ▼
+     UI (BadgeGrid)
+```
+
+`refresh_badges_progress` は同じ `update_github_aggregates`
+パスを通り、呼び出し直後の最新値で
+`get_badges_with_progress` 相当の応答を返す。
+
+## `BadgeEvalContext` のフィールド対応
+
+| `BadgeEvalContext` フィールド | DB 列 (`user_stats.*`)        | 書き込みタイミング |
+| ----------------------------- | ----------------------------- | ------------------ |
+| `total_commits`               | `total_commits`               | sync               |
+| `current_streak`              | `current_streak`              | sync (streak)      |
+| `longest_streak`              | `longest_streak`              | sync (streak)      |
+| `weekly_streak`               | `weekly_streak` *(v14)*       | sync               |
+| `monthly_streak`              | `monthly_streak` *(v14)*      | sync               |
+| `total_reviews`               | `total_reviews`               | sync               |
+| `total_prs`                   | `total_prs`                   | sync               |
+| `total_prs_merged`            | `total_prs_merged` *(v14)*    | sync               |
+| `total_issues_closed`         | `total_issues_closed` *(v14)* | sync               |
+| `languages_count`             | `languages_count` *(v14)*     | sync               |
+| `current_level`               | derived from `total_xp`        | (read-only)        |
+| `total_stars_received`        | `total_stars_received` *(v14)* | sync               |
+
+`*(v14)*` は migration v14
+(`add_user_stats_badge_eval_fields`) で追加された列。
+
+## 不変条件 (Invariants)
+
+- `get_badges_with_progress` / `get_near_completion_badges`
+  は **GitHub API を呼ばない**。
+- `update_github_aggregates` は XP・current_level・current_streak・
+  longest_streak・last_activity_date を **書き換えない**
+  （これらは XP / streak の専用パスが書く）。
+- 既存ユーザーは migration v14 直後、新規 6 列が `0` で初期化される。
+  最初の `sync_github_stats` 実行で正しい値に上書きされる。
+  それまでバッジ進捗は「不足」側に倒れるが、誤って「達成」側に
+  なることはない（v14 直後にいきなり満たされる badge は無い）。
+
+## 完了条件 (DoD) — Issue #191
+
+- [x] バッジ表示時に GitHub API が叩かれない
+- [x] レート制限消費が顕著に減る
+  (Search 30 req/min を消費する `get_user_stats` を
+  badge UI から取り除いたため)
+
+## テスト観点
+
+- `database::repository::tests::test_update_github_aggregates_persists_badge_eval_fields`
+  — `UserStatsGitHubAggregates` の全フィールドが
+  `user_stats` に正しく書き込まれ、再フェッチでも保持されること。
+- `database::repository::tests::test_update_github_aggregates_preserves_xp_and_streak`
+  — 集計フィールドの書き込みが XP / streak / level を破壊しないこと。
+- `database::migrations::tests::test_migrations_run_successfully` /
+  `test_migrations_are_idempotent` — v14 を含むスキーマ全体が
+  繰り返し適用されても整合すること。
+- 既存の `database::models::badge::badge::tests::*`
+  — `BadgeEvalContext` ベースの評価ロジック（badge
+  evaluator 自体は本変更で改変していない）。

--- a/src-tauri/src/database/models/badge.spec.md
+++ b/src-tauri/src/database/models/badge.spec.md
@@ -25,8 +25,9 @@
    (`get_badges_with_progress` / `get_near_completion_badges`)。
 2. これらの呼び出しが GitHub API を叩かないことを保証する。
 3. 「最新化したい」ユーザー操作のために
-   `refresh_badges_progress` を提供する（このコマンドだけが
-   `client.get_user_stats` を叩く）。
+   `refresh_badges_progress` を提供する。`run_github_sync` も
+   `client.get_user_stats` を叩くが、バッジ表示系コマンドの中で
+   直接 GitHub 取得を行うのはこの `refresh_badges_progress` だけ。
 
 ## データフロー
 

--- a/src-tauri/src/database/models/badge.spec.md
+++ b/src-tauri/src/database/models/badge.spec.md
@@ -77,6 +77,15 @@ get_badges_with_progress / get_near_completion_badges
 - `update_github_aggregates` は XP・current_level・current_streak・
   longest_streak・last_activity_date を **書き換えない**
   （これらは XP / streak の専用パスが書く）。
+- `refresh_badges_progress` は GitHub から取得した
+  `streak_info.current_streak` / `longest_streak` を
+  返り値の `BadgeEvalContext` には反映するが、
+  `user_stats` には **書き戻さない**。`run_github_sync` は
+  `user_stats.current_streak` を XP ストリークボーナスの
+  `old_streak` 基準値として読むため、refresh が DB に
+  書いてしまうと次回 sync で `(old_streak == new_streak)` と
+  なり日次／マイルストーンボーナスが恒久的に取り逃される。
+  ストリークの永続化は `run_github_sync` の単一責任。
 - 既存ユーザーは migration v14 直後、新規 6 列が `0` で初期化される。
   最初の `sync_github_stats` 実行で正しい値に上書きされる。
   それまでバッジ進捗は「不足」側に倒れるが、誤って「達成」側に

--- a/src-tauri/src/database/models/badge.spec.md
+++ b/src-tauri/src/database/models/badge.spec.md
@@ -31,7 +31,7 @@
 
 ## データフロー
 
-```
+```text
 sync_github_stats          ── get_user_stats(REST 4 + GraphQL 1) ──▶ GitHubStats
         │
         │ 1) update_github_aggregates(user.id, &agg)

--- a/src-tauri/src/database/models/user.rs
+++ b/src-tauri/src/database/models/user.rs
@@ -35,6 +35,15 @@ pub struct UserStats {
     pub total_prs: i32,
     pub total_reviews: i32,
     pub total_issues: i32,
+    // Badge evaluation fields (Issue #191): persisted on every
+    // `sync_github_stats` so badge progress can be computed without
+    // re-hitting the GitHub aggregate API.
+    pub weekly_streak: i32,
+    pub monthly_streak: i32,
+    pub total_prs_merged: i32,
+    pub total_issues_closed: i32,
+    pub languages_count: i32,
+    pub total_stars_received: i32,
     pub updated_at: DateTime<Utc>,
 }
 
@@ -52,6 +61,12 @@ impl Default for UserStats {
             total_prs: 0,
             total_reviews: 0,
             total_issues: 0,
+            weekly_streak: 0,
+            monthly_streak: 0,
+            total_prs_merged: 0,
+            total_issues_closed: 0,
+            languages_count: 0,
+            total_stars_received: 0,
             updated_at: Utc::now(),
         }
     }

--- a/src-tauri/src/database/repository/mod.rs
+++ b/src-tauri/src/database/repository/mod.rs
@@ -16,6 +16,7 @@ mod xp_history;
 #[cfg(test)]
 mod tests;
 
-// Re-export all repository operations
-// Note: Repository operations are implemented as methods on Database,
-// so they're automatically available when Database is imported.
+// Re-export repository-owned types that callers need to construct directly.
+// (Most repository operations are methods on `Database` and become
+// available automatically when `Database` is imported.)
+pub use user_stats::UserStatsGitHubAggregates;

--- a/src-tauri/src/database/repository/settings.rs
+++ b/src-tauri/src/database/repository/settings.rs
@@ -267,6 +267,12 @@ impl Database {
                 total_prs = 0,
                 total_reviews = 0,
                 total_issues = 0,
+                weekly_streak = 0,
+                monthly_streak = 0,
+                total_prs_merged = 0,
+                total_issues_closed = 0,
+                languages_count = 0,
+                total_stars_received = 0,
                 updated_at = ?
             WHERE user_id = ?
             "#,

--- a/src-tauri/src/database/repository/tests.rs
+++ b/src-tauri/src/database/repository/tests.rs
@@ -503,6 +503,128 @@ async fn test_get_last_weekly_challenge_date() {
 }
 
 #[tokio::test]
+async fn test_update_github_aggregates_persists_badge_eval_fields() {
+    use crate::database::UserStatsGitHubAggregates;
+
+    let db = setup_test_db().await;
+
+    let user = db
+        .create_user(12345, "testuser", None, "token", None, None)
+        .await
+        .expect("Should create user");
+
+    // Defaults are all zero on a freshly-created stats row.
+    let initial = db
+        .get_user_stats(user.id)
+        .await
+        .expect("Should get stats")
+        .expect("Stats should exist");
+    assert_eq!(initial.weekly_streak, 0);
+    assert_eq!(initial.monthly_streak, 0);
+    assert_eq!(initial.total_prs_merged, 0);
+    assert_eq!(initial.total_issues_closed, 0);
+    assert_eq!(initial.languages_count, 0);
+    assert_eq!(initial.total_stars_received, 0);
+
+    let agg = UserStatsGitHubAggregates {
+        total_commits: 250,
+        total_prs: 40,
+        total_reviews: 12,
+        total_issues: 8,
+        total_prs_merged: 30,
+        total_issues_closed: 5,
+        weekly_streak: 4,
+        monthly_streak: 2,
+        languages_count: 6,
+        total_stars_received: 75,
+    };
+
+    let updated = db
+        .update_github_aggregates(user.id, &agg)
+        .await
+        .expect("Should update aggregates");
+
+    // Aggregates from GitHub mirror onto user_stats so the badge UI can
+    // read them on subsequent calls without re-fetching from GitHub.
+    assert_eq!(updated.total_commits, 250);
+    assert_eq!(updated.total_prs, 40);
+    assert_eq!(updated.total_reviews, 12);
+    assert_eq!(updated.total_issues, 8);
+    assert_eq!(updated.total_prs_merged, 30);
+    assert_eq!(updated.total_issues_closed, 5);
+    assert_eq!(updated.weekly_streak, 4);
+    assert_eq!(updated.monthly_streak, 2);
+    assert_eq!(updated.languages_count, 6);
+    assert_eq!(updated.total_stars_received, 75);
+
+    // Round-trips through SELECT — the `RETURNING *` value matches a
+    // fresh fetch.
+    let refetched = db
+        .get_user_stats(user.id)
+        .await
+        .expect("Should re-fetch")
+        .expect("Stats should exist");
+    assert_eq!(refetched.total_prs_merged, 30);
+    assert_eq!(refetched.total_stars_received, 75);
+    assert_eq!(refetched.languages_count, 6);
+}
+
+#[tokio::test]
+async fn test_update_github_aggregates_preserves_xp_and_streak() {
+    use crate::database::UserStatsGitHubAggregates;
+
+    let db = setup_test_db().await;
+
+    let user = db
+        .create_user(12345, "testuser", None, "token", None, None)
+        .await
+        .expect("Should create user");
+
+    // Seed XP and streak — these must not be touched by the aggregates
+    // mirror, which is responsible only for the GitHub-derived counts.
+    db.add_xp(user.id, 500).await.expect("Should add XP");
+    db.update_streak_from_github(user.id, 7, 14, Some("2026-04-26"))
+        .await
+        .expect("Should update streak from GitHub");
+
+    let before = db
+        .get_user_stats(user.id)
+        .await
+        .expect("fetch")
+        .expect("stats exist");
+
+    db.update_github_aggregates(
+        user.id,
+        &UserStatsGitHubAggregates {
+            total_commits: 99,
+            total_prs: 11,
+            total_reviews: 4,
+            total_issues: 3,
+            total_prs_merged: 9,
+            total_issues_closed: 2,
+            weekly_streak: 3,
+            monthly_streak: 1,
+            languages_count: 4,
+            total_stars_received: 21,
+        },
+    )
+    .await
+    .expect("Should update aggregates");
+
+    let after = db
+        .get_user_stats(user.id)
+        .await
+        .expect("fetch")
+        .expect("stats exist");
+
+    assert_eq!(after.total_xp, before.total_xp);
+    assert_eq!(after.current_level, before.current_level);
+    assert_eq!(after.current_streak, before.current_streak);
+    assert_eq!(after.longest_streak, before.longest_streak);
+    assert_eq!(after.last_activity_date, before.last_activity_date);
+}
+
+#[tokio::test]
 async fn test_progress_capped_at_target() {
     let db = setup_test_db().await;
 

--- a/src-tauri/src/database/repository/user_stats.rs
+++ b/src-tauri/src/database/repository/user_stats.rs
@@ -20,6 +20,12 @@ pub(crate) struct UserStatsRow {
     pub total_prs: i32,
     pub total_reviews: i32,
     pub total_issues: i32,
+    pub weekly_streak: i32,
+    pub monthly_streak: i32,
+    pub total_prs_merged: i32,
+    pub total_issues_closed: i32,
+    pub languages_count: i32,
+    pub total_stars_received: i32,
     pub updated_at: String,
 }
 
@@ -41,6 +47,12 @@ impl TryFrom<UserStatsRow> for UserStats {
             total_prs: row.total_prs,
             total_reviews: row.total_reviews,
             total_issues: row.total_issues,
+            weekly_streak: row.weekly_streak,
+            monthly_streak: row.monthly_streak,
+            total_prs_merged: row.total_prs_merged,
+            total_issues_closed: row.total_issues_closed,
+            languages_count: row.languages_count,
+            total_stars_received: row.total_stars_received,
             updated_at: DateTime::parse_from_rfc3339(&row.updated_at)
                 .map(|dt| dt.with_timezone(&Utc))
                 .unwrap_or_else(|_| Utc::now()),
@@ -234,7 +246,7 @@ impl Database {
 
         sqlx::query(
             r#"
-            UPDATE user_stats 
+            UPDATE user_stats
             SET total_commits = total_commits + ?,
                 total_prs = total_prs + ?,
                 total_reviews = total_reviews + ?,
@@ -255,4 +267,68 @@ impl Database {
 
         Ok(())
     }
+
+    /// Snapshot of GitHub-derived aggregates we mirror on `user_stats` so
+    /// the badge evaluator (`get_badges_with_progress`) can compute
+    /// progress without re-hitting `client.get_user_stats`. See Issue #191.
+    pub async fn update_github_aggregates(
+        &self,
+        user_id: i64,
+        agg: &UserStatsGitHubAggregates,
+    ) -> DbResult<UserStats> {
+        let now = Utc::now().to_rfc3339();
+
+        let updated_row: UserStatsRow = sqlx::query_as(
+            r#"
+            UPDATE user_stats
+            SET total_commits = ?,
+                total_prs = ?,
+                total_reviews = ?,
+                total_issues = ?,
+                total_prs_merged = ?,
+                total_issues_closed = ?,
+                weekly_streak = ?,
+                monthly_streak = ?,
+                languages_count = ?,
+                total_stars_received = ?,
+                updated_at = ?
+            WHERE user_id = ?
+            RETURNING *
+            "#,
+        )
+        .bind(agg.total_commits)
+        .bind(agg.total_prs)
+        .bind(agg.total_reviews)
+        .bind(agg.total_issues)
+        .bind(agg.total_prs_merged)
+        .bind(agg.total_issues_closed)
+        .bind(agg.weekly_streak)
+        .bind(agg.monthly_streak)
+        .bind(agg.languages_count)
+        .bind(agg.total_stars_received)
+        .bind(&now)
+        .bind(user_id)
+        .fetch_one(self.pool())
+        .await
+        .map_err(|e| DatabaseError::Query(e.to_string()))?;
+
+        updated_row.try_into()
+    }
+}
+
+/// Aggregates derived from `GitHubStats` that we mirror on `user_stats`.
+/// Kept as a plain struct (not the `GitHubStats` itself) so the repository
+/// layer doesn't depend on the `github` module.
+#[derive(Debug, Clone, Default)]
+pub struct UserStatsGitHubAggregates {
+    pub total_commits: i32,
+    pub total_prs: i32,
+    pub total_reviews: i32,
+    pub total_issues: i32,
+    pub total_prs_merged: i32,
+    pub total_issues_closed: i32,
+    pub weekly_streak: i32,
+    pub monthly_streak: i32,
+    pub languages_count: i32,
+    pub total_stars_received: i32,
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -58,6 +58,8 @@ use commands::{
     get_near_completion_badges,
     // GitHub Notifications commands (Issue #186)
     get_notifications,
+    // Issue #191: explicit refresh for badge progress (heavy aggregate API call)
+    refresh_badges_progress,
     get_project,
     get_project_issues,
     get_projects,
@@ -197,6 +199,7 @@ pub fn run() {
             get_contribution_calendar,
             get_badges_with_progress,
             get_near_completion_badges,
+            refresh_badges_progress,
             // Cache fallback commands
             get_github_stats_with_cache,
             get_user_stats_with_cache,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -58,8 +58,6 @@ use commands::{
     get_near_completion_badges,
     // GitHub Notifications commands (Issue #186)
     get_notifications,
-    // Issue #191: explicit refresh for badge progress (heavy aggregate API call)
-    refresh_badges_progress,
     get_project,
     get_project_issues,
     get_projects,
@@ -79,6 +77,8 @@ use commands::{
     open_external_url,
     open_url,
     poll_device_token,
+    // Issue #191: explicit refresh for badge progress (heavy aggregate API call)
+    refresh_badges_progress,
     relink_repository,
     reset_all_data,
     reset_settings,

--- a/src/lib/tauri/commands.ts
+++ b/src/lib/tauri/commands.ts
@@ -471,6 +471,15 @@ export const github = {
     invoke<BadgeWithProgress[]>('get_near_completion_badges', { threshold_percent }),
 
   /**
+   * Force-refresh badge progress aggregates from GitHub (heavy: REST 4 +
+   * GraphQL 1). Use only for an explicit user "refresh" gesture — the
+   * default `getBadgesWithProgress` reads from the local DB so it's free
+   * to call on every render. See Issue #191.
+   */
+  refreshBadgesProgress: (): Promise<BadgeWithProgress[]> =>
+    invoke<BadgeWithProgress[]>('refresh_badges_progress'),
+
+  /**
    * Sync code statistics from GitHub
    */
   syncCodeStats: (force_full_sync?: boolean | null): Promise<CodeStatsSyncResult> =>


### PR DESCRIPTION
## Summary

Resolves Issue #191 by eliminating GitHub API calls from badge progress rendering. Badge evaluation now reads entirely from locally-cached aggregates on the `user_stats` row, with a new explicit `refresh_badges_progress` command for users who want fresh numbers.

## Key Changes

- **Database Schema (Migration v14)**: Added 6 new columns to `user_stats` to cache GitHub-derived aggregates:
  - `weekly_streak`, `monthly_streak`, `total_prs_merged`, `total_issues_closed`, `languages_count`, `total_stars_received`
  - These fields default to 0 on existing rows and are populated by the next `sync_github_stats` run

- **Repository Layer**: 
  - New `update_github_aggregates()` method to atomically write GitHub stats snapshot to `user_stats`
  - New `UserStatsGitHubAggregates` struct to decouple the repository from the `github` module
  - Updated `UserStatsRow` and `UserStats` models to include the new fields

- **Badge Evaluation Commands**:
  - Refactored `build_badge_context()` → `db_only_badge_context()` to read purely from local DB (no API calls)
  - Removed `AppHandle` parameter from `get_badges_with_progress()` and `get_near_completion_badges()` since they no longer need GitHub API access
  - New `refresh_badges_progress()` command: explicit escape hatch that re-fetches from GitHub and returns updated badge progress

- **Sync Flow**:
  - `run_github_sync()` now calls `update_github_aggregates()` after fetching fresh stats, mirroring aggregates onto `user_stats`
  - Failure to write aggregates is logged but doesn't fail the sync (best-effort)
  - New helper `github_stats_aggregates()` projects `GitHubStats` onto the subset of fields we cache

- **Frontend**: Added `refreshBadgesProgress()` Tauri command binding with documentation noting it's heavy (REST 4 + GraphQL 1) and should only be called on explicit user gesture

## Implementation Details

- **Invariants Preserved**: `update_github_aggregates()` intentionally does not touch XP, level, current_streak, longest_streak, or last_activity_date—those remain under their own update paths
- **Backward Compatibility**: Existing users get 0 values for new columns until their first post-migration sync; badge progress shows 0 (never spurious progress)
- **Rate Limit Impact**: Eliminates the Search 30 req/min budget drain from badge UI renders by removing the `client.get_user_stats()` call (REST 4 + GraphQL 1) from the hot path
- **Tests**: Added comprehensive tests for aggregate persistence and XP/streak preservation

## Related Documentation

- Audit Report: `docs/02_research/2026_04/20260425_github_integration_audit.md` §6.3 / §9.1
- New spec: `src-tauri/src/database/models/badge.spec.md` (data flow, field mapping, invariants, DoD)

https://claude.ai/code/session_01Ka9dNB86zgg285VT1AUsNh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * バッジ進捗を明示的にリフレッシュするコマンドを追加しました。
  * プロジェクトのアーカイブ機能を追加しました。

* **パフォーマンス改善**
  * バッジ評価・進捗はローカルの集計データのみで算出するよう最適化しました（外部API呼び出しを削減）。

* **データベース / マイグレーション**
  * ユーザー統計にバッジ集計用フィールドを永続化するマイグレーションを追加しました。

* **テスト**
  * 集計の永続化と既存のXP/ストリーク保持を検証するテストを追加しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otomatty/development-tools/pull/214)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->