### PR TITLE
Add language/repository breakdown visualization (Issue #193)

### DIFF
--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -1896,11 +1896,13 @@ const LANGUAGE_BREAKDOWN_MAX_REPOS: i32 = 50;
 
 /// Lower-bound window for the per-repository commit history scan, in days.
 ///
-/// Mirrors `StatsPeriod::Quarter` so the bar chart can show a reasonable
-/// activity trail (90 days catches month-over-month drift) without
-/// inflating GraphQL cost — the heavy lifting is the language edges, not
-/// the commit history.
-const LANGUAGE_BREAKDOWN_DAYS: i64 = 90;
+/// 30 days fits inside `history(first: 100, ...)` for almost every realistic
+/// per-author commit cadence (≈3.3 commits/day before truncation kicks in),
+/// so the per-repo additions/deletions bars stay accurate without a
+/// pagination loop. A 90-day window would silently undercount high-activity
+/// repos — exactly the ones the chart is meant to surface — see Codex P2 on
+/// PR #216.
+const LANGUAGE_BREAKDOWN_DAYS: i64 = 30;
 
 /// Language / repository code-stat breakdown with a 24-hour SQLite cache.
 ///

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -1882,3 +1882,128 @@ pub async fn get_today_commits_with_cache(
         }
     }
 }
+
+// ============================================================================
+// Language / Repository Breakdown command (Issue #193 — G-11)
+// ============================================================================
+
+/// Cap on repositories scanned per `get_language_breakdown_with_cache` call.
+///
+/// 50 keeps the GraphQL cost bounded (history + languages edges per repo)
+/// while covering substantially all of a developer's actively-pushed work
+/// — `PUSHED_AT DESC` ordering means the cap drops cold repos first.
+const LANGUAGE_BREAKDOWN_MAX_REPOS: i32 = 50;
+
+/// Lower-bound window for the per-repository commit history scan, in days.
+///
+/// Mirrors `StatsPeriod::Quarter` so the bar chart can show a reasonable
+/// activity trail (90 days catches month-over-month drift) without
+/// inflating GraphQL cost — the heavy lifting is the language edges, not
+/// the commit history.
+const LANGUAGE_BREAKDOWN_DAYS: i64 = 90;
+
+/// Language / repository code-stat breakdown with a 24-hour SQLite cache.
+///
+/// Backs the dashboard panel introduced in Issue #193 — language pie + per-
+/// repository additions/deletions bars. A single GraphQL query drives both
+/// visualizations to keep rate-limit pressure low; behaviour mirrors the
+/// other `*_with_cache` commands so the SWR-style frontend hook can render
+/// the previously-cached payload while a refresh is in flight.
+#[command]
+pub async fn get_language_breakdown_with_cache(
+    app: AppHandle,
+    state: State<'_, AppState>,
+) -> Result<CachedResponse<crate::github::types::LanguageBreakdownResponse>, String> {
+    let user = state
+        .token_manager
+        .get_current_user()
+        .await
+        .map_err(|e| e.to_string())?
+        .ok_or("Not logged in")?;
+
+    let now = chrono::Utc::now();
+    let since_dt = now - chrono::Duration::days(LANGUAGE_BREAKDOWN_DAYS);
+    let since = since_dt.to_rfc3339();
+
+    let api_result = async {
+        let token = state
+            .token_manager
+            .get_access_token()
+            .await
+            .map_err(|e| GitHubError::ApiError(e.to_string()))?;
+        let client = GitHubClient::new(token);
+        client
+            .get_language_breakdown(&user.username, &since, LANGUAGE_BREAKDOWN_MAX_REPOS)
+            .await
+    }
+    .await;
+
+    match api_result {
+        Ok(payload) => {
+            let payload_json = serde_json::to_string(&payload)
+                .map_err(|e| format!("Failed to serialize language breakdown: {}", e))?;
+
+            let expires_at = now
+                + chrono::Duration::minutes(
+                    crate::database::cache_durations::LANGUAGE_BREAKDOWN,
+                );
+
+            let _ = state
+                .db
+                .save_cache(
+                    user.id,
+                    cache_types::LANGUAGE_BREAKDOWN,
+                    &payload_json,
+                    expires_at,
+                )
+                .await;
+
+            Ok(CachedResponse {
+                data: payload,
+                from_cache: false,
+                cached_at: Some(now.to_rfc3339()),
+                expires_at: Some(expires_at.to_rfc3339()),
+            })
+        }
+        Err(GitHubError::Unauthorized) => {
+            handle_unauthorized(&app, state.inner(), reasons::GITHUB_UNAUTHORIZED).await;
+            Err(GitHubError::Unauthorized.to_string())
+        }
+        Err(api_error) => {
+            if !is_network_error(&api_error) {
+                return Err(format!("GitHub API error: {}", api_error));
+            }
+
+            eprintln!(
+                "Language breakdown fetch failed, attempting cache fallback: {}",
+                api_error
+            );
+
+            let cache_result = state
+                .db
+                .get_any_cache(user.id, cache_types::LANGUAGE_BREAKDOWN)
+                .await
+                .ok()
+                .flatten();
+
+            match cache_result {
+                Some((data_json, cached_at, expires_at)) => {
+                    let payload: crate::github::types::LanguageBreakdownResponse =
+                        serde_json::from_str(&data_json)
+                            .map_err(|e| format!("Failed to parse cached data: {}", e))?;
+
+                    Ok(CachedResponse {
+                        data: payload,
+                        from_cache: true,
+                        cached_at: Some(cached_at),
+                        expires_at: Some(expires_at),
+                    })
+                }
+                None => Err(format!(
+                    "GitHub APIにアクセスできず、キャッシュもありません: {}",
+                    api_error
+                )),
+            }
+        }
+    }
+}

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -1944,9 +1944,7 @@ pub async fn get_language_breakdown_with_cache(
                 .map_err(|e| format!("Failed to serialize language breakdown: {}", e))?;
 
             let expires_at = now
-                + chrono::Duration::minutes(
-                    crate::database::cache_durations::LANGUAGE_BREAKDOWN,
-                );
+                + chrono::Duration::minutes(crate::database::cache_durations::LANGUAGE_BREAKDOWN);
 
             let _ = state
                 .db

--- a/src-tauri/src/database/models/cache.rs
+++ b/src-tauri/src/database/models/cache.rs
@@ -49,6 +49,9 @@ pub mod cache_types {
     /// Realtime "今日のコミット数" — thin commit-count query used by the
     /// gamification today-quest UI. See Issue #188.
     pub const TODAY_COMMITS: &str = "today_commits";
+    /// Language / repository breakdown payload (per-language byte share +
+    /// per-repository additions/deletions). See Issue #193.
+    pub const LANGUAGE_BREAKDOWN: &str = "language_breakdown";
 }
 
 /// Default cache durations in minutes
@@ -89,4 +92,10 @@ pub mod cache_durations {
     /// 3-minute TTL gives the gamification today-quest UI near-realtime
     /// updates while keeping GraphQL spend trivial. See Issue #188.
     pub const TODAY_COMMITS: i64 = 3;
+    /// Language / repository breakdown cache duration (24 hours).
+    /// The underlying GraphQL query scans up to 100 repos with language
+    /// edges and 100 commits each — keeping a 24h TTL matches the issue
+    /// #193 requirement and prevents focus revalidations from burning
+    /// the GraphQL budget on what is fundamentally slow-moving data.
+    pub const LANGUAGE_BREAKDOWN: i64 = 1440;
 }

--- a/src-tauri/src/github/client.rs
+++ b/src-tauri/src/github/client.rs
@@ -752,6 +752,190 @@ impl GitHubClient {
         Ok(result)
     }
 
+    /// Get the language / repository breakdown used by the dashboard
+    /// visualizations introduced in Issue #193 (G-11).
+    ///
+    /// A single GraphQL query fetches both the per-repository language
+    /// distribution (`languages(first: 10) { edges { size, node { name color } } }`)
+    /// and per-repository commit history with additions/deletions, so a
+    /// single API call drives both the language pie chart and the
+    /// repo-wise additions/deletions bars. Forks are excluded to match
+    /// `get_code_stats`'s coverage policy.
+    ///
+    /// # Arguments
+    /// * `username` - GitHub username
+    /// * `since` - ISO8601 timestamp lower bound for commit history (e.g.
+    ///   `"2026-04-10T00:00:00Z"`).
+    /// * `max_repos` - Cap on repositories to scan (1..=100). Orders by
+    ///   `PUSHED_AT DESC` so the cap drops cold repos first.
+    pub async fn get_language_breakdown(
+        &self,
+        username: &str,
+        since: &str,
+        max_repos: i32,
+    ) -> GitHubResult<LanguageBreakdownResponse> {
+        let capped = max_repos.clamp(1, 100);
+
+        let query = r#"
+            query($login: String!, $since: GitTimestamp!, $maxRepos: Int!) {
+                user(login: $login) {
+                    repositories(
+                        first: $maxRepos,
+                        isFork: false,
+                        ownerAffiliations: [OWNER, COLLABORATOR],
+                        orderBy: {field: PUSHED_AT, direction: DESC}
+                    ) {
+                        nodes {
+                            nameWithOwner
+                            url
+                            languages(first: 10, orderBy: {field: SIZE, direction: DESC}) {
+                                edges {
+                                    size
+                                    node {
+                                        name
+                                        color
+                                    }
+                                }
+                            }
+                            defaultBranchRef {
+                                target {
+                                    ... on Commit {
+                                        history(first: 100, since: $since) {
+                                            nodes {
+                                                additions
+                                                deletions
+                                                committedDate
+                                                oid
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                rateLimit {
+                    limit
+                    cost
+                    remaining
+                    resetAt
+                }
+            }
+        "#;
+
+        let variables = serde_json::json!({
+            "login": username,
+            "since": since,
+            "maxRepos": capped,
+        });
+
+        let response: LanguageBreakdownQueryResponse =
+            self.graphql(query, Some(variables)).await?;
+
+        let mut language_totals: std::collections::HashMap<String, (i64, Option<String>)> =
+            std::collections::HashMap::new();
+        let mut repositories: Vec<RepositoryCodeStats> = Vec::new();
+        let mut repositories_scanned: i32 = 0;
+
+        if let Some(user) = response.user {
+            for repo in user.repositories.nodes {
+                repositories_scanned += 1;
+
+                // Aggregate language sizes across all repositories.
+                let mut primary_language: Option<String> = None;
+                let mut primary_language_color: Option<String> = None;
+                let mut primary_language_size: i64 = 0;
+
+                if let Some(langs) = &repo.languages {
+                    for edge in &langs.edges {
+                        let entry = language_totals
+                            .entry(edge.node.name.clone())
+                            .or_insert_with(|| (0, edge.node.color.clone()));
+                        entry.0 += edge.size;
+                        if entry.1.is_none() && edge.node.color.is_some() {
+                            entry.1 = edge.node.color.clone();
+                        }
+
+                        if edge.size > primary_language_size {
+                            primary_language_size = edge.size;
+                            primary_language = Some(edge.node.name.clone());
+                            primary_language_color = edge.node.color.clone();
+                        }
+                    }
+                }
+
+                // Aggregate per-repository commit totals over the window.
+                let mut additions: i32 = 0;
+                let mut deletions: i32 = 0;
+                let mut commits_count: i32 = 0;
+
+                if let Some(branch_ref) = repo.default_branch_ref {
+                    if let Some(target) = branch_ref.target {
+                        if let Some(history) = target.history {
+                            for commit in history.nodes {
+                                additions += commit.additions;
+                                deletions += commit.deletions;
+                                commits_count += 1;
+                            }
+                        }
+                    }
+                }
+
+                if commits_count > 0 || primary_language.is_some() {
+                    repositories.push(RepositoryCodeStats {
+                        name_with_owner: repo.name_with_owner,
+                        url: repo.url,
+                        additions,
+                        deletions,
+                        commits_count,
+                        primary_language,
+                        primary_language_color,
+                    });
+                }
+            }
+        }
+
+        // Sort repositories by total churn (additions + deletions) descending
+        // so the bar chart leads with the most active repos. Repos with no
+        // commits in the window but a known primary language fall to the
+        // bottom — they're useful context, not the headline.
+        repositories.sort_by(|a, b| {
+            (b.additions + b.deletions)
+                .cmp(&(a.additions + a.deletions))
+                .then_with(|| b.commits_count.cmp(&a.commits_count))
+        });
+
+        let total_bytes: i64 = language_totals.values().map(|(size, _)| *size).sum();
+
+        let mut languages: Vec<LanguageStats> = language_totals
+            .into_iter()
+            .map(|(name, (bytes, color))| {
+                let percentage = if total_bytes > 0 {
+                    bytes as f32 / total_bytes as f32
+                } else {
+                    0.0
+                };
+                LanguageStats {
+                    name,
+                    color,
+                    bytes,
+                    percentage,
+                }
+            })
+            .collect();
+
+        // Largest language first for the pie / legend ordering.
+        languages.sort_by(|a, b| b.bytes.cmp(&a.bytes));
+
+        Ok(LanguageBreakdownResponse {
+            languages,
+            repositories,
+            total_bytes,
+            since: since.to_string(),
+            repositories_scanned,
+        })
+    }
+
     /// Get total commits authored by the user since `since` across their
     /// `max_repos` most recently pushed repositories.
     ///

--- a/src-tauri/src/github/client.rs
+++ b/src-tauri/src/github/client.rs
@@ -776,13 +776,42 @@ impl GitHubClient {
     ) -> GitHubResult<LanguageBreakdownResponse> {
         let capped = max_repos.clamp(1, 100);
 
+        // Resolve the user's node id so `history(author: {id: ...})` filters
+        // commits down to the signed-in user. Without this, collaborator
+        // pushes on the default branch get attributed to the dashboard owner,
+        // making the per-repository additions/deletions bars meaningless on
+        // any team repo. Mirrors the pattern used by `get_today_commits`.
+        let id_query = r#"
+            query($login: String!) {
+                user(login: $login) { id }
+            }
+        "#;
+
+        #[derive(serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct UserIdResponse {
+            user: Option<UserId>,
+        }
+        #[derive(serde::Deserialize)]
+        struct UserId {
+            id: String,
+        }
+
+        let id_resp: UserIdResponse = self
+            .graphql(id_query, Some(serde_json::json!({ "login": username })))
+            .await?;
+        let author_id = id_resp
+            .user
+            .map(|u| u.id)
+            .ok_or_else(|| GitHubError::NotFound(format!("User {} not found", username)))?;
+
         let query = r#"
-            query($login: String!, $since: GitTimestamp!, $maxRepos: Int!) {
+            query($login: String!, $since: GitTimestamp!, $maxRepos: Int!, $author: ID!) {
                 user(login: $login) {
                     repositories(
                         first: $maxRepos,
                         isFork: false,
-                        ownerAffiliations: [OWNER, COLLABORATOR],
+                        ownerAffiliations: [OWNER, COLLABORATOR, ORGANIZATION_MEMBER],
                         orderBy: {field: PUSHED_AT, direction: DESC}
                     ) {
                         nodes {
@@ -800,7 +829,7 @@ impl GitHubClient {
                             defaultBranchRef {
                                 target {
                                     ... on Commit {
-                                        history(first: 100, since: $since) {
+                                        history(first: 100, since: $since, author: {id: $author}) {
                                             nodes {
                                                 additions
                                                 deletions
@@ -827,6 +856,7 @@ impl GitHubClient {
             "login": username,
             "since": since,
             "maxRepos": capped,
+            "author": author_id,
         });
 
         let response: LanguageBreakdownQueryResponse =
@@ -873,9 +903,14 @@ impl GitHubClient {
                     if let Some(target) = branch_ref.target {
                         if let Some(history) = target.history {
                             for commit in history.nodes {
-                                additions += commit.additions;
-                                deletions += commit.deletions;
-                                commits_count += 1;
+                                // saturating_add guards against i32 overflow on
+                                // pathological diffs (generated code, vendored
+                                // monorepos) so the sync never panics in debug
+                                // builds. Saturation produces a visible-but-
+                                // bounded number rather than wrapping silently.
+                                additions = additions.saturating_add(commit.additions);
+                                deletions = deletions.saturating_add(commit.deletions);
+                                commits_count = commits_count.saturating_add(1);
                             }
                         }
                     }
@@ -898,10 +933,14 @@ impl GitHubClient {
         // Sort repositories by total churn (additions + deletions) descending
         // so the bar chart leads with the most active repos. Repos with no
         // commits in the window but a known primary language fall to the
-        // bottom — they're useful context, not the headline.
+        // bottom — they're useful context, not the headline. Cast to i64
+        // before summing so a near-`i32::MAX` repo can't panic the sort in
+        // debug builds.
         repositories.sort_by(|a, b| {
-            (b.additions + b.deletions)
-                .cmp(&(a.additions + a.deletions))
+            let churn_a = a.additions as i64 + a.deletions as i64;
+            let churn_b = b.additions as i64 + b.deletions as i64;
+            churn_b
+                .cmp(&churn_a)
                 .then_with(|| b.commits_count.cmp(&a.commits_count))
         });
 

--- a/src-tauri/src/github/client.rs
+++ b/src-tauri/src/github/client.rs
@@ -859,8 +859,7 @@ impl GitHubClient {
             "author": author_id,
         });
 
-        let response: LanguageBreakdownQueryResponse =
-            self.graphql(query, Some(variables)).await?;
+        let response: LanguageBreakdownQueryResponse = self.graphql(query, Some(variables)).await?;
 
         let mut language_totals: std::collections::HashMap<String, (i64, Option<String>)> =
             std::collections::HashMap::new();

--- a/src-tauri/src/github/types.rs
+++ b/src-tauri/src/github/types.rs
@@ -300,6 +300,102 @@ pub struct DailyCodeStatsAggregated {
 }
 
 // ============================================================================
+// Language / Repository Breakdown Types (Issue #193 — G-11)
+// ============================================================================
+
+/// GraphQL response wrapper for the language breakdown query.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LanguageBreakdownQueryResponse {
+    pub user: Option<LanguageBreakdownUser>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LanguageBreakdownUser {
+    pub repositories: LanguageBreakdownRepositoriesConnection,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LanguageBreakdownRepositoriesConnection {
+    pub nodes: Vec<LanguageBreakdownRepository>,
+}
+
+/// Repository node returned by the breakdown query — combines languages
+/// and commit history so a single GraphQL call drives both visualizations.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LanguageBreakdownRepository {
+    pub name_with_owner: String,
+    pub url: Option<String>,
+    pub languages: Option<LanguageConnection>,
+    pub default_branch_ref: Option<DefaultBranchRef>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LanguageConnection {
+    pub edges: Vec<LanguageEdge>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LanguageEdge {
+    /// Bytes of code attributed to this language by GitHub linguist.
+    pub size: i64,
+    pub node: LanguageNode,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LanguageNode {
+    pub name: String,
+    pub color: Option<String>,
+}
+
+/// Per-language aggregated stats surfaced to the frontend.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct LanguageStats {
+    pub name: String,
+    /// Hex color (e.g. `#3178c6`) sourced from GitHub linguist when known.
+    pub color: Option<String>,
+    /// Bytes attributed to this language across the scanned repositories.
+    pub bytes: i64,
+    /// Share of `total_bytes` (0.0..=1.0).
+    pub percentage: f32,
+}
+
+/// Per-repository aggregated stats over the breakdown window.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct RepositoryCodeStats {
+    pub name_with_owner: String,
+    pub url: Option<String>,
+    pub additions: i32,
+    pub deletions: i32,
+    pub commits_count: i32,
+    /// Primary language (highest byte count) for the repository, if any.
+    pub primary_language: Option<String>,
+    pub primary_language_color: Option<String>,
+}
+
+/// Combined response for the language / repository breakdown panel.
+///
+/// `since` is the ISO8601 lower bound applied to the commit history scan
+/// so the UI can label the chart period without recomputing it.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct LanguageBreakdownResponse {
+    pub languages: Vec<LanguageStats>,
+    pub repositories: Vec<RepositoryCodeStats>,
+    pub total_bytes: i64,
+    pub since: String,
+    pub repositories_scanned: i32,
+}
+
+// ============================================================================
 // Today's Commits Types (Issue #188 — G-01 realtime today commit count)
 // ============================================================================
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -50,6 +50,8 @@ use commands::{
     get_github_stats_with_cache,
     get_github_user,
     get_kanban_board,
+    // Language / repository breakdown command (Issue #193)
+    get_language_breakdown_with_cache,
     get_level_info,
     // Cross-repository "Today / Inbox" command (Issue #183)
     get_my_open_work_with_cache,
@@ -67,8 +69,6 @@ use commands::{
     get_sync_intervals,
     // Realtime "today's commits" command (Issue #188)
     get_today_commits_with_cache,
-    // Language / repository breakdown command (Issue #193)
-    get_language_breakdown_with_cache,
     get_user_repositories,
     get_user_stats,
     get_user_stats_with_cache,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -67,6 +67,8 @@ use commands::{
     get_sync_intervals,
     // Realtime "today's commits" command (Issue #188)
     get_today_commits_with_cache,
+    // Language / repository breakdown command (Issue #193)
+    get_language_breakdown_with_cache,
     get_user_repositories,
     get_user_stats,
     get_user_stats_with_cache,
@@ -213,6 +215,8 @@ pub fn run() {
             get_rate_limit_info,
             // Realtime "today's commits" command (Issue #188)
             get_today_commits_with_cache,
+            // Language / repository breakdown command (Issue #193)
+            get_language_breakdown_with_cache,
             // Gamification commands
             get_level_info,
             add_xp,

--- a/src/components/features/gamification/DashboardContent.tsx
+++ b/src/components/features/gamification/DashboardContent.tsx
@@ -17,13 +17,25 @@ import { StatsDisplay } from './StatsDisplay';
 import { ChallengeCard } from './ChallengeCard';
 import { BadgeGrid } from './BadgeGrid';
 import { ContributionGraph } from './ContributionGraph';
-import type { LevelInfo, UserStats, GitHubStats, StatsDiffResult } from '../../../types';
+import { LanguageBreakdownCard } from './LanguageBreakdownCard';
+import type {
+  LevelInfo,
+  UserStats,
+  GitHubStats,
+  StatsDiffResult,
+  LanguageBreakdownResponse,
+} from '../../../types';
 
 interface DashboardContentProps {
   levelInfo?: LevelInfo | null;
   userStats?: UserStats | null;
   githubStats?: GitHubStats | null;
   statsDiff?: StatsDiffResult | null;
+  /// 言語別 / リポジトリ別ブレイクダウン (Issue #193)
+  languageBreakdown?: LanguageBreakdownResponse | null;
+  languageBreakdownLoading?: boolean;
+  languageBreakdownError?: Error | null;
+  languageBreakdownFromCache?: boolean;
 }
 
 // Skeleton components
@@ -89,7 +101,16 @@ const ContributionGraphSkeleton: React.FC = () => (
   </div>
 );
 
-export const DashboardContent: React.FC<DashboardContentProps> = ({ levelInfo, userStats, githubStats, statsDiff }) => {
+export const DashboardContent: React.FC<DashboardContentProps> = ({
+  levelInfo,
+  userStats,
+  githubStats,
+  statsDiff,
+  languageBreakdown,
+  languageBreakdownLoading,
+  languageBreakdownError,
+  languageBreakdownFromCache,
+}) => {
   const navigate = useNavigate();
 
   return (
@@ -137,6 +158,14 @@ export const DashboardContent: React.FC<DashboardContentProps> = ({ levelInfo, u
       <Suspense fallback={<ContributionGraphSkeleton />}>
         <ContributionGraph githubStats={githubStats} />
       </Suspense>
+
+      {/* Language / Repository Breakdown (Issue #193) */}
+      <LanguageBreakdownCard
+        data={languageBreakdown ?? null}
+        isLoading={languageBreakdownLoading ?? false}
+        error={languageBreakdownError ? languageBreakdownError.message : null}
+        fromCache={languageBreakdownFromCache ?? false}
+      />
     </div>
   );
 };

--- a/src/components/features/gamification/LanguageBreakdownCard.tsx
+++ b/src/components/features/gamification/LanguageBreakdownCard.tsx
@@ -234,7 +234,7 @@ const LanguagePie: React.FC<{ data: LanguageBreakdownResponse }> = ({ data }) =>
           className="fill-dt-text-main"
           style={{ fontSize: '12px' }}
         >
-          {data.repositoriesScanned} repos
+          {data.repositoriesScanned} リポジトリ
         </text>
         <text
           x={CX}
@@ -310,7 +310,7 @@ const RepositoryBars: React.FC<{ repositories: RepositoryCodeStats[] }> = ({ rep
                           repo.primaryLanguageColor ?? FALLBACK_COLORS[0],
                       }}
                       title={repo.primaryLanguage}
-                      aria-label={`Primary language: ${repo.primaryLanguage}`}
+                      aria-label={`主要言語: ${repo.primaryLanguage}`}
                     />
                   )}
                   {repo.url ? (
@@ -334,7 +334,7 @@ const RepositoryBars: React.FC<{ repositories: RepositoryCodeStats[] }> = ({ rep
                   <span className="mx-1 text-slate-500">·</span>
                   <span className="text-rose-400">−{formatLines(repo.deletions)}</span>
                   <span className="mx-1 text-slate-500">·</span>
-                  <span>{repo.commitsCount} commits</span>
+                  <span>{repo.commitsCount} コミット</span>
                 </span>
               </div>
 
@@ -352,8 +352,8 @@ const RepositoryBars: React.FC<{ repositories: RepositoryCodeStats[] }> = ({ rep
               </div>
 
               <span className="sr-only">
-                {repo.nameWithOwner} added {repo.additions} lines and removed {repo.deletions}
-                lines across {repo.commitsCount} commits ({formatLines(churn)} total churn).
+                {repo.nameWithOwner} は {repo.additions} 行追加、{repo.deletions} 行削除、
+                {repo.commitsCount} コミット（総変更量 {formatLines(churn)}）。
               </span>
             </li>
           );

--- a/src/components/features/gamification/LanguageBreakdownCard.tsx
+++ b/src/components/features/gamification/LanguageBreakdownCard.tsx
@@ -1,0 +1,413 @@
+/**
+ * Language / Repository Breakdown Card
+ *
+ * Renders the language distribution (pie + legend) and the repository-wise
+ * additions/deletions chart introduced in Issue #193 (audit §1 G-11).
+ *
+ * Both visualizations share a single GraphQL call (24h cache) — see
+ * `github.getLanguageBreakdownWithCache` and `get_language_breakdown` on
+ * the backend. The component is purely presentational: it expects a
+ * resolved payload and renders skeletons / empty states locally.
+ *
+ * Charts are SVG-based on purpose: this app has no chart library
+ * dependency and the dataset is small (≤ 10 languages, ≤ 10 repos shown)
+ * so handrolled SVG keeps the bundle lean.
+ *
+ * Related Documentation:
+ *   - Issue: https://github.com/otomatty/development-tools/issues/193
+ */
+
+import React, { useMemo } from 'react';
+import type {
+  LanguageBreakdownResponse,
+  LanguageStats,
+  RepositoryCodeStats,
+} from '../../../types';
+
+interface LanguageBreakdownCardProps {
+  data: LanguageBreakdownResponse | null;
+  isLoading: boolean;
+  error: string | null;
+  fromCache?: boolean;
+}
+
+const MAX_REPOS_SHOWN = 8;
+const MAX_LANGUAGES_LEGEND = 8;
+
+/// Fallback palette for languages whose `color` field is null. Chosen to
+/// stay readable on the dark dashboard background and rotated by index so
+/// adjacent slices remain distinguishable.
+const FALLBACK_COLORS = [
+  '#22d3ee',
+  '#a78bfa',
+  '#f472b6',
+  '#34d399',
+  '#fbbf24',
+  '#fb7185',
+  '#60a5fa',
+  '#f97316',
+  '#84cc16',
+  '#e879f9',
+];
+
+function languageColor(language: LanguageStats, fallbackIndex: number): string {
+  return language.color ?? FALLBACK_COLORS[fallbackIndex % FALLBACK_COLORS.length];
+}
+
+function formatPercent(value: number): string {
+  if (value <= 0) return '0%';
+  if (value < 0.001) return '<0.1%';
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
+function formatLines(value: number): string {
+  if (value < 1000) return value.toString();
+  if (value < 1_000_000) return `${(value / 1000).toFixed(1)}k`;
+  return `${(value / 1_000_000).toFixed(2)}M`;
+}
+
+interface PieSlice {
+  startAngle: number;
+  endAngle: number;
+  language: LanguageStats;
+  fallbackIndex: number;
+}
+
+/// Build the slice geometry. Languages with sub-percent share are folded
+/// into "Other" so the SVG path stays meaningful at small radii.
+function buildPieData(languages: LanguageStats[]): {
+  slices: PieSlice[];
+  legend: Array<{ language: LanguageStats; fallbackIndex: number }>;
+} {
+  if (languages.length === 0) {
+    return { slices: [], legend: [] };
+  }
+
+  const total = languages.reduce((sum, l) => sum + l.bytes, 0);
+  if (total <= 0) {
+    return { slices: [], legend: [] };
+  }
+
+  const visible = languages.slice(0, MAX_LANGUAGES_LEGEND);
+  const restBytes = languages
+    .slice(MAX_LANGUAGES_LEGEND)
+    .reduce((sum, l) => sum + l.bytes, 0);
+
+  const entries: LanguageStats[] = restBytes > 0
+    ? [
+        ...visible,
+        {
+          name: 'Other',
+          color: '#475569',
+          bytes: restBytes,
+          percentage: restBytes / total,
+        },
+      ]
+    : visible;
+
+  let cumulative = 0;
+  const slices: PieSlice[] = entries.map((language, idx) => {
+    const angle = (language.bytes / total) * Math.PI * 2;
+    const slice: PieSlice = {
+      startAngle: cumulative,
+      endAngle: cumulative + angle,
+      language,
+      fallbackIndex: idx,
+    };
+    cumulative += angle;
+    return slice;
+  });
+
+  return {
+    slices,
+    legend: entries.map((language, idx) => ({ language, fallbackIndex: idx })),
+  };
+}
+
+function pieSlicePath(
+  slice: PieSlice,
+  cx: number,
+  cy: number,
+  radius: number,
+): string {
+  const startX = cx + radius * Math.cos(slice.startAngle - Math.PI / 2);
+  const startY = cy + radius * Math.sin(slice.startAngle - Math.PI / 2);
+  const endX = cx + radius * Math.cos(slice.endAngle - Math.PI / 2);
+  const endY = cy + radius * Math.sin(slice.endAngle - Math.PI / 2);
+
+  const sweep = slice.endAngle - slice.startAngle;
+  // A full-circle slice (single dominant language) needs to be drawn as a
+  // closed circle path because the start/end points coincide and the SVG
+  // arc command would otherwise render nothing.
+  if (sweep >= Math.PI * 2 - 1e-6) {
+    return `M ${cx - radius} ${cy} a ${radius} ${radius} 0 1 0 ${radius * 2} 0 a ${radius} ${radius} 0 1 0 ${-radius * 2} 0 Z`;
+  }
+
+  const largeArc = sweep > Math.PI ? 1 : 0;
+  return [
+    `M ${cx} ${cy}`,
+    `L ${startX} ${startY}`,
+    `A ${radius} ${radius} 0 ${largeArc} 1 ${endX} ${endY}`,
+    'Z',
+  ].join(' ');
+}
+
+const SkeletonView: React.FC = () => (
+  <div className="p-6 bg-gm-bg-card/80 backdrop-blur-sm rounded-2xl border border-gm-accent-cyan/20 animate-pulse">
+    <div className="h-6 w-48 bg-slate-700 rounded mb-4"></div>
+    <div className="grid grid-cols-1 lg:grid-cols-[14rem_1fr] gap-6">
+      <div className="h-56 bg-slate-700 rounded-xl"></div>
+      <div className="space-y-3">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div key={i} className="h-8 bg-slate-700 rounded-lg"></div>
+        ))}
+      </div>
+    </div>
+  </div>
+);
+
+const ErrorView: React.FC<{ message: string }> = ({ message }) => (
+  <div className="p-6 bg-gm-bg-card/80 backdrop-blur-sm rounded-2xl border border-red-500/30">
+    <h3 className="text-lg font-semibold text-red-300 mb-2">
+      言語別 / リポジトリ別統計を読み込めませんでした
+    </h3>
+    <p className="text-sm text-dt-text-sub">{message}</p>
+  </div>
+);
+
+const EmptyView: React.FC = () => (
+  <div className="p-6 bg-gm-bg-card/80 backdrop-blur-sm rounded-2xl border border-gm-accent-cyan/20">
+    <h3 className="text-lg font-semibold text-dt-text-main mb-2">
+      言語別 / リポジトリ別統計
+    </h3>
+    <p className="text-sm text-dt-text-sub">
+      集計対象のリポジトリが見つかりませんでした。GitHub にコミットを公開すると
+      ここに表示されます。
+    </p>
+  </div>
+);
+
+const LanguagePie: React.FC<{ data: LanguageBreakdownResponse }> = ({ data }) => {
+  const { slices, legend } = useMemo(() => buildPieData(data.languages), [data.languages]);
+
+  if (slices.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-56 text-sm text-dt-text-sub">
+        言語データがありません
+      </div>
+    );
+  }
+
+  const SIZE = 200;
+  const RADIUS = 90;
+  const CX = SIZE / 2;
+  const CY = SIZE / 2;
+
+  return (
+    <div className="flex flex-col items-center gap-4">
+      <svg width={SIZE} height={SIZE} viewBox={`0 0 ${SIZE} ${SIZE}`} role="img" aria-label="言語別バイト比率">
+        {slices.map((slice) => (
+          <path
+            key={slice.language.name}
+            d={pieSlicePath(slice, CX, CY, RADIUS)}
+            fill={languageColor(slice.language, slice.fallbackIndex)}
+            stroke="#0f172a"
+            strokeWidth={1}
+          >
+            <title>
+              {slice.language.name} — {formatPercent(slice.language.percentage)} ({formatBytes(slice.language.bytes)})
+            </title>
+          </path>
+        ))}
+        <circle cx={CX} cy={CY} r={RADIUS * 0.55} fill="#0f172a" />
+        <text
+          x={CX}
+          y={CY - 6}
+          textAnchor="middle"
+          className="fill-dt-text-main"
+          style={{ fontSize: '12px' }}
+        >
+          {data.repositoriesScanned} repos
+        </text>
+        <text
+          x={CX}
+          y={CY + 12}
+          textAnchor="middle"
+          className="fill-dt-text-sub"
+          style={{ fontSize: '11px' }}
+        >
+          {formatBytes(data.totalBytes)}
+        </text>
+      </svg>
+
+      <ul className="w-full space-y-1.5 text-sm">
+        {legend.map(({ language, fallbackIndex }) => (
+          <li
+            key={language.name}
+            className="flex items-center justify-between gap-2"
+          >
+            <span className="flex items-center gap-2 min-w-0">
+              <span
+                className="inline-block w-3 h-3 rounded-sm flex-shrink-0"
+                style={{ backgroundColor: languageColor(language, fallbackIndex) }}
+                aria-hidden="true"
+              />
+              <span className="truncate text-dt-text-main">{language.name}</span>
+            </span>
+            <span className="text-dt-text-sub font-gaming-mono text-xs flex-shrink-0">
+              {formatPercent(language.percentage)}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+const RepositoryBars: React.FC<{ repositories: RepositoryCodeStats[] }> = ({ repositories }) => {
+  const visible = repositories.slice(0, MAX_REPOS_SHOWN);
+  const peakChurn = useMemo(() => {
+    return visible.reduce((max, r) => Math.max(max, r.additions + r.deletions), 0);
+  }, [visible]);
+
+  if (visible.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-32 text-sm text-dt-text-sub">
+        過去 90 日のコミット履歴に該当するリポジトリがありません
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-baseline justify-between text-xs text-dt-text-sub">
+        <span>過去 90 日 — 上位 {visible.length} リポジトリ</span>
+        <span className="font-gaming-mono">+追加 / −削除</span>
+      </div>
+
+      <ul className="space-y-3">
+        {visible.map((repo) => {
+          const churn = repo.additions + repo.deletions;
+          const additionsRatio = peakChurn > 0 ? repo.additions / peakChurn : 0;
+          const deletionsRatio = peakChurn > 0 ? repo.deletions / peakChurn : 0;
+
+          return (
+            <li key={repo.nameWithOwner} className="space-y-1">
+              <div className="flex items-center justify-between gap-2 text-sm">
+                <span className="flex items-center gap-2 min-w-0">
+                  {repo.primaryLanguage && (
+                    <span
+                      className="inline-block w-2.5 h-2.5 rounded-full flex-shrink-0"
+                      style={{
+                        backgroundColor:
+                          repo.primaryLanguageColor ?? FALLBACK_COLORS[0],
+                      }}
+                      title={repo.primaryLanguage}
+                      aria-label={`Primary language: ${repo.primaryLanguage}`}
+                    />
+                  )}
+                  {repo.url ? (
+                    <a
+                      href={repo.url}
+                      target="_blank"
+                      rel="noreferrer noopener"
+                      className="truncate text-dt-text-main hover:text-gm-accent-cyan transition-colors"
+                      title={repo.nameWithOwner}
+                    >
+                      {repo.nameWithOwner}
+                    </a>
+                  ) : (
+                    <span className="truncate text-dt-text-main" title={repo.nameWithOwner}>
+                      {repo.nameWithOwner}
+                    </span>
+                  )}
+                </span>
+                <span className="text-xs text-dt-text-sub font-gaming-mono whitespace-nowrap">
+                  <span className="text-emerald-400">+{formatLines(repo.additions)}</span>
+                  <span className="mx-1 text-slate-500">·</span>
+                  <span className="text-rose-400">−{formatLines(repo.deletions)}</span>
+                  <span className="mx-1 text-slate-500">·</span>
+                  <span>{repo.commitsCount} commits</span>
+                </span>
+              </div>
+
+              <div className="flex h-2 rounded-full overflow-hidden bg-slate-800/60">
+                <div
+                  className="bg-emerald-500/80"
+                  style={{ width: `${additionsRatio * 100}%` }}
+                  aria-hidden="true"
+                />
+                <div
+                  className="bg-rose-500/80"
+                  style={{ width: `${deletionsRatio * 100}%` }}
+                  aria-hidden="true"
+                />
+              </div>
+
+              <span className="sr-only">
+                {repo.nameWithOwner} added {repo.additions} lines and removed {repo.deletions}
+                lines across {repo.commitsCount} commits ({formatLines(churn)} total churn).
+              </span>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+};
+
+export const LanguageBreakdownCard: React.FC<LanguageBreakdownCardProps> = ({
+  data,
+  isLoading,
+  error,
+  fromCache,
+}) => {
+  if (isLoading && data === null && error === null) {
+    return <SkeletonView />;
+  }
+
+  if (error !== null && data === null) {
+    return <ErrorView message={error} />;
+  }
+
+  if (data === null) {
+    return <SkeletonView />;
+  }
+
+  const isEmpty =
+    data.languages.length === 0 && data.repositories.length === 0;
+
+  if (isEmpty) {
+    return <EmptyView />;
+  }
+
+  return (
+    <div className="p-6 bg-gm-bg-card/80 backdrop-blur-sm rounded-2xl border border-gm-accent-cyan/20">
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-lg font-semibold text-dt-text-main">
+          言語別 / リポジトリ別統計
+        </h3>
+        {fromCache ? (
+          <span
+            className="text-xs text-dt-text-sub px-2 py-0.5 rounded-full bg-slate-800/80"
+            title="キャッシュから表示中（バックグラウンドで更新）"
+          >
+            キャッシュ
+          </span>
+        ) : null}
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-[14rem_1fr] gap-6">
+        <LanguagePie data={data} />
+        <RepositoryBars repositories={data.repositories} />
+      </div>
+    </div>
+  );
+};

--- a/src/components/features/gamification/LanguageBreakdownCard.tsx
+++ b/src/components/features/gamification/LanguageBreakdownCard.tsx
@@ -255,13 +255,13 @@ const LanguagePie: React.FC<{ data: LanguageBreakdownResponse }> = ({ data }) =>
           >
             <span className="flex items-center gap-2 min-w-0">
               <span
-                className="inline-block w-3 h-3 rounded-sm flex-shrink-0"
+                className="inline-block w-3 h-3 rounded-sm shrink-0"
                 style={{ backgroundColor: languageColor(language, fallbackIndex) }}
                 aria-hidden="true"
               />
               <span className="truncate text-dt-text-main">{language.name}</span>
             </span>
-            <span className="text-dt-text-sub font-gaming-mono text-xs flex-shrink-0">
+            <span className="text-dt-text-sub font-gaming-mono text-xs shrink-0">
               {formatPercent(language.percentage)}
             </span>
           </li>
@@ -280,7 +280,7 @@ const RepositoryBars: React.FC<{ repositories: RepositoryCodeStats[] }> = ({ rep
   if (visible.length === 0) {
     return (
       <div className="flex items-center justify-center h-32 text-sm text-dt-text-sub">
-        過去 90 日のコミット履歴に該当するリポジトリがありません
+        過去 30 日のコミット履歴に該当するリポジトリがありません
       </div>
     );
   }
@@ -288,7 +288,7 @@ const RepositoryBars: React.FC<{ repositories: RepositoryCodeStats[] }> = ({ rep
   return (
     <div className="space-y-3">
       <div className="flex items-baseline justify-between text-xs text-dt-text-sub">
-        <span>過去 90 日 — 上位 {visible.length} リポジトリ</span>
+        <span>過去 30 日 — 上位 {visible.length} リポジトリ</span>
         <span className="font-gaming-mono">+追加 / −削除</span>
       </div>
 
@@ -304,7 +304,7 @@ const RepositoryBars: React.FC<{ repositories: RepositoryCodeStats[] }> = ({ rep
                 <span className="flex items-center gap-2 min-w-0">
                   {repo.primaryLanguage && (
                     <span
-                      className="inline-block w-2.5 h-2.5 rounded-full flex-shrink-0"
+                      className="inline-block w-2.5 h-2.5 rounded-full shrink-0"
                       style={{
                         backgroundColor:
                           repo.primaryLanguageColor ?? FALLBACK_COLORS[0],

--- a/src/components/features/gamification/index.ts
+++ b/src/components/features/gamification/index.ts
@@ -12,5 +12,6 @@ export { StatsDisplay } from './StatsDisplay';
 export { ChallengeCard } from './ChallengeCard';
 export { BadgeGrid } from './BadgeGrid';
 export { ContributionGraph } from './ContributionGraph';
+export { LanguageBreakdownCard } from './LanguageBreakdownCard';
 export { XpNotification } from './XpNotification';
 export { DashboardContent } from './DashboardContent';

--- a/src/lib/tauri/commands.ts
+++ b/src/lib/tauri/commands.ts
@@ -43,6 +43,7 @@ import type {
   SyncResult,
   CodeStatsSyncResult,
   CodeStatsResponse,
+  LanguageBreakdownResponse,
   RateLimitInfo,
   RateLimitDetailed,
   TodayCommitsSummary,
@@ -531,6 +532,16 @@ export const github = {
    */
   getTodayCommitsWithCache: (): Promise<CachedResponse<TodayCommitsSummary>> =>
     invoke<CachedResponse<TodayCommitsSummary>>('get_today_commits_with_cache'),
+
+  /**
+   * 言語別／リポジトリ別コード統計の集計（Issue #193 — G-11）。
+   *
+   * 単一の GraphQL クエリで言語の byte 比率と過去 90 日のリポジトリ別
+   * 追加・削除を取得し、24 時間 SQLite キャッシュでフォアグラウンドの
+   * リバリデーションでもレート制限を消費しない設計。
+   */
+  getLanguageBreakdownWithCache: (): Promise<CachedResponse<LanguageBreakdownResponse>> =>
+    invoke<CachedResponse<LanguageBreakdownResponse>>('get_language_breakdown_with_cache'),
 };
 
 // ============================================================================

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -130,6 +130,13 @@ export const Home = () => {
     githubStatsQuery.data === null && githubStatsQuery.error === null;
   const userPending =
     userStatsQuery.data === null && userStatsQuery.error === null;
+  // Same `data === null && error === null` anchor as the other queries so
+  // the LanguageBreakdownCard renders its skeleton (not an Empty state) for
+  // the indeterminate frame between `enabled = true` and the hook's first
+  // commit.
+  const languageBreakdownPending =
+    languageBreakdownQuery.data === null &&
+    languageBreakdownQuery.error === null;
   const initialDataLoading =
     isLoggedIn && (githubPending || userPending || levelLoading);
 
@@ -138,19 +145,23 @@ export const Home = () => {
   const fromCache =
     githubStatsQuery.fromCache ||
     userStatsQuery.fromCache ||
-    activityQuery.fromCache;
+    activityQuery.fromCache ||
+    languageBreakdownQuery.fromCache;
   const hasError =
     githubStatsQuery.error !== null ||
     userStatsQuery.error !== null ||
-    activityQuery.error !== null;
+    activityQuery.error !== null ||
+    languageBreakdownQuery.error !== null;
   const hasData =
     githubStatsQuery.data !== null ||
     userStatsQuery.data !== null ||
-    activityQuery.data !== null;
+    activityQuery.data !== null ||
+    languageBreakdownQuery.data !== null;
   const isRevalidating =
     githubStatsQuery.isRevalidating ||
     userStatsQuery.isRevalidating ||
-    activityQuery.isRevalidating;
+    activityQuery.isRevalidating ||
+    languageBreakdownQuery.isRevalidating;
   // Surface the older of the cache timestamps across all sources so the
   // user sees the worst-case staleness rather than the freshest one.
   const bannerCachedAt =
@@ -158,6 +169,7 @@ export const Home = () => {
       githubStatsQuery.cachedAt,
       userStatsQuery.cachedAt,
       activityQuery.cachedAt,
+      languageBreakdownQuery.cachedAt,
     ]
       .filter((value): value is string => value !== null)
       .sort()[0] ?? null;
@@ -182,7 +194,9 @@ export const Home = () => {
             githubStats={githubStatsQuery.data}
             statsDiff={null}
             languageBreakdown={languageBreakdownQuery.data}
-            languageBreakdownLoading={languageBreakdownQuery.isLoading}
+            languageBreakdownLoading={
+              languageBreakdownQuery.isLoading || languageBreakdownPending
+            }
             languageBreakdownError={languageBreakdownQuery.error}
             languageBreakdownFromCache={languageBreakdownQuery.fromCache}
           />

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -28,6 +28,10 @@ const USER_STATS_STALE_TIME_MS = 60 * 60 * 1000; // 60 minutes
 // Backend caches the events payload for 5 minutes — match it on the client
 // so a focus-revalidation triggers a fresh fetch instead of replaying cache.
 const ACTIVITY_STALE_TIME_MS = 5 * 60 * 1000;
+// Language / repository breakdown is cached server-side for 24h (Issue
+// #193). Mirroring that on the client keeps focus revalidations from
+// burning the GraphQL budget on what is fundamentally slow-moving data.
+const LANGUAGE_BREAKDOWN_STALE_TIME_MS = 24 * 60 * 60 * 1000;
 
 // Home skeleton loader
 const HomeSkeleton = () => (
@@ -64,6 +68,14 @@ export const Home = () => {
     staleTime: ACTIVITY_STALE_TIME_MS,
   });
 
+  const languageBreakdownQuery = useCachedFetch(
+    github.getLanguageBreakdownWithCache,
+    {
+      enabled,
+      staleTime: LANGUAGE_BREAKDOWN_STALE_TIME_MS,
+    },
+  );
+
   // `level_info` does not yet have a `_with_cache` variant — it is computed
   // from local DB state and is cheap, so a plain fetch is fine here.
   const [levelInfo, setLevelInfo] = useState<LevelInfo | null>(null);
@@ -96,11 +108,13 @@ export const Home = () => {
   const githubRevalidate = githubStatsQuery.revalidate;
   const userRevalidate = userStatsQuery.revalidate;
   const activityRevalidate = activityQuery.revalidate;
+  const languageBreakdownRevalidate = languageBreakdownQuery.revalidate;
   const handleRetry = useCallback(() => {
     void githubRevalidate();
     void userRevalidate();
     void activityRevalidate();
-  }, [githubRevalidate, userRevalidate, activityRevalidate]);
+    void languageBreakdownRevalidate();
+  }, [githubRevalidate, userRevalidate, activityRevalidate, languageBreakdownRevalidate]);
 
   // Initial loading: wait for auth restore and the first data fetch when
   // logged in. Cached data short-circuits this — once any cached value is
@@ -167,6 +181,10 @@ export const Home = () => {
             userStats={userStatsQuery.data}
             githubStats={githubStatsQuery.data}
             statsDiff={null}
+            languageBreakdown={languageBreakdownQuery.data}
+            languageBreakdownLoading={languageBreakdownQuery.isLoading}
+            languageBreakdownError={languageBreakdownQuery.error}
+            languageBreakdownFromCache={languageBreakdownQuery.fromCache}
           />
           <div className="mt-6">
             <ActivityTimeline

--- a/src/types/gamification.ts
+++ b/src/types/gamification.ts
@@ -394,6 +394,49 @@ export interface CodeStatsSyncResult {
   rateLimit: RateLimitInfo | null;
 }
 
+/// 言語別コード統計（Issue #193）
+export interface LanguageStats {
+  /// 言語名（例: "TypeScript"）
+  name: string;
+  /// GitHub linguist が提供するカラーコード（例: "#3178c6"）
+  color: string | null;
+  /// 走査したリポジトリ全体での累積バイト数
+  bytes: number;
+  /// 全体に占める割合（0.0〜1.0）
+  percentage: number;
+}
+
+/// リポジトリ別コード統計（Issue #193）
+export interface RepositoryCodeStats {
+  /// `owner/repo` 形式の完全名
+  nameWithOwner: string;
+  /// リポジトリの URL
+  url: string | null;
+  /// 集計期間中の追加行数
+  additions: number;
+  /// 集計期間中の削除行数
+  deletions: number;
+  /// 集計期間中のコミット数
+  commitsCount: number;
+  /// プライマリ言語（バイト数最大の言語）
+  primaryLanguage: string | null;
+  primaryLanguageColor: string | null;
+}
+
+/// 言語別／リポジトリ別の集計レスポンス（Issue #193 — G-11）
+export interface LanguageBreakdownResponse {
+  /// バイト数降順で並んだ言語別統計
+  languages: LanguageStats[];
+  /// 追加・削除の合計が大きい順に並んだリポジトリ別統計
+  repositories: RepositoryCodeStats[];
+  /// 全言語のバイト数合計
+  totalBytes: number;
+  /// 集計期間の開始 ISO8601 タイムスタンプ
+  since: string;
+  /// 走査したリポジトリ数
+  repositoriesScanned: number;
+}
+
 /// 純増減行数を取得
 export function netChange(stats: DailyCodeStats): number {
   return stats.additions - stats.deletions;


### PR DESCRIPTION
## Summary

Implements the language distribution pie chart and per-repository additions/deletions bar chart introduced in Issue #193 (audit §1 G-11). A single GraphQL query fetches both visualizations to minimize API rate-limit pressure, with 24-hour server-side caching and client-side SWR-style revalidation.

## Key Changes

**Backend (Rust)**
- Added `get_language_breakdown()` GraphQL query to `GitHubClient` that fetches:
  - Per-language byte distribution across repositories (top 10 languages per repo)
  - Per-repository commit history (additions/deletions) over a 90-day window
  - Excludes forks and orders repositories by `PUSHED_AT DESC` to prioritize active work
- Implemented `get_language_breakdown_with_cache()` command with:
  - 24-hour SQLite cache with automatic expiration
  - Network error fallback to stale cache (mirrors existing `*_with_cache` patterns)
  - 50-repository scan cap to keep GraphQL cost bounded
- Added type definitions for GraphQL response parsing and frontend serialization

**Frontend (TypeScript/React)**
- Created `LanguageBreakdownCard` component with:
  - Hand-rolled SVG pie chart (no chart library dependency; dataset is small)
  - Per-language legend with byte percentages
  - Per-repository bar chart showing additions (green) vs. deletions (red) over 90 days
  - Skeleton, error, and empty states
  - Accessibility features (ARIA labels, semantic HTML, screen reader text)
- Integrated into `DashboardContent` with loading/error/cache state props
- Added `useCachedFetch` hook integration in `Home.tsx` with 24-hour stale time
- Exported new types and component from gamification module

**Database**
- Added `LANGUAGE_BREAKDOWN` cache type constant

## Implementation Details

- **SVG-based charts**: No external chart library; pie slices computed via trigonometry, bars via CSS flexbox with percentage widths
- **Single GraphQL call**: Both visualizations driven by one query to reduce API pressure
- **Fallback colors**: 10-color palette for languages without GitHub linguist color data
- **Aggregation logic**: Languages summed across all scanned repos; repositories sorted by total churn (additions + deletions)
- **Caching strategy**: 24-hour server cache with client-side SWR revalidation on focus (matches `ACTIVITY_STALE_TIME_MS` pattern)
- **Japanese UI labels**: Consistent with existing gamification dashboard localization

https://claude.ai/code/session_01TH1XSPRRBnmRyv1rKS4zrk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 言語・リポジトリ内訳カードを追加しました。言語バイト比率を円グラフで、リポジトリ別の追加/削除をバーチャートで表示します。
  * データは24時間キャッシュされ、ネットワークや認証エラー時は直近のキャッシュをフォールバック利用します。フロントエンドにキャッシュ/ロード/エラー状態を提供します。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otomatty/development-tools/pull/216)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->