### PR TITLE
feat: Add past-year XP recalculation feature (Issue #194)

### DIFF
--- a/src-tauri/src/commands/gamification.rs
+++ b/src-tauri/src/commands/gamification.rs
@@ -359,6 +359,20 @@ pub async fn recalculate_xp_history(
     // wait for the scheduler-driven sync to finish, so the upper bound
     // of the window must reflect that wait.
     let recalc_at = Utc::now();
+
+    // Re-derive the 365-day floor against `recalc_at` and clamp
+    // `parsed_since` forward if the lock wait pushed the original lower
+    // bound past the contributionCalendar cap. Without this, a long
+    // lock wait (e.g. behind a scheduler-driven sync) could send a
+    // `[from, to]` span > 365 days to GitHub and trigger an intermittent
+    // GraphQL rejection for a request that was valid at submit time.
+    let effective_max_lookback = recalc_at - Duration::days(RECALC_MAX_WINDOW_DAYS);
+    let parsed_since = if parsed_since < effective_max_lookback {
+        effective_max_lookback
+    } else {
+        parsed_since
+    };
+
     if let Some(last) = state
         .db
         .get_last_recalculation_at(user.id)

--- a/src-tauri/src/commands/gamification.rs
+++ b/src-tauri/src/commands/gamification.rs
@@ -2,10 +2,13 @@
 //!
 //! These commands handle the gamification features: XP, levels, badges, etc.
 
-use tauri::{command, State};
+use chrono::{DateTime, Duration, Utc};
+use tauri::{command, AppHandle, State};
 
 use super::auth::AppState;
-use crate::database::{badge, level, Badge, UserStats, XpHistoryEntry};
+use crate::auth::map_github_result;
+use crate::database::{badge, level, xp::XpBreakdown, Badge, UserStats, XpHistoryEntry};
+use crate::github::GitHubClient;
 
 /// Level info for frontend
 #[derive(Debug, Clone, serde::Serialize)]
@@ -189,4 +192,294 @@ pub fn get_badge_definitions() -> Vec<BadgeDefinition> {
             icon: def.icon,
         })
         .collect()
+}
+
+// ============================================================================
+// Past-year XP recalculation (Issue #194 / Audit §6.2 / §8 G-13)
+//
+// `contributionCalendar` is GraphQL-capped to ~1 year, so this is the
+// maximum window we can ever recalculate. The user-facing rate-limit
+// guard is intentionally short (1 hour): the GraphQL call itself is
+// cheap, but recalculation churns `xp_history` and the comparison UI is
+// not useful to re-run rapidly. Concurrent invocations are serialised
+// through `AppState::sync_lock` so a manual recalc can't race a
+// scheduler-driven `run_github_sync`.
+// ============================================================================
+
+/// Maximum span for `contributionCalendar` — GitHub rejects `from` values
+/// older than this. Mirrors the cap documented in
+/// `XpBreakdown::calculate` / Issue #194.
+const RECALC_MAX_WINDOW_DAYS: i64 = 365;
+
+/// Minimum interval between recalculations per user. Short enough that
+/// fixing a mistake is easy, long enough that the button can't be
+/// drum-rolled into mass `xp_history` rows.
+const RECALC_RATE_LIMIT_MINUTES: i64 = 60;
+
+/// XP breakdown surface for the recalculation result.
+///
+/// Mirrors `XpBreakdownResult` from `commands::github` so the frontend
+/// can render the same breakdown widget without depending on
+/// gamification-internal types. Defined locally to avoid a cross-command
+/// import cycle.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RecalculatedXpBreakdown {
+    pub commits_xp: i32,
+    pub prs_created_xp: i32,
+    pub prs_merged_xp: i32,
+    pub issues_created_xp: i32,
+    pub issues_closed_xp: i32,
+    pub reviews_xp: i32,
+    pub stars_xp: i32,
+    pub streak_bonus_xp: i32,
+    pub total_xp: i32,
+}
+
+impl From<&XpBreakdown> for RecalculatedXpBreakdown {
+    fn from(b: &XpBreakdown) -> Self {
+        Self {
+            commits_xp: b.commits_xp,
+            prs_created_xp: b.prs_created_xp,
+            prs_merged_xp: b.prs_merged_xp,
+            issues_created_xp: b.issues_created_xp,
+            issues_closed_xp: b.issues_closed_xp,
+            reviews_xp: b.reviews_xp,
+            stars_xp: b.stars_xp,
+            streak_bonus_xp: b.streak_bonus_xp,
+            total_xp: b.total_xp,
+        }
+    }
+}
+
+/// Result returned to the frontend after a successful recalculation.
+///
+/// Contains both the freshly computed total and the existing live total
+/// for the same window so the UI can render the "before / after" diff
+/// required by Issue #194's DoD ("計算前後の値を比較表示できる"). The
+/// recalculated row is persisted in `xp_history` with `source =
+/// 'recalculated'` (NOT folded into `user_stats.total_xp`) — its row id
+/// is returned in `recalculation_history_id` so callers can drill into
+/// it from the XP history page.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RecalculationResult {
+    /// Inclusive lower bound of the window (RFC3339).
+    pub since: String,
+    /// Exclusive upper bound of the window — the moment the recalc ran
+    /// (RFC3339).
+    pub until: String,
+    /// Total XP the recalculation produced for the window.
+    pub recalculated_total_xp: i32,
+    /// Per-category breakdown driving `recalculated_total_xp`.
+    pub recalculated_breakdown: RecalculatedXpBreakdown,
+    /// Sum of `xp_history.xp_amount` rows with `source = 'live'` that
+    /// were created within `[since, until]`. Used to render the diff.
+    pub previous_live_total_xp_in_window: i32,
+    /// `recalculated_total_xp - previous_live_total_xp_in_window`. Can
+    /// be negative when live XP was higher (e.g. legacy XP rules
+    /// granted more than the current ruleset).
+    pub xp_diff: i32,
+    /// `xp_history.id` of the inserted `source = 'recalculated'` row.
+    pub recalculation_history_id: i64,
+    /// Number of days the recalculation window spanned, for UI labels.
+    pub window_days: i64,
+    /// Raw GitHub category totals over the window (commits / PRs /
+    /// issues / reviews). Exposed so the UI can explain *why* the
+    /// breakdown looks the way it does without a second API call.
+    pub contributions: RecalcContributionTotals,
+    /// Categories the recalculation cannot fill from
+    /// `contributionsCollection` alone (PR merges, issues closed,
+    /// stars). Surfaced so the UI can disclose the gap rather than
+    /// silently treating them as zero.
+    pub uncovered_categories: Vec<&'static str>,
+}
+
+/// GitHub-side category totals consumed by `XpBreakdown::calculate`.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RecalcContributionTotals {
+    pub commits: i32,
+    pub pull_requests: i32,
+    pub issues: i32,
+    pub reviews: i32,
+    pub current_streak: i32,
+}
+
+/// Recalculate XP for the past `contributionCalendar` window
+/// (≤ 1 year). Inserts an audit row in `xp_history` with
+/// `source = 'recalculated'` and returns the comparison against the
+/// existing live XP earned in the same window.
+///
+/// `since` is an optional RFC3339 timestamp; when omitted the full year
+/// window is used. Out-of-range values (in the future, or older than
+/// 1 year) are rejected with a descriptive error.
+#[command]
+pub async fn recalculate_xp_history(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    since: Option<String>,
+) -> Result<RecalculationResult, String> {
+    let user = state
+        .token_manager
+        .get_current_user()
+        .await
+        .map_err(|e| e.to_string())?
+        .ok_or("Not logged in")?;
+
+    let now = Utc::now();
+    let max_lookback = now - Duration::days(RECALC_MAX_WINDOW_DAYS);
+
+    let parsed_since = match since.as_deref() {
+        Some(s) => DateTime::parse_from_rfc3339(s)
+            .map(|dt| dt.with_timezone(&Utc))
+            .map_err(|e| format!("Invalid `since` timestamp ({}): {}", s, e))?,
+        None => max_lookback,
+    };
+
+    if parsed_since > now {
+        return Err("`since` cannot be in the future".to_string());
+    }
+    if parsed_since < max_lookback {
+        return Err(format!(
+            "`since` must be within the last {} days (contributionCalendar limit)",
+            RECALC_MAX_WINDOW_DAYS
+        ));
+    }
+
+    // Rate-limit guard — short and read-only so we can reject before
+    // taking the sync lock or hitting the GraphQL API.
+    if let Some(last) = state
+        .db
+        .get_last_recalculation_at(user.id)
+        .await
+        .map_err(|e| e.to_string())?
+    {
+        let next_allowed = last + Duration::minutes(RECALC_RATE_LIMIT_MINUTES);
+        if next_allowed > now {
+            let wait_minutes = (next_allowed - now).num_minutes().max(1);
+            return Err(format!(
+                "XP 再計算は{}分に1回までです。次回は約{}分後 ({}) に実行できます。",
+                RECALC_RATE_LIMIT_MINUTES,
+                wait_minutes,
+                next_allowed.to_rfc3339()
+            ));
+        }
+    }
+
+    // Hold the sync lock so a manual recalc can't race a scheduler-driven
+    // `run_github_sync`. The locking pattern mirrors `run_github_sync`.
+    let _guard = state.sync_lock.lock().await;
+
+    let token = state
+        .token_manager
+        .get_access_token()
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let client = GitHubClient::new(token);
+    let contributions = map_github_result(
+        &app,
+        state.inner(),
+        client
+            .get_contribution_calendar_window(&user.username, Some(parsed_since), Some(now))
+            .await,
+    )
+    .await?;
+
+    // Use the live current_streak so the recalculation's streak bonus
+    // matches what `run_github_sync` would award today. Streak history
+    // is not part of `contributionsCollection`, so we deliberately read
+    // it from local state rather than re-deriving it.
+    let current_streak = state
+        .db
+        .get_user_stats(user.id)
+        .await
+        .map_err(|e| e.to_string())?
+        .map(|s| s.current_streak)
+        .unwrap_or(0);
+
+    // `contributionsCollection` only exposes counts for the four
+    // categories below — PR merges, issues closed, and stars require
+    // separate (Search API) requests that we deliberately avoid here
+    // to keep the recalculation cheap and rate-limit-safe. The UI
+    // surfaces the gap via `uncovered_categories`.
+    let commits = clamp_to_u64(contributions.total_commit_contributions);
+    let prs = clamp_to_u64(contributions.total_pull_request_contributions);
+    let issues = clamp_to_u64(contributions.total_issue_contributions);
+    let reviews = clamp_to_u64(contributions.total_pull_request_review_contributions);
+
+    let breakdown = XpBreakdown::calculate(
+        commits,
+        prs,
+        /* prs_merged */ 0,
+        issues,
+        /* issues_closed */ 0,
+        reviews,
+        /* stars */ 0,
+        current_streak,
+    );
+
+    let window_days = (now - parsed_since).num_days().max(0);
+    let description = format!(
+        "過去{}日分のXP再計算 (commits={}, prs={}, issues={}, reviews={}, streak={})",
+        window_days,
+        contributions.total_commit_contributions,
+        contributions.total_pull_request_contributions,
+        contributions.total_issue_contributions,
+        contributions.total_pull_request_review_contributions,
+        current_streak,
+    );
+
+    let recalc_id = state
+        .db
+        .record_xp_recalculation(
+            user.id,
+            breakdown.total_xp,
+            Some(&description),
+            Some(&breakdown),
+        )
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let previous_live_total = state
+        .db
+        .get_xp_total_in_range(
+            user.id,
+            parsed_since,
+            crate::database::repository::XP_HISTORY_SOURCE_LIVE,
+        )
+        .await
+        .map_err(|e| e.to_string())?;
+
+    Ok(RecalculationResult {
+        since: parsed_since.to_rfc3339(),
+        until: now.to_rfc3339(),
+        recalculated_total_xp: breakdown.total_xp,
+        recalculated_breakdown: RecalculatedXpBreakdown::from(&breakdown),
+        previous_live_total_xp_in_window: previous_live_total,
+        xp_diff: breakdown.total_xp - previous_live_total,
+        recalculation_history_id: recalc_id,
+        window_days,
+        contributions: RecalcContributionTotals {
+            commits: contributions.total_commit_contributions,
+            pull_requests: contributions.total_pull_request_contributions,
+            issues: contributions.total_issue_contributions,
+            reviews: contributions.total_pull_request_review_contributions,
+            current_streak,
+        },
+        uncovered_categories: vec!["prs_merged", "issues_closed", "stars"],
+    })
+}
+
+/// Clamp a possibly-negative `i32` count to `u64` so it can feed
+/// `XpBreakdown::calculate`. Mirrors the helper in `commands::github`
+/// but duplicated here to avoid pulling the entire github command
+/// module into the gamification surface.
+fn clamp_to_u64(value: i32) -> u64 {
+    if value < 0 {
+        0
+    } else {
+        value as u64
+    }
 }

--- a/src-tauri/src/commands/gamification.rs
+++ b/src-tauri/src/commands/gamification.rs
@@ -347,8 +347,18 @@ pub async fn recalculate_xp_history(
         ));
     }
 
-    // Rate-limit guard — short and read-only so we can reject before
-    // taking the sync lock or hitting the GraphQL API.
+    // Hold the sync lock so a manual recalc can't race a scheduler-driven
+    // `run_github_sync` *and* so two concurrent recalc calls can't both
+    // pass the rate-limit guard before either has written its row. The
+    // rate-limit check therefore runs INSIDE the locked section — moving
+    // it before `lock()` would re-introduce the TOCTOU window flagged in
+    // PR #217 review.
+    let _guard = state.sync_lock.lock().await;
+
+    // Re-take the clock after acquiring the lock; `lock()` itself can
+    // wait for the scheduler-driven sync to finish, so the upper bound
+    // of the window must reflect that wait.
+    let recalc_at = Utc::now();
     if let Some(last) = state
         .db
         .get_last_recalculation_at(user.id)
@@ -356,8 +366,8 @@ pub async fn recalculate_xp_history(
         .map_err(|e| e.to_string())?
     {
         let next_allowed = last + Duration::minutes(RECALC_RATE_LIMIT_MINUTES);
-        if next_allowed > now {
-            let wait_minutes = (next_allowed - now).num_minutes().max(1);
+        if next_allowed > recalc_at {
+            let wait_minutes = (next_allowed - recalc_at).num_minutes().max(1);
             return Err(format!(
                 "XP 再計算は{}分に1回までです。次回は約{}分後 ({}) に実行できます。",
                 RECALC_RATE_LIMIT_MINUTES,
@@ -366,10 +376,6 @@ pub async fn recalculate_xp_history(
             ));
         }
     }
-
-    // Hold the sync lock so a manual recalc can't race a scheduler-driven
-    // `run_github_sync`. The locking pattern mirrors `run_github_sync`.
-    let _guard = state.sync_lock.lock().await;
 
     let token = state
         .token_manager
@@ -382,7 +388,7 @@ pub async fn recalculate_xp_history(
         &app,
         state.inner(),
         client
-            .get_contribution_calendar_window(&user.username, Some(parsed_since), Some(now))
+            .get_contribution_calendar_window(&user.username, Some(parsed_since), Some(recalc_at))
             .await,
     )
     .await?;
@@ -420,7 +426,7 @@ pub async fn recalculate_xp_history(
         current_streak,
     );
 
-    let window_days = (now - parsed_since).num_days().max(0);
+    let window_days = (recalc_at - parsed_since).num_days().max(0);
     let description = format!(
         "過去{}日分のXP再計算 (commits={}, prs={}, issues={}, reviews={}, streak={})",
         window_days,
@@ -442,11 +448,17 @@ pub async fn recalculate_xp_history(
         .await
         .map_err(|e| e.to_string())?;
 
+    // Bound the live-XP comparison query to the exact `[since, recalc_at]`
+    // window the result reports, so the "before" total never drifts even
+    // if `run_github_sync` was queued behind our sync_lock and recorded a
+    // row between `recalc_at` and this query — that row would belong to
+    // the *next* window, not this one.
     let previous_live_total = state
         .db
         .get_xp_total_in_range(
             user.id,
             parsed_since,
+            recalc_at,
             crate::database::repository::XP_HISTORY_SOURCE_LIVE,
         )
         .await
@@ -454,7 +466,7 @@ pub async fn recalculate_xp_history(
 
     Ok(RecalculationResult {
         since: parsed_since.to_rfc3339(),
-        until: now.to_rfc3339(),
+        until: recalc_at.to_rfc3339(),
         recalculated_total_xp: breakdown.total_xp,
         recalculated_breakdown: RecalculatedXpBreakdown::from(&breakdown),
         previous_live_total_xp_in_window: previous_live_total,

--- a/src-tauri/src/commands/gamification.rs
+++ b/src-tauri/src/commands/gamification.rs
@@ -9,6 +9,7 @@ use super::auth::AppState;
 use crate::auth::map_github_result;
 use crate::database::{badge, level, xp::XpBreakdown, Badge, UserStats, XpHistoryEntry};
 use crate::github::GitHubClient;
+use crate::utils::numeric::clamp_to_u64;
 
 /// Level info for frontend
 #[derive(Debug, Clone, serde::Serialize)]
@@ -296,6 +297,12 @@ pub struct RecalculationResult {
 }
 
 /// GitHub-side category totals consumed by `XpBreakdown::calculate`.
+///
+/// `live_current_streak` is the user's *current* streak as of the
+/// recalculation moment — NOT a streak re-derived from the recalculation
+/// window. The UI labels it as such so users don't read it as "streak
+/// during the recalculated period". See the comment in
+/// `recalculate_xp_history` for the rationale.
 #[derive(Debug, Clone, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RecalcContributionTotals {
@@ -303,7 +310,7 @@ pub struct RecalcContributionTotals {
     pub pull_requests: i32,
     pub issues: i32,
     pub reviews: i32,
-    pub current_streak: i32,
+    pub live_current_streak: i32,
 }
 
 /// Recalculate XP for the past `contributionCalendar` window
@@ -407,11 +414,22 @@ pub async fn recalculate_xp_history(
     )
     .await?;
 
-    // Use the live current_streak so the recalculation's streak bonus
-    // matches what `run_github_sync` would award today. Streak history
-    // is not part of `contributionsCollection`, so we deliberately read
-    // it from local state rather than re-deriving it.
-    let current_streak = state
+    // Deliberate design: the streak bonus uses the **live current
+    // streak as of `recalc_at`**, not a streak re-derived from the
+    // recalculation window. Two reasons:
+    //
+    //   1. `contributionsCollection` doesn't expose per-day streak
+    //      state, so a window-derived streak would have to be
+    //      re-implemented from `contribution_calendar.weeks` and would
+    //      diverge from `Self::calculate_streak`'s production logic.
+    //   2. The bonus in `XpBreakdown::calculate` is "current consistency"
+    //      reward — using today's streak keeps the recalculation aligned
+    //      with what `run_github_sync` would award at this moment.
+    //
+    // `RecalcContributionTotals.current_streak` surfaces the value to
+    // the UI so the modal can label it explicitly as the live streak,
+    // not the historical one.
+    let live_current_streak = state
         .db
         .get_user_stats(user.id)
         .await
@@ -437,18 +455,18 @@ pub async fn recalculate_xp_history(
         /* issues_closed */ 0,
         reviews,
         /* stars */ 0,
-        current_streak,
+        live_current_streak,
     );
 
     let window_days = (recalc_at - parsed_since).num_days().max(0);
     let description = format!(
-        "過去{}日分のXP再計算 (commits={}, prs={}, issues={}, reviews={}, streak={})",
+        "過去{}日分のXP再計算 (commits={}, prs={}, issues={}, reviews={}, live_streak={})",
         window_days,
         contributions.total_commit_contributions,
         contributions.total_pull_request_contributions,
         contributions.total_issue_contributions,
         contributions.total_pull_request_review_contributions,
-        current_streak,
+        live_current_streak,
     );
 
     let recalc_id = state
@@ -492,20 +510,8 @@ pub async fn recalculate_xp_history(
             pull_requests: contributions.total_pull_request_contributions,
             issues: contributions.total_issue_contributions,
             reviews: contributions.total_pull_request_review_contributions,
-            current_streak,
+            live_current_streak,
         },
         uncovered_categories: vec!["prs_merged", "issues_closed", "stars"],
     })
-}
-
-/// Clamp a possibly-negative `i32` count to `u64` so it can feed
-/// `XpBreakdown::calculate`. Mirrors the helper in `commands::github`
-/// but duplicated here to avoid pulling the entire github command
-/// module into the gamification surface.
-fn clamp_to_u64(value: i32) -> u64 {
-    if value < 0 {
-        0
-    } else {
-        value as u64
-    }
 }

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -12,6 +12,7 @@ use crate::database::{
 };
 use crate::github::{GitHubClient, GitHubStats, GitHubUser};
 use crate::utils::notifications::send_notification;
+use crate::utils::numeric::clamp_to_u64;
 
 /// Saturating, sign-safe difference between two cumulative i32 counters.
 ///
@@ -23,15 +24,6 @@ use crate::utils::notifications::send_notification;
 /// "first sync" branches funnel through.
 fn diff_count(current: i32, previous: i32) -> u64 {
     clamp_to_u64(current).saturating_sub(clamp_to_u64(previous))
-}
-
-/// Clamp a possibly-negative `i32` count to a `u64` (negative → 0).
-fn clamp_to_u64(value: i32) -> u64 {
-    if value < 0 {
-        0
-    } else {
-        value as u64
-    }
 }
 
 /// Get GitHub user profile

--- a/src-tauri/src/database/migrations.rs
+++ b/src-tauri/src/database/migrations.rs
@@ -493,6 +493,41 @@ CREATE INDEX IF NOT EXISTS idx_xp_history_user_source_created
     ON xp_history(user_id, source, created_at);
 "#,
     },
+    Migration {
+        version: 16,
+        name: "normalize_xp_history_created_at_to_rfc3339",
+        sql: r#"
+-- One-shot canonicalisation of `xp_history.created_at`.
+--
+-- Rows recorded before Issue #194 were inserted via SQLite's
+-- `CURRENT_TIMESTAMP` default and stored as `YYYY-MM-DD HH:MM:SS` (UTC,
+-- whole seconds). Rows recorded after Issue #194 are written as RFC3339
+-- with sub-second precision (e.g. `2026-05-10T22:11:33.482912+00:00`).
+--
+-- The mixed format forced range queries to wrap `created_at` in
+-- `datetime(...)` for correctness, which (a) prevented the
+-- `(user_id, source, created_at)` index from being used for the range
+-- portion and (b) silently rounded both sides to whole seconds, so a
+-- sub-second-precision live row written near the bound could be
+-- mis-classified by `recalculate_xp_history`'s before/after diff
+-- (Codex P2 review on PR #217).
+--
+-- Backfilling the legacy rows to `YYYY-MM-DDTHH:MM:SS+00:00` gives the
+-- whole table a single canonical lexicographic ordering that:
+--   1. matches the new RFC3339 inserts byte-for-byte for the same
+--      whole-second instant;
+--   2. preserves sub-second precision (no `datetime()` truncation);
+--   3. lets the v15 composite index drive range scans directly.
+--
+-- Idempotent guard: the `WHERE` clause skips any row that already has
+-- a 'T' (i.e. is already RFC3339), so re-running the migration on a
+-- fresh install (with no legacy rows) or on a partially-migrated DB
+-- is a no-op.
+UPDATE xp_history
+   SET created_at = strftime('%Y-%m-%dT%H:%M:%S+00:00', created_at)
+ WHERE created_at NOT LIKE '%T%';
+"#,
+    },
 ];
 
 /// Create the migrations tracking table

--- a/src-tauri/src/database/migrations.rs
+++ b/src-tauri/src/database/migrations.rs
@@ -465,6 +465,34 @@ ALTER TABLE user_stats ADD COLUMN languages_count INTEGER NOT NULL DEFAULT 0;
 ALTER TABLE user_stats ADD COLUMN total_stars_received INTEGER NOT NULL DEFAULT 0;
 "#,
     },
+    Migration {
+        version: 15,
+        name: "add_xp_history_source",
+        sql: r#"
+-- Distinguish how each xp_history row was produced so the past-year
+-- recalculation feature (Issue #194 / Audit §6.2 / §8 G-13) can coexist
+-- with the live sync stream without overwriting it.
+--
+-- 'live'         — recorded by run_github_sync / streak bonus / manual add_xp
+--                  (default for all existing rows so this migration is a no-op
+--                  for live behaviour and `total_xp` is unchanged).
+-- 'recalculated' — written by recalculate_xp_history; these rows are NOT
+--                  added to `user_stats.total_xp`. They exist purely as an
+--                  audit / comparison surface so the UI can render
+--                  "live vs recalculated" without destroying the original
+--                  XP record.
+--
+-- Keeping the original 'live' rows intact preserves the audit trail and
+-- makes the recalculation idempotent: re-running just inserts another
+-- 'recalculated' row, never mutates past 'live' entries.
+ALTER TABLE xp_history ADD COLUMN source TEXT NOT NULL DEFAULT 'live';
+
+-- Index supports both (a) the rate-limit guard's "most recent recalc per
+-- user" lookup and (b) the per-window total used for before/after diffing.
+CREATE INDEX IF NOT EXISTS idx_xp_history_user_source_created
+    ON xp_history(user_id, source, created_at);
+"#,
+    },
 ];
 
 /// Create the migrations tracking table

--- a/src-tauri/src/database/models/xp.rs
+++ b/src-tauri/src/database/models/xp.rs
@@ -64,6 +64,12 @@ pub struct XpHistoryEntry {
     pub github_event_id: Option<String>,
     pub breakdown: Option<XpBreakdown>,
     pub created_at: DateTime<Utc>,
+    /// How this row was produced. `"live"` for entries that contribute to
+    /// `user_stats.total_xp` (sync, streak bonus, manual add_xp);
+    /// `"recalculated"` for audit-only rows written by
+    /// `recalculate_xp_history` (Issue #194). Older rows pre-migration v15
+    /// default to `"live"`.
+    pub source: String,
 }
 
 /// XP action types for database

--- a/src-tauri/src/database/repository/mod.rs
+++ b/src-tauri/src/database/repository/mod.rs
@@ -20,3 +20,4 @@ mod tests;
 // (Most repository operations are methods on `Database` and become
 // available automatically when `Database` is imported.)
 pub use user_stats::UserStatsGitHubAggregates;
+pub use xp_history::{XP_HISTORY_SOURCE_LIVE, XP_HISTORY_SOURCE_RECALCULATED};

--- a/src-tauri/src/database/repository/tests.rs
+++ b/src-tauri/src/database/repository/tests.rs
@@ -738,74 +738,25 @@ async fn test_get_xp_total_in_range_filters_by_source_and_window() {
     assert_eq!(past_window_total, 0);
 }
 
-/// Regression for PR #217 P2 review: `get_recent_xp_history` must order
-/// rows by the canonical instant, not by the raw text. A lexicographic
-/// compare across the two on-disk formats puts every legacy row
-/// (`YYYY-MM-DD HH:MM:SS`) before every RFC3339 row of the same instant
-/// because `' ' < 'T'` — which would scramble the timeline around the
-/// migration day for users carrying pre-Issue #194 rows.
-#[tokio::test]
-async fn test_get_recent_xp_history_orders_mixed_timestamp_formats() {
-    let db = setup_test_db().await;
-    let user = db
-        .create_user(12345, "testuser", None, "token", None, None)
-        .await
-        .expect("Should create user");
-
-    // Older legacy-format row (one hour earlier).
-    sqlx::query(
-        "INSERT INTO xp_history (user_id, action_type, xp_amount, source, created_at) \
-         VALUES (?, 'github_sync', 10, 'live', '2025-12-01 09:00:00')",
-    )
-    .bind(user.id)
-    .execute(db.pool())
-    .await
-    .expect("Insert legacy row");
-    // Newer RFC3339 row (one hour later). Lexicographically the legacy
-    // string sorts *before* the RFC3339 string for the same wall time,
-    // so without `datetime()` normalisation this row would be returned
-    // *second* even though it is the most recent.
-    sqlx::query(
-        "INSERT INTO xp_history (user_id, action_type, xp_amount, source, created_at) \
-         VALUES (?, 'github_sync', 20, 'live', '2025-12-01T10:00:00+00:00')",
-    )
-    .bind(user.id)
-    .execute(db.pool())
-    .await
-    .expect("Insert RFC3339 row");
-
-    let history = db
-        .get_recent_xp_history(user.id, 10)
-        .await
-        .expect("Should fetch history");
-    assert_eq!(history.len(), 2);
-    assert_eq!(
-        history[0].xp_amount, 20,
-        "newest row (RFC3339, 10:00) must come first"
-    );
-    assert_eq!(history[1].xp_amount, 10);
-}
-
-/// Regression for PR #217 P1 review: comparing RFC3339 `since` against
-/// legacy `YYYY-MM-DD HH:MM:SS` `created_at` values must not drop rows.
+/// Regression for PR #217 / migration v16: a directly-inserted legacy
+/// `YYYY-MM-DD HH:MM:SS` row must end up canonical RFC3339 after the v16
+/// backfill SQL runs, so subsequent lexicographic range / ORDER BY
+/// queries are correct without `datetime()` wrapping.
 ///
-/// We seed a legacy-format row directly so `datetime(created_at)`
-/// normalisation in `get_xp_total_in_range` /
-/// `get_last_recalculation_at` is exercised on the format that older
-/// (pre-Issue #194) installs actually have.
+/// We exercise the migration body directly because `setup_test_db` runs
+/// every migration once at boot, before any test row exists.
 #[tokio::test]
-async fn test_get_xp_total_in_range_handles_legacy_timestamp_format() {
+async fn test_migration_v16_normalizes_legacy_created_at_to_rfc3339() {
     let db = setup_test_db().await;
     let user = db
         .create_user(12345, "testuser", None, "token", None, None)
         .await
         .expect("Should create user");
 
-    // Bypass record_xp_gain so the inserted row keeps SQLite's
-    // CURRENT_TIMESTAMP default ("YYYY-MM-DD HH:MM:SS"). The wall
-    // time used here ('2025-12-01 10:00:00') is intentionally chosen
-    // so that the boundary RFC3339 `since` ('2025-12-01T00:00:00+00:00')
-    // sorts *after* it lexicographically — the bug being regressed.
+    // Insert a legacy-format row that v16 hasn't seen yet (it ran during
+    // setup, before this row existed). Mirrors the SQL in
+    // migrations.rs::Migration { version: 16 } so the test fails if the
+    // migration is ever weakened.
     sqlx::query(
         "INSERT INTO xp_history (user_id, action_type, xp_amount, source, created_at) \
          VALUES (?, 'github_sync', 42, 'live', '2025-12-01 10:00:00')",
@@ -814,29 +765,75 @@ async fn test_get_xp_total_in_range_handles_legacy_timestamp_format() {
     .execute(db.pool())
     .await
     .expect("Insert legacy row");
+    sqlx::query(
+        "UPDATE xp_history \
+            SET created_at = strftime('%Y-%m-%dT%H:%M:%S+00:00', created_at) \
+          WHERE created_at NOT LIKE '%T%'",
+    )
+    .execute(db.pool())
+    .await
+    .expect("Re-run v16 backfill");
 
+    let stored: String = sqlx::query_scalar("SELECT created_at FROM xp_history WHERE user_id = ?")
+        .bind(user.id)
+        .fetch_one(db.pool())
+        .await
+        .expect("Read normalised row");
+    assert_eq!(stored, "2025-12-01T10:00:00+00:00");
+
+    // And the canonical row participates in range queries lexicographically.
     let since: chrono::DateTime<Utc> = "2025-12-01T00:00:00+00:00".parse().unwrap();
     let until: chrono::DateTime<Utc> = "2025-12-02T00:00:00+00:00".parse().unwrap();
     let total = db
         .get_xp_total_in_range(user.id, since, until, "live")
         .await
-        .expect("Should fetch legacy-row total");
-    assert_eq!(total, 42, "legacy YYYY-MM-DD HH:MM:SS row must be included");
+        .expect("Should fetch normalised total");
+    assert_eq!(total, 42);
+}
 
-    // A recalc row in the same format must satisfy the rate-limit guard.
+/// Regression for PR #217 Codex P2 review: range filtering must preserve
+/// sub-second precision. Wrapping bounds in `datetime()` previously
+/// rounded both sides to whole seconds, so a row written at .500ms
+/// would wrongly match a bound at .300ms in the same wall-clock second.
+/// After dropping `datetime()` (post-v16 canonicalisation), lexicographic
+/// RFC3339 compare keeps fractional precision intact.
+#[tokio::test]
+async fn test_get_xp_total_in_range_preserves_subsecond_precision() {
+    let db = setup_test_db().await;
+    let user = db
+        .create_user(12345, "testuser", None, "token", None, None)
+        .await
+        .expect("Should create user");
+
+    // Insert a row at exactly :00.500, then bound the window at :00.300.
+    // The row must NOT be counted because it occurs after the bound.
     sqlx::query(
         "INSERT INTO xp_history (user_id, action_type, xp_amount, source, created_at) \
-         VALUES (?, 'recalculation', 0, 'recalculated', '2025-12-01 11:00:00')",
+         VALUES (?, 'github_sync', 99, 'live', '2025-12-01T10:00:00.500+00:00')",
     )
     .bind(user.id)
     .execute(db.pool())
     .await
-    .expect("Insert legacy recalc row");
-    let last = db
-        .get_last_recalculation_at(user.id)
+    .expect("Insert subsecond row");
+
+    let since: chrono::DateTime<Utc> = "2025-12-01T00:00:00+00:00".parse().unwrap();
+    let until: chrono::DateTime<Utc> = "2025-12-01T10:00:00.300+00:00".parse().unwrap();
+    let total = db
+        .get_xp_total_in_range(user.id, since, until, "live")
         .await
-        .expect("Should fetch latest recalc");
-    assert!(last.is_some(), "legacy recalc row must be discoverable");
+        .expect("Should fetch sub-second-bounded total");
+    assert_eq!(
+        total, 0,
+        "row at .500ms must NOT match a bound at .300ms in the same second"
+    );
+
+    // Widening the bound past .500 includes the row.
+    let until_wide: chrono::DateTime<Utc> = "2025-12-01T10:00:00.700+00:00".parse().unwrap();
+    let total_wide = db
+        .get_xp_total_in_range(user.id, since, until_wide, "live")
+        .await
+        .expect("Should fetch widened total");
+    assert_eq!(total_wide, 99);
 }
 
 #[tokio::test]

--- a/src-tauri/src/database/repository/tests.rs
+++ b/src-tauri/src/database/repository/tests.rs
@@ -679,7 +679,10 @@ async fn test_record_xp_recalculation_is_separate_from_live() {
         .await
         .expect("Should fetch history");
     let live_count = history.iter().filter(|e| e.source == "live").count();
-    let recalc_count = history.iter().filter(|e| e.source == "recalculated").count();
+    let recalc_count = history
+        .iter()
+        .filter(|e| e.source == "recalculated")
+        .count();
     assert_eq!(live_count, 1);
     assert_eq!(recalc_count, 1);
 }

--- a/src-tauri/src/database/repository/tests.rs
+++ b/src-tauri/src/database/repository/tests.rs
@@ -624,6 +624,139 @@ async fn test_update_github_aggregates_preserves_xp_and_streak() {
     assert_eq!(after.last_activity_date, before.last_activity_date);
 }
 
+// ---------------------------------------------------------------------------
+// Issue #194: xp_history.source coexistence (recalculation vs live entries).
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_record_xp_gain_defaults_to_live_source() {
+    let db = setup_test_db().await;
+    let user = db
+        .create_user(12345, "testuser", None, "token", None, None)
+        .await
+        .expect("Should create user");
+
+    db.record_xp_gain(user.id, "github_sync", 50, Some("first sync"), None, None)
+        .await
+        .expect("Should record xp gain");
+
+    let history = db
+        .get_recent_xp_history(user.id, 10)
+        .await
+        .expect("Should fetch history");
+    assert_eq!(history.len(), 1);
+    assert_eq!(history[0].source, "live");
+    assert_eq!(history[0].xp_amount, 50);
+}
+
+#[tokio::test]
+async fn test_record_xp_recalculation_is_separate_from_live() {
+    let db = setup_test_db().await;
+    let user = db
+        .create_user(12345, "testuser", None, "token", None, None)
+        .await
+        .expect("Should create user");
+
+    db.record_xp_gain(user.id, "github_sync", 100, Some("live"), None, None)
+        .await
+        .expect("live row");
+    db.record_xp_recalculation(user.id, 80, Some("recalc"), None)
+        .await
+        .expect("recalc row");
+
+    // user_stats.total_xp must NOT include the recalculation row.
+    // record_xp_gain / record_xp_recalculation only write xp_history;
+    // adding to user_stats.total_xp is the live caller's responsibility.
+    let stats = db
+        .get_user_stats(user.id)
+        .await
+        .expect("Should get stats")
+        .expect("Stats should exist");
+    assert_eq!(stats.total_xp, 0);
+
+    let history = db
+        .get_recent_xp_history(user.id, 10)
+        .await
+        .expect("Should fetch history");
+    let live_count = history.iter().filter(|e| e.source == "live").count();
+    let recalc_count = history.iter().filter(|e| e.source == "recalculated").count();
+    assert_eq!(live_count, 1);
+    assert_eq!(recalc_count, 1);
+}
+
+#[tokio::test]
+async fn test_get_xp_total_in_range_filters_by_source_and_window() {
+    let db = setup_test_db().await;
+    let user = db
+        .create_user(12345, "testuser", None, "token", None, None)
+        .await
+        .expect("Should create user");
+
+    // Two live rows ~ now, plus a recalc row that must NOT be counted.
+    db.record_xp_gain(user.id, "github_sync", 30, None, None, None)
+        .await
+        .unwrap();
+    db.record_xp_gain(user.id, "streak_bonus", 20, None, None, None)
+        .await
+        .unwrap();
+    db.record_xp_recalculation(user.id, 999, None, None)
+        .await
+        .unwrap();
+
+    let yesterday = Utc::now() - chrono::Duration::days(1);
+    let live_total = db
+        .get_xp_total_in_range(user.id, yesterday, "live")
+        .await
+        .expect("Should fetch live total");
+    let recalc_total = db
+        .get_xp_total_in_range(user.id, yesterday, "recalculated")
+        .await
+        .expect("Should fetch recalc total");
+
+    assert_eq!(live_total, 50);
+    assert_eq!(recalc_total, 999);
+
+    // Window in the future returns 0 (no rows newer than tomorrow).
+    let tomorrow = Utc::now() + chrono::Duration::days(1);
+    let future_total = db
+        .get_xp_total_in_range(user.id, tomorrow, "live")
+        .await
+        .expect("Should fetch future total");
+    assert_eq!(future_total, 0);
+}
+
+#[tokio::test]
+async fn test_get_last_recalculation_at_returns_latest_recalc_only() {
+    let db = setup_test_db().await;
+    let user = db
+        .create_user(12345, "testuser", None, "token", None, None)
+        .await
+        .expect("Should create user");
+
+    // No recalc rows yet → None.
+    let initial = db
+        .get_last_recalculation_at(user.id)
+        .await
+        .expect("Should query empty");
+    assert!(initial.is_none());
+
+    // Live row alone must not satisfy the rate-limit guard.
+    db.record_xp_gain(user.id, "github_sync", 10, None, None, None)
+        .await
+        .unwrap();
+    assert!(db
+        .get_last_recalculation_at(user.id)
+        .await
+        .unwrap()
+        .is_none());
+
+    db.record_xp_recalculation(user.id, 1, None, None)
+        .await
+        .unwrap();
+    let latest = db.get_last_recalculation_at(user.id).await.unwrap();
+    assert!(latest.is_some(), "Should return the recalc timestamp");
+}
+
 #[tokio::test]
 async fn test_progress_capped_at_target() {
     let db = setup_test_db().await;

--- a/src-tauri/src/database/repository/tests.rs
+++ b/src-tauri/src/database/repository/tests.rs
@@ -704,25 +704,88 @@ async fn test_get_xp_total_in_range_filters_by_source_and_window() {
         .unwrap();
 
     let yesterday = Utc::now() - chrono::Duration::days(1);
+    let tomorrow = Utc::now() + chrono::Duration::days(1);
     let live_total = db
-        .get_xp_total_in_range(user.id, yesterday, "live")
+        .get_xp_total_in_range(user.id, yesterday, tomorrow, "live")
         .await
         .expect("Should fetch live total");
     let recalc_total = db
-        .get_xp_total_in_range(user.id, yesterday, "recalculated")
+        .get_xp_total_in_range(user.id, yesterday, tomorrow, "recalculated")
         .await
         .expect("Should fetch recalc total");
 
     assert_eq!(live_total, 50);
     assert_eq!(recalc_total, 999);
 
-    // Window in the future returns 0 (no rows newer than tomorrow).
-    let tomorrow = Utc::now() + chrono::Duration::days(1);
+    // Window entirely in the future returns 0 (no rows in [tomorrow, day-after]).
+    let day_after = Utc::now() + chrono::Duration::days(2);
     let future_total = db
-        .get_xp_total_in_range(user.id, tomorrow, "live")
+        .get_xp_total_in_range(user.id, tomorrow, day_after, "live")
         .await
         .expect("Should fetch future total");
     assert_eq!(future_total, 0);
+
+    // Upper-bound clamp: a window that ends before "now" must exclude
+    // the just-inserted rows even though they pass the lower bound.
+    let two_days_ago = Utc::now() - chrono::Duration::days(2);
+    let past_window_total = db
+        .get_xp_total_in_range(user.id, two_days_ago, yesterday, "live")
+        .await
+        .expect("Should fetch past-window total");
+    assert_eq!(past_window_total, 0);
+}
+
+/// Regression for PR #217 P1 review: comparing RFC3339 `since` against
+/// legacy `YYYY-MM-DD HH:MM:SS` `created_at` values must not drop rows.
+///
+/// We seed a legacy-format row directly so `datetime(created_at)`
+/// normalisation in `get_xp_total_in_range` /
+/// `get_last_recalculation_at` is exercised on the format that older
+/// (pre-Issue #194) installs actually have.
+#[tokio::test]
+async fn test_get_xp_total_in_range_handles_legacy_timestamp_format() {
+    let db = setup_test_db().await;
+    let user = db
+        .create_user(12345, "testuser", None, "token", None, None)
+        .await
+        .expect("Should create user");
+
+    // Bypass record_xp_gain so the inserted row keeps SQLite's
+    // CURRENT_TIMESTAMP default ("YYYY-MM-DD HH:MM:SS"). The wall
+    // time used here ('2025-12-01 10:00:00') is intentionally chosen
+    // so that the boundary RFC3339 `since` ('2025-12-01T00:00:00+00:00')
+    // sorts *after* it lexicographically — the bug being regressed.
+    sqlx::query(
+        "INSERT INTO xp_history (user_id, action_type, xp_amount, source, created_at) \
+         VALUES (?, 'github_sync', 42, 'live', '2025-12-01 10:00:00')",
+    )
+    .bind(user.id)
+    .execute(db.pool())
+    .await
+    .expect("Insert legacy row");
+
+    let since: chrono::DateTime<Utc> = "2025-12-01T00:00:00+00:00".parse().unwrap();
+    let until: chrono::DateTime<Utc> = "2025-12-02T00:00:00+00:00".parse().unwrap();
+    let total = db
+        .get_xp_total_in_range(user.id, since, until, "live")
+        .await
+        .expect("Should fetch legacy-row total");
+    assert_eq!(total, 42, "legacy YYYY-MM-DD HH:MM:SS row must be included");
+
+    // A recalc row in the same format must satisfy the rate-limit guard.
+    sqlx::query(
+        "INSERT INTO xp_history (user_id, action_type, xp_amount, source, created_at) \
+         VALUES (?, 'recalculation', 0, 'recalculated', '2025-12-01 11:00:00')",
+    )
+    .bind(user.id)
+    .execute(db.pool())
+    .await
+    .expect("Insert legacy recalc row");
+    let last = db
+        .get_last_recalculation_at(user.id)
+        .await
+        .expect("Should fetch latest recalc");
+    assert!(last.is_some(), "legacy recalc row must be discoverable");
 }
 
 #[tokio::test]

--- a/src-tauri/src/database/repository/tests.rs
+++ b/src-tauri/src/database/repository/tests.rs
@@ -738,6 +738,54 @@ async fn test_get_xp_total_in_range_filters_by_source_and_window() {
     assert_eq!(past_window_total, 0);
 }
 
+/// Regression for PR #217 P2 review: `get_recent_xp_history` must order
+/// rows by the canonical instant, not by the raw text. A lexicographic
+/// compare across the two on-disk formats puts every legacy row
+/// (`YYYY-MM-DD HH:MM:SS`) before every RFC3339 row of the same instant
+/// because `' ' < 'T'` — which would scramble the timeline around the
+/// migration day for users carrying pre-Issue #194 rows.
+#[tokio::test]
+async fn test_get_recent_xp_history_orders_mixed_timestamp_formats() {
+    let db = setup_test_db().await;
+    let user = db
+        .create_user(12345, "testuser", None, "token", None, None)
+        .await
+        .expect("Should create user");
+
+    // Older legacy-format row (one hour earlier).
+    sqlx::query(
+        "INSERT INTO xp_history (user_id, action_type, xp_amount, source, created_at) \
+         VALUES (?, 'github_sync', 10, 'live', '2025-12-01 09:00:00')",
+    )
+    .bind(user.id)
+    .execute(db.pool())
+    .await
+    .expect("Insert legacy row");
+    // Newer RFC3339 row (one hour later). Lexicographically the legacy
+    // string sorts *before* the RFC3339 string for the same wall time,
+    // so without `datetime()` normalisation this row would be returned
+    // *second* even though it is the most recent.
+    sqlx::query(
+        "INSERT INTO xp_history (user_id, action_type, xp_amount, source, created_at) \
+         VALUES (?, 'github_sync', 20, 'live', '2025-12-01T10:00:00+00:00')",
+    )
+    .bind(user.id)
+    .execute(db.pool())
+    .await
+    .expect("Insert RFC3339 row");
+
+    let history = db
+        .get_recent_xp_history(user.id, 10)
+        .await
+        .expect("Should fetch history");
+    assert_eq!(history.len(), 2);
+    assert_eq!(
+        history[0].xp_amount, 20,
+        "newest row (RFC3339, 10:00) must come first"
+    );
+    assert_eq!(history[1].xp_amount, 10);
+}
+
 /// Regression for PR #217 P1 review: comparing RFC3339 `since` against
 /// legacy `YYYY-MM-DD HH:MM:SS` `created_at` values must not drop rows.
 ///

--- a/src-tauri/src/database/repository/xp_history.rs
+++ b/src-tauri/src/database/repository/xp_history.rs
@@ -244,6 +244,33 @@ impl Database {
                     }
                 });
 
+                // `try_get` instead of `get` so a NULL / unexpected-type
+                // `created_at` cell can't panic the whole query. The
+                // RFC3339-or-legacy parse is also fallible, so we log
+                // both failure modes (matching the breakdown_json
+                // handling above) and fall back to `Utc::now()` rather
+                // than aborting the entire history fetch on a single
+                // malformed row.
+                let created_at = row
+                    .try_get::<String, _>("created_at")
+                    .map_err(|e| {
+                        // TODO: [INFRA] logクレートに置換（ログ基盤整備時に一括対応）
+                        eprintln!("[WARN] Failed to read xp_history.created_at: {}", e);
+                    })
+                    .ok()
+                    .and_then(|s| {
+                        let parsed = parse_xp_history_timestamp(&s);
+                        if parsed.is_none() {
+                            // TODO: [INFRA] logクレートに置換（ログ基盤整備時に一括対応）
+                            eprintln!(
+                                "[WARN] Failed to parse xp_history.created_at value: {:?}",
+                                s
+                            );
+                        }
+                        parsed
+                    })
+                    .unwrap_or_else(Utc::now);
+
                 XpHistoryEntry {
                     id: row.get("id"),
                     user_id: row.get("user_id"),
@@ -252,8 +279,7 @@ impl Database {
                     description: row.get("description"),
                     github_event_id: row.get("github_event_id"),
                     breakdown,
-                    created_at: parse_xp_history_timestamp(row.get::<&str, _>("created_at"))
-                        .unwrap_or_else(Utc::now),
+                    created_at,
                     source: row.get("source"),
                 }
             })

--- a/src-tauri/src/database/repository/xp_history.rs
+++ b/src-tauri/src/database/repository/xp_history.rs
@@ -170,10 +170,7 @@ impl Database {
     /// compared on a single canonical scale — see the comment on
     /// `get_xp_total_in_range` for why a lexicographic ordering on the raw
     /// column would otherwise mis-order across formats.
-    pub async fn get_last_recalculation_at(
-        &self,
-        user_id: i64,
-    ) -> DbResult<Option<DateTime<Utc>>> {
+    pub async fn get_last_recalculation_at(&self, user_id: i64) -> DbResult<Option<DateTime<Utc>>> {
         let row: Option<(String,)> = sqlx::query_as(
             r#"
             SELECT created_at

--- a/src-tauri/src/database/repository/xp_history.rs
+++ b/src-tauri/src/database/repository/xp_history.rs
@@ -122,13 +122,22 @@ impl Database {
     }
 
     /// Sum `xp_history.xp_amount` for a user, scoped to a `source` value and
-    /// a `[since, now]` window. Used by `recalculate_xp_history` to render
+    /// a `[since, until]` window. Used by `recalculate_xp_history` to render
     /// "previous live XP earned in this window" alongside the recalculated
     /// value (DoD: 計算前後の値を比較表示できる).
+    ///
+    /// Both bounds are normalised through SQLite's `datetime()` function so
+    /// the comparison is correct even when the row mixes the new RFC3339
+    /// format (`YYYY-MM-DDTHH:MM:SS.fff+00:00`) and the legacy
+    /// `CURRENT_TIMESTAMP` default (`YYYY-MM-DD HH:MM:SS`). A naïve
+    /// lexicographic compare across those two formats can drop boundary
+    /// rows because `' ' < 'T'` ASCII-wise, which broke the "before" total
+    /// for any user with pre-migration v15 rows on the boundary day.
     pub async fn get_xp_total_in_range(
         &self,
         user_id: i64,
         since: DateTime<Utc>,
+        until: DateTime<Utc>,
         source: &str,
     ) -> DbResult<i32> {
         let total: Option<i32> = sqlx::query_scalar(
@@ -137,12 +146,14 @@ impl Database {
             FROM xp_history
             WHERE user_id = ?
               AND source = ?
-              AND created_at >= ?
+              AND datetime(created_at) >= datetime(?)
+              AND datetime(created_at) <= datetime(?)
             "#,
         )
         .bind(user_id)
         .bind(source)
         .bind(since.to_rfc3339())
+        .bind(until.to_rfc3339())
         .fetch_one(self.pool())
         .await
         .map_err(|e| DatabaseError::Query(e.to_string()))?;
@@ -153,6 +164,12 @@ impl Database {
     /// Most-recent recalculation timestamp for a user, used by the
     /// rate-limit guard in `recalculate_xp_history`. `None` means the user
     /// has never run a recalculation.
+    ///
+    /// `ORDER BY datetime(created_at) DESC` (rather than the raw column)
+    /// ensures legacy `YYYY-MM-DD HH:MM:SS` rows and new RFC3339 rows are
+    /// compared on a single canonical scale — see the comment on
+    /// `get_xp_total_in_range` for why a lexicographic ordering on the raw
+    /// column would otherwise mis-order across formats.
     pub async fn get_last_recalculation_at(
         &self,
         user_id: i64,
@@ -162,7 +179,7 @@ impl Database {
             SELECT created_at
             FROM xp_history
             WHERE user_id = ? AND source = ?
-            ORDER BY created_at DESC
+            ORDER BY datetime(created_at) DESC
             LIMIT 1
             "#,
         )

--- a/src-tauri/src/database/repository/xp_history.rs
+++ b/src-tauri/src/database/repository/xp_history.rs
@@ -6,9 +6,25 @@ use sqlx::Row;
 use crate::database::connection::{Database, DatabaseError, DbResult};
 use crate::database::models::{XpBreakdown, XpHistoryEntry};
 
+/// `xp_history.source` value for entries produced by the live sync stream
+/// (`run_github_sync`, streak bonus, manual `add_xp`, …). This is the default
+/// for every pre-Issue #194 row.
+pub const XP_HISTORY_SOURCE_LIVE: &str = "live";
+
+/// `xp_history.source` value for entries produced by `recalculate_xp_history`
+/// (Issue #194). These rows are intentionally NOT folded into
+/// `user_stats.total_xp` — they exist for audit / comparison only, so a
+/// recalculation never overwrites or double-counts the live XP stream.
+pub const XP_HISTORY_SOURCE_RECALCULATED: &str = "recalculated";
+
 /// XP History repository operations
 impl Database {
-    /// Record XP gain with optional breakdown
+    /// Record an XP gain produced by the live sync stream.
+    ///
+    /// Thin wrapper over [`record_xp_gain_with_source`] that pins the new
+    /// `xp_history.source` column to [`XP_HISTORY_SOURCE_LIVE`] so existing
+    /// callers don't need to thread the source through. Recalculation
+    /// entries must go through [`record_xp_recalculation`] instead.
     pub async fn record_xp_gain(
         &self,
         user_id: i64,
@@ -18,6 +34,32 @@ impl Database {
         github_event_id: Option<&str>,
         breakdown: Option<&XpBreakdown>,
     ) -> DbResult<i64> {
+        self.record_xp_gain_with_source(
+            user_id,
+            action_type,
+            xp_amount,
+            description,
+            github_event_id,
+            breakdown,
+            XP_HISTORY_SOURCE_LIVE,
+        )
+        .await
+    }
+
+    /// Record an XP gain, tagging it with the supplied `source`.
+    ///
+    /// Centralises the INSERT so the live path and the recalculation path
+    /// can't drift apart on serialization or column ordering.
+    pub async fn record_xp_gain_with_source(
+        &self,
+        user_id: i64,
+        action_type: &str,
+        xp_amount: i32,
+        description: Option<&str>,
+        github_event_id: Option<&str>,
+        breakdown: Option<&XpBreakdown>,
+        source: &str,
+    ) -> DbResult<i64> {
         let breakdown_json = breakdown
             .map(|b| serde_json::to_string(b))
             .transpose()
@@ -25,10 +67,19 @@ impl Database {
                 DatabaseError::Query(format!("Failed to serialize XP breakdown: {}", e))
             })?;
 
+        // Bind `created_at` explicitly as RFC3339 (with microseconds)
+        // instead of falling back to SQLite's CURRENT_TIMESTAMP default,
+        // which uses 'YYYY-MM-DD HH:MM:SS'. Both formats sort
+        // lexicographically against UTC RFC3339, but pinning the column
+        // to a single format makes the range queries in
+        // `get_xp_total_in_range` and the rate-limit guard in
+        // `get_last_recalculation_at` deterministic and lets the
+        // recalculation feature reuse RFC3339 throughout.
+        let now = Utc::now().to_rfc3339();
         let id = sqlx::query(
             r#"
-            INSERT INTO xp_history (user_id, action_type, xp_amount, description, github_event_id, breakdown_json)
-            VALUES (?, ?, ?, ?, ?, ?)
+            INSERT INTO xp_history (user_id, action_type, xp_amount, description, github_event_id, breakdown_json, source, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             "#,
         )
         .bind(user_id)
@@ -37,12 +88,91 @@ impl Database {
         .bind(description)
         .bind(github_event_id)
         .bind(breakdown_json)
+        .bind(source)
+        .bind(now)
         .execute(self.pool())
         .await
         .map_err(|e| DatabaseError::Query(e.to_string()))?
         .last_insert_rowid();
 
         Ok(id)
+    }
+
+    /// Record a past-year XP recalculation (Issue #194).
+    ///
+    /// Always writes with `source = 'recalculated'` so `user_stats.total_xp`
+    /// is left untouched — the row is for audit / before-after comparison.
+    pub async fn record_xp_recalculation(
+        &self,
+        user_id: i64,
+        xp_amount: i32,
+        description: Option<&str>,
+        breakdown: Option<&XpBreakdown>,
+    ) -> DbResult<i64> {
+        self.record_xp_gain_with_source(
+            user_id,
+            "recalculation",
+            xp_amount,
+            description,
+            None,
+            breakdown,
+            XP_HISTORY_SOURCE_RECALCULATED,
+        )
+        .await
+    }
+
+    /// Sum `xp_history.xp_amount` for a user, scoped to a `source` value and
+    /// a `[since, now]` window. Used by `recalculate_xp_history` to render
+    /// "previous live XP earned in this window" alongside the recalculated
+    /// value (DoD: 計算前後の値を比較表示できる).
+    pub async fn get_xp_total_in_range(
+        &self,
+        user_id: i64,
+        since: DateTime<Utc>,
+        source: &str,
+    ) -> DbResult<i32> {
+        let total: Option<i32> = sqlx::query_scalar(
+            r#"
+            SELECT COALESCE(SUM(xp_amount), 0)
+            FROM xp_history
+            WHERE user_id = ?
+              AND source = ?
+              AND created_at >= ?
+            "#,
+        )
+        .bind(user_id)
+        .bind(source)
+        .bind(since.to_rfc3339())
+        .fetch_one(self.pool())
+        .await
+        .map_err(|e| DatabaseError::Query(e.to_string()))?;
+
+        Ok(total.unwrap_or(0))
+    }
+
+    /// Most-recent recalculation timestamp for a user, used by the
+    /// rate-limit guard in `recalculate_xp_history`. `None` means the user
+    /// has never run a recalculation.
+    pub async fn get_last_recalculation_at(
+        &self,
+        user_id: i64,
+    ) -> DbResult<Option<DateTime<Utc>>> {
+        let row: Option<(String,)> = sqlx::query_as(
+            r#"
+            SELECT created_at
+            FROM xp_history
+            WHERE user_id = ? AND source = ?
+            ORDER BY created_at DESC
+            LIMIT 1
+            "#,
+        )
+        .bind(user_id)
+        .bind(XP_HISTORY_SOURCE_RECALCULATED)
+        .fetch_optional(self.pool())
+        .await
+        .map_err(|e| DatabaseError::Query(e.to_string()))?;
+
+        Ok(row.and_then(|(s,)| parse_xp_history_timestamp(&s)))
     }
 
     /// Check if XP was already recorded for a GitHub event
@@ -65,7 +195,7 @@ impl Database {
     ) -> DbResult<Vec<XpHistoryEntry>> {
         let rows = sqlx::query(
             r#"
-            SELECT id, user_id, action_type, xp_amount, description, github_event_id, breakdown_json, created_at
+            SELECT id, user_id, action_type, xp_amount, description, github_event_id, breakdown_json, created_at, source
             FROM xp_history
             WHERE user_id = ?
             ORDER BY created_at DESC
@@ -101,13 +231,30 @@ impl Database {
                     description: row.get("description"),
                     github_event_id: row.get("github_event_id"),
                     breakdown,
-                    created_at: DateTime::parse_from_rfc3339(row.get::<&str, _>("created_at"))
-                        .map(|dt| dt.with_timezone(&Utc))
-                        .unwrap_or_else(|_| Utc::now()),
+                    created_at: parse_xp_history_timestamp(row.get::<&str, _>("created_at"))
+                        .unwrap_or_else(Utc::now),
+                    source: row.get("source"),
                 }
             })
             .collect();
 
         Ok(entries)
     }
+}
+
+/// Parse a `xp_history.created_at` cell into a UTC `DateTime`.
+///
+/// Older rows (pre-Issue #194) were inserted without an explicit
+/// `created_at` bind and use SQLite's `CURRENT_TIMESTAMP` default
+/// (`YYYY-MM-DD HH:MM:SS`). New rows are written as RFC3339 (see
+/// `record_xp_gain_with_source`). This helper accepts either, so the
+/// rate-limit guard works for both legacy and fresh entries.
+fn parse_xp_history_timestamp(raw: &str) -> Option<DateTime<Utc>> {
+    if let Ok(dt) = DateTime::parse_from_rfc3339(raw) {
+        return Some(dt.with_timezone(&Utc));
+    }
+    if let Ok(naive) = chrono::NaiveDateTime::parse_from_str(raw, "%Y-%m-%d %H:%M:%S") {
+        return Some(DateTime::<Utc>::from_naive_utc_and_offset(naive, Utc));
+    }
+    None
 }

--- a/src-tauri/src/database/repository/xp_history.rs
+++ b/src-tauri/src/database/repository/xp_history.rs
@@ -202,6 +202,13 @@ impl Database {
     }
 
     /// Get recent XP history
+    ///
+    /// `ORDER BY datetime(created_at) DESC` (rather than the raw column)
+    /// keeps the timeline chronologically correct for users who have a
+    /// mix of legacy `YYYY-MM-DD HH:MM:SS` rows (pre-Issue #194) and new
+    /// RFC3339 rows. A lexicographic sort on the raw text would place
+    /// every legacy row before every RFC3339 row of the same instant
+    /// because `' ' < 'T'` ASCII-wise.
     pub async fn get_recent_xp_history(
         &self,
         user_id: i64,
@@ -212,7 +219,7 @@ impl Database {
             SELECT id, user_id, action_type, xp_amount, description, github_event_id, breakdown_json, created_at, source
             FROM xp_history
             WHERE user_id = ?
-            ORDER BY created_at DESC
+            ORDER BY datetime(created_at) DESC
             LIMIT ?
             "#,
         )

--- a/src-tauri/src/database/repository/xp_history.rs
+++ b/src-tauri/src/database/repository/xp_history.rs
@@ -126,13 +126,12 @@ impl Database {
     /// "previous live XP earned in this window" alongside the recalculated
     /// value (DoD: 計算前後の値を比較表示できる).
     ///
-    /// Both bounds are normalised through SQLite's `datetime()` function so
-    /// the comparison is correct even when the row mixes the new RFC3339
-    /// format (`YYYY-MM-DDTHH:MM:SS.fff+00:00`) and the legacy
-    /// `CURRENT_TIMESTAMP` default (`YYYY-MM-DD HH:MM:SS`). A naïve
-    /// lexicographic compare across those two formats can drop boundary
-    /// rows because `' ' < 'T'` ASCII-wise, which broke the "before" total
-    /// for any user with pre-migration v15 rows on the boundary day.
+    /// Migration v16 backfilled every legacy `YYYY-MM-DD HH:MM:SS` row to
+    /// `YYYY-MM-DDTHH:MM:SS+00:00`, so the entire column is now in a single
+    /// canonical RFC3339 form. That lets us compare strings lexicographically
+    /// — preserving sub-second precision (no `datetime()` truncation; see
+    /// Codex P2 review) and letting the `idx_xp_history_user_source_created`
+    /// composite index drive the range scan directly.
     pub async fn get_xp_total_in_range(
         &self,
         user_id: i64,
@@ -146,8 +145,8 @@ impl Database {
             FROM xp_history
             WHERE user_id = ?
               AND source = ?
-              AND datetime(created_at) >= datetime(?)
-              AND datetime(created_at) <= datetime(?)
+              AND created_at >= ?
+              AND created_at <= ?
             "#,
         )
         .bind(user_id)
@@ -165,18 +164,16 @@ impl Database {
     /// rate-limit guard in `recalculate_xp_history`. `None` means the user
     /// has never run a recalculation.
     ///
-    /// `ORDER BY datetime(created_at) DESC` (rather than the raw column)
-    /// ensures legacy `YYYY-MM-DD HH:MM:SS` rows and new RFC3339 rows are
-    /// compared on a single canonical scale — see the comment on
-    /// `get_xp_total_in_range` for why a lexicographic ordering on the raw
-    /// column would otherwise mis-order across formats.
+    /// Lexicographic ORDER BY is correct because migration v16 normalised
+    /// all `xp_history.created_at` rows to canonical RFC3339 — see
+    /// `get_xp_total_in_range` for the rationale.
     pub async fn get_last_recalculation_at(&self, user_id: i64) -> DbResult<Option<DateTime<Utc>>> {
         let row: Option<(String,)> = sqlx::query_as(
             r#"
             SELECT created_at
             FROM xp_history
             WHERE user_id = ? AND source = ?
-            ORDER BY datetime(created_at) DESC
+            ORDER BY created_at DESC
             LIMIT 1
             "#,
         )
@@ -203,12 +200,9 @@ impl Database {
 
     /// Get recent XP history
     ///
-    /// `ORDER BY datetime(created_at) DESC` (rather than the raw column)
-    /// keeps the timeline chronologically correct for users who have a
-    /// mix of legacy `YYYY-MM-DD HH:MM:SS` rows (pre-Issue #194) and new
-    /// RFC3339 rows. A lexicographic sort on the raw text would place
-    /// every legacy row before every RFC3339 row of the same instant
-    /// because `' ' < 'T'` ASCII-wise.
+    /// Lexicographic ORDER BY is correct because migration v16 normalised
+    /// all `xp_history.created_at` rows to canonical RFC3339 — see
+    /// `get_xp_total_in_range` for the rationale.
     pub async fn get_recent_xp_history(
         &self,
         user_id: i64,
@@ -219,7 +213,7 @@ impl Database {
             SELECT id, user_id, action_type, xp_amount, description, github_event_id, breakdown_json, created_at, source
             FROM xp_history
             WHERE user_id = ?
-            ORDER BY datetime(created_at) DESC
+            ORDER BY created_at DESC
             LIMIT ?
             "#,
         )

--- a/src-tauri/src/github/client.rs
+++ b/src-tauri/src/github/client.rs
@@ -250,10 +250,31 @@ impl GitHubClient {
         &self,
         username: &str,
     ) -> GitHubResult<ContributionsCollection> {
+        self.get_contribution_calendar_window(username, None, None)
+            .await
+    }
+
+    /// Get contribution calendar scoped to a `[from, to]` UTC window.
+    ///
+    /// Both bounds are optional — passing `None` matches GitHub's default
+    /// behaviour (the past ~1 year). When both are supplied the GraphQL API
+    /// enforces a maximum span of one year, so callers must clamp `from`
+    /// themselves before invoking this method.
+    ///
+    /// Used by `recalculate_xp_history` (Issue #194) to get per-window
+    /// category totals (`totalCommitContributions`, etc.) so the past-year
+    /// XP recalculation can reuse `XpBreakdown::calculate` over the exact
+    /// window the user selected.
+    pub async fn get_contribution_calendar_window(
+        &self,
+        username: &str,
+        from: Option<chrono::DateTime<Utc>>,
+        to: Option<chrono::DateTime<Utc>>,
+    ) -> GitHubResult<ContributionsCollection> {
         let query = r#"
-            query($login: String!) {
+            query($login: String!, $from: DateTime, $to: DateTime) {
                 user(login: $login) {
-                    contributionsCollection {
+                    contributionsCollection(from: $from, to: $to) {
                         contributionCalendar {
                             totalContributions
                             weeks {
@@ -273,7 +294,11 @@ impl GitHubClient {
             }
         "#;
 
-        let variables = serde_json::json!({ "login": username });
+        let variables = serde_json::json!({
+            "login": username,
+            "from": from.map(|dt| dt.to_rfc3339()),
+            "to": to.map(|dt| dt.to_rfc3339()),
+        });
         let response: ContributionCollectionResponse = self.graphql(query, Some(variables)).await?;
 
         response

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -79,6 +79,8 @@ use commands::{
     open_external_url,
     open_url,
     poll_device_token,
+    // Issue #194: past-year XP recalculation
+    recalculate_xp_history,
     // Issue #191: explicit refresh for badge progress (heavy aggregate API call)
     refresh_badges_progress,
     relink_repository,
@@ -224,6 +226,8 @@ pub fn run() {
             award_badge,
             get_xp_history,
             get_badge_definitions,
+            // Past-year XP recalculation (Issue #194)
+            recalculate_xp_history,
             // Challenge commands
             get_active_challenges,
             get_all_challenges,

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -1,3 +1,4 @@
 //! Utility modules
 
 pub mod notifications;
+pub mod numeric;

--- a/src-tauri/src/utils/numeric.rs
+++ b/src-tauri/src/utils/numeric.rs
@@ -1,0 +1,36 @@
+//! Small numeric helpers shared across commands.
+//!
+//! Currently just `clamp_to_u64`, used wherever a possibly-negative
+//! cumulative GitHub counter has to feed `XpBreakdown::calculate`'s
+//! `u64`-typed inputs. Centralising it avoids the duplicate definitions
+//! `commands::github` and `commands::gamification` previously kept in
+//! sync by hand (PR #217 review).
+
+/// Clamp a possibly-negative `i32` count to `u64` (negative → 0).
+///
+/// Used as the boundary between GitHub's `i32`-typed cumulative counters
+/// and `XpBreakdown::calculate`'s `u64`-typed inputs. A regression in
+/// any cumulative metric (e.g. losing a star) clamps to 0 instead of
+/// wrapping into a giant positive value.
+#[inline]
+pub fn clamp_to_u64(value: i32) -> u64 {
+    value.max(0) as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clamps_negative_to_zero() {
+        assert_eq!(clamp_to_u64(-1), 0);
+        assert_eq!(clamp_to_u64(i32::MIN), 0);
+    }
+
+    #[test]
+    fn passes_non_negative_through() {
+        assert_eq!(clamp_to_u64(0), 0);
+        assert_eq!(clamp_to_u64(42), 42);
+        assert_eq!(clamp_to_u64(i32::MAX), i32::MAX as u64);
+    }
+}

--- a/src/components/features/settings/XpRecalculation.tsx
+++ b/src/components/features/settings/XpRecalculation.tsx
@@ -222,10 +222,15 @@ const ResultModal: React.FC<ResultModalProps> = ({ result, onClose }) => {
               <div className="flex justify-between">
                 <span className="text-dt-text-sub">Streak Bonus</span>
                 <span className="text-white font-mono">
-                  {breakdown.streakBonusXp} XP (streak={result.contributions.currentStreak})
+                  {breakdown.streakBonusXp} XP (現在のストリーク={result.contributions.liveCurrentStreak}日)
                 </span>
               </div>
             </div>
+            <p className="mt-2 text-[11px] text-dt-text-sub leading-snug">
+              ※ ストリークボーナスは <span className="font-bold">現在のストリーク</span> を基準に計算しています
+              （`contributionsCollection` から再計算ウィンドウ内のストリークは取得できないため、
+              ライブ同期と同じ値を使用しています）。
+            </p>
           </div>
 
           {/* 未集計カテゴリの注意 */}

--- a/src/components/features/settings/XpRecalculation.tsx
+++ b/src/components/features/settings/XpRecalculation.tsx
@@ -1,0 +1,326 @@
+/**
+ * XP Recalculation Component (Issue #194)
+ *
+ * Surfaces the past-year XP recalculation feature in the Settings page.
+ *
+ * UX flow:
+ *   1. Button → opens a confirmation modal explaining the risks /
+ *      limitations (1-year cap, uncovered categories, audit-only writes).
+ *   2. Confirm → invokes `recalculateXpHistory` on the backend.
+ *   3. Backend response → renders a "before / after" comparison modal so
+ *      the DoD ("計算前後の値を比較表示できる") is satisfied without
+ *      navigating away from Settings.
+ *
+ * The recalculation never mutates `user_stats.total_xp`; it only writes a
+ * `source = 'recalculated'` row to `xp_history` for audit purposes.
+ *
+ * Related Documentation:
+ *   - Issue: https://github.com/otomatty/development-tools/issues/194
+ *   - Backend: src-tauri/src/commands/gamification.rs `recalculate_xp_history`
+ */
+
+import React, { useState } from 'react';
+import { gamification } from '../../../lib/tauri/commands';
+import { Modal, ModalHeader, ModalBody, ModalFooter } from '../../ui/dialog';
+import { Button } from '../../ui/button';
+import type { RecalculationResult } from '../../../types';
+
+const RATE_LIMIT_HINT = 'XP 再計算は 1 時間に 1 回までです';
+
+const UNCOVERED_LABELS: Record<string, string> = {
+  prs_merged: 'PR マージ数',
+  issues_closed: 'クローズした Issue 数',
+  stars: '獲得スター数',
+};
+
+const formatJstDateTime = (iso: string): string => {
+  try {
+    return new Date(iso).toLocaleString('ja-JP', { timeZone: 'Asia/Tokyo' });
+  } catch {
+    return iso;
+  }
+};
+
+const diffSign = (n: number): string => (n > 0 ? '+' : n < 0 ? '' : '±');
+
+interface ConfirmationModalProps {
+  visible: boolean;
+  running: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+const ConfirmationModal: React.FC<ConfirmationModalProps> = ({
+  visible,
+  running,
+  onConfirm,
+  onCancel,
+}) => (
+  <Modal
+    visible={visible}
+    onClose={onCancel}
+    size="md"
+    closeOnOverlay={!running}
+    closeOnEscape={!running}
+    borderClass="border-2 border-gm-accent-cyan/50"
+  >
+    <ModalHeader onClose={running ? undefined : onCancel}>
+      <div className="flex items-center gap-3">
+        <div className="w-12 h-12 rounded-full bg-gm-accent-cyan/20 flex items-center justify-center border border-gm-accent-cyan/30">
+          <span className="text-2xl">🔄</span>
+        </div>
+        <h3 className="text-xl font-gaming font-bold text-white">
+          XP 再計算の実行
+        </h3>
+      </div>
+    </ModalHeader>
+    <ModalBody>
+      <div className="space-y-4 text-sm">
+        <p className="text-dt-text-sub">
+          GitHub の <span className="font-mono">contributionCalendar</span>{' '}
+          から過去 1 年分のアクティビティを取得し、現在の XP ルールで再計算します。
+        </p>
+
+        <div className="p-3 bg-amber-900/20 border border-amber-500/30 rounded-lg space-y-2">
+          <p className="text-amber-200 font-bold flex items-center gap-2">
+            <span>⚠️</span>
+            実行前にご確認ください
+          </p>
+          <ul className="list-disc list-inside text-amber-100/80 space-y-1">
+            <li>
+              再計算結果は <span className="font-bold">監査用エントリ</span>{' '}
+              として `xp_history` に追加されます。
+            </li>
+            <li>
+              既存の合計 XP・レベルは <span className="font-bold">変更されません</span>
+              （表示用の比較値として使えます）。
+            </li>
+            <li>
+              `contributionCalendar` の制約上、再計算できるのは{' '}
+              <span className="font-bold">過去 1 年分</span> のみです。
+            </li>
+            <li>
+              PR マージ数 / クローズ Issue 数 / 獲得スター数は{' '}
+              <span className="font-mono">contributionsCollection</span>{' '}
+              から取得できないため <span className="font-bold">0 として計算</span>{' '}
+              されます。
+            </li>
+            <li>{RATE_LIMIT_HINT}。</li>
+          </ul>
+        </div>
+      </div>
+    </ModalBody>
+    <ModalFooter>
+      <Button variant="secondary" onClick={onCancel} disabled={running}>
+        キャンセル
+      </Button>
+      <Button variant="primary" onClick={onConfirm} disabled={running} isLoading={running}>
+        {running ? '再計算中...' : '再計算を実行'}
+      </Button>
+    </ModalFooter>
+  </Modal>
+);
+
+interface ResultModalProps {
+  result: RecalculationResult | null;
+  onClose: () => void;
+}
+
+const ResultModal: React.FC<ResultModalProps> = ({ result, onClose }) => {
+  if (!result) return null;
+
+  const live = result.previousLiveTotalXpInWindow;
+  const recalc = result.recalculatedTotalXp;
+  const diff = result.xpDiff;
+  const breakdown = result.recalculatedBreakdown;
+
+  return (
+    <Modal
+      visible
+      onClose={onClose}
+      size="lg"
+      closeOnOverlay
+      closeOnEscape
+      borderClass="border-2 border-gm-accent-cyan/50"
+    >
+      <ModalHeader onClose={onClose}>
+        <div className="flex items-center gap-3">
+          <div className="w-12 h-12 rounded-full bg-gm-accent-cyan/20 flex items-center justify-center border border-gm-accent-cyan/30">
+            <span className="text-2xl">📊</span>
+          </div>
+          <h3 className="text-xl font-gaming font-bold text-white">
+            XP 再計算結果
+          </h3>
+        </div>
+      </ModalHeader>
+      <ModalBody>
+        <div className="space-y-4 text-sm">
+          <div className="text-dt-text-sub">
+            集計期間: {formatJstDateTime(result.since)} 〜{' '}
+            {formatJstDateTime(result.until)}（{result.windowDays} 日間）
+          </div>
+
+          {/* Before / After 比較 */}
+          <div className="grid grid-cols-3 gap-3">
+            <div className="p-3 bg-gm-bg-primary/50 rounded-lg border border-slate-700">
+              <div className="text-dt-text-sub text-xs mb-1">既存の Live XP</div>
+              <div className="text-white font-gaming text-lg">{live} XP</div>
+            </div>
+            <div className="p-3 bg-gm-bg-primary/50 rounded-lg border border-gm-accent-cyan/40">
+              <div className="text-dt-text-sub text-xs mb-1">再計算結果</div>
+              <div className="text-gm-accent-cyan font-gaming text-lg">{recalc} XP</div>
+            </div>
+            <div
+              className={`p-3 bg-gm-bg-primary/50 rounded-lg border ${
+                diff > 0
+                  ? 'border-green-500/40'
+                  : diff < 0
+                    ? 'border-red-500/40'
+                    : 'border-slate-700'
+              }`}
+            >
+              <div className="text-dt-text-sub text-xs mb-1">差分</div>
+              <div
+                className={`font-gaming text-lg ${
+                  diff > 0 ? 'text-green-400' : diff < 0 ? 'text-red-400' : 'text-white'
+                }`}
+              >
+                {diffSign(diff)}
+                {diff} XP
+              </div>
+            </div>
+          </div>
+
+          {/* 内訳 */}
+          <div className="p-3 bg-gm-bg-card/50 rounded-lg border border-slate-700">
+            <h4 className="text-white font-gaming mb-2">XP 内訳（再計算）</h4>
+            <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
+              <div className="flex justify-between">
+                <span className="text-dt-text-sub">Commits</span>
+                <span className="text-white font-mono">
+                  {breakdown.commitsXp} XP ({result.contributions.commits} 件)
+                </span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-dt-text-sub">PRs 作成</span>
+                <span className="text-white font-mono">
+                  {breakdown.prsCreatedXp} XP ({result.contributions.pullRequests} 件)
+                </span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-dt-text-sub">Issues 作成</span>
+                <span className="text-white font-mono">
+                  {breakdown.issuesCreatedXp} XP ({result.contributions.issues} 件)
+                </span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-dt-text-sub">Reviews</span>
+                <span className="text-white font-mono">
+                  {breakdown.reviewsXp} XP ({result.contributions.reviews} 件)
+                </span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-dt-text-sub">Streak Bonus</span>
+                <span className="text-white font-mono">
+                  {breakdown.streakBonusXp} XP (streak={result.contributions.currentStreak})
+                </span>
+              </div>
+            </div>
+          </div>
+
+          {/* 未集計カテゴリの注意 */}
+          {result.uncoveredCategories.length > 0 && (
+            <div className="p-3 bg-amber-900/20 border border-amber-500/30 rounded-lg">
+              <p className="text-amber-200 text-xs">
+                <span className="font-bold">未集計のカテゴリ:</span>{' '}
+                {result.uncoveredCategories
+                  .map((c) => UNCOVERED_LABELS[c] ?? c)
+                  .join('、')}{' '}
+                は `contributionsCollection` から取得できないため 0 として計算しています。
+              </p>
+            </div>
+          )}
+
+          <p className="text-xs text-dt-text-sub">
+            監査エントリ ID: #{result.recalculationHistoryId}{' '}
+            （`xp_history` に `source = recalculated` で記録されています）
+          </p>
+        </div>
+      </ModalBody>
+      <ModalFooter>
+        <Button variant="primary" onClick={onClose}>
+          閉じる
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+};
+
+export const XpRecalculation: React.FC = () => {
+  const [showConfirm, setShowConfirm] = useState(false);
+  const [running, setRunning] = useState(false);
+  const [result, setResult] = useState<RecalculationResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const onConfirm = async () => {
+    setRunning(true);
+    setError(null);
+    try {
+      const res = await gamification.recalculateXpHistory();
+      setResult(res);
+      setShowConfirm(false);
+    } catch (e) {
+      setError(`${e}`);
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      <ConfirmationModal
+        visible={showConfirm}
+        running={running}
+        onConfirm={onConfirm}
+        onCancel={() => {
+          if (!running) {
+            setShowConfirm(false);
+            setError(null);
+          }
+        }}
+      />
+      <ResultModal result={result} onClose={() => setResult(null)} />
+
+      <h3 className="text-lg font-gaming font-bold text-white flex items-center gap-2">
+        🔄 XP 再計算
+      </h3>
+      <div className="p-4 bg-gm-bg-card/50 rounded-xl border border-gm-accent-cyan/20">
+        <p className="text-dt-text-sub mb-4 text-sm">
+          GitHub の `contributionCalendar` から過去 1 年分のアクティビティを再取得し、
+          現在の XP ルールで再計算します。結果は監査用エントリとして履歴に追加され、
+          現在の合計 XP・レベルは変更されません。
+        </p>
+        <p className="text-xs text-dt-text-sub mb-4">
+          {RATE_LIMIT_HINT}。連続実行を試みるとエラーが返ります。
+        </p>
+        <Button
+          variant="primary"
+          onClick={() => {
+            setError(null);
+            setShowConfirm(true);
+          }}
+          disabled={running}
+          fullWidth
+          isLoading={running}
+        >
+          {running ? '再計算中...' : '過去 1 年分の XP を再計算'}
+        </Button>
+        {error && (
+          <div className="mt-3 p-3 bg-red-900/30 border border-red-500/50 rounded-lg text-red-200 text-sm">
+            {error}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/components/features/settings/index.ts
+++ b/src/components/features/settings/index.ts
@@ -14,3 +14,4 @@ export { SyncSettings } from './SyncSettings';
 export { DataManagement } from './DataManagement';
 export { SettingsReset } from './SettingsReset';
 export { AppInfo } from './AppInfo';
+export { XpRecalculation } from './XpRecalculation';

--- a/src/lib/tauri/commands.ts
+++ b/src/lib/tauri/commands.ts
@@ -34,6 +34,7 @@ import type {
   Badge,
   BadgeDefinition,
   XpHistoryEntry,
+  RecalculationResult,
   ChallengeInfo,
   CreateChallengeRequest,
   ChallengeStats,
@@ -374,6 +375,16 @@ export const gamification = {
    */
   getBadgeDefinitions: (): Promise<BadgeDefinition[]> =>
     invoke<BadgeDefinition[]>('get_badge_definitions'),
+
+  /**
+   * 過去 1 年分の XP を contributionCalendar から再計算する（Issue #194）。
+   *
+   * `xp_history` には `source = 'recalculated'` の監査エントリが追加されるが、
+   * `user_stats.total_xp` は変更されない。レート制限ガードで 1 時間に
+   * 1 回のみ実行できる。
+   */
+  recalculateXpHistory: (since?: string | null): Promise<RecalculationResult> =>
+    invoke<RecalculationResult>('recalculate_xp_history', { since: since ?? null }),
 };
 
 // ============================================================================

--- a/src/pages/Settings/Settings.tsx
+++ b/src/pages/Settings/Settings.tsx
@@ -19,6 +19,7 @@ import {
   DataManagement,
   AppInfo,
   SettingsReset,
+  XpRecalculation,
 } from '../../components/features/settings';
 
 type SettingsSection = 'Account' | 'Notification' | 'Sync' | 'Appearance' | 'DataManagement' | 'AppInfo';
@@ -100,9 +101,13 @@ export const Settings = () => {
           icon="database"
           expanded={isExpanded('DataManagement')}
           onToggle={() => toggleSection('DataManagement')}
-          maxHeight="1200px"
+          maxHeight="1600px"
         >
-          <DataManagement />
+          <div className="space-y-6">
+            <DataManagement />
+            <div className="border-t border-gm-accent-cyan/20" />
+            <XpRecalculation />
+          </div>
         </AccordionSection>
 
         {/* App Info Section */}

--- a/src/types/gamification.ts
+++ b/src/types/gamification.ts
@@ -461,12 +461,16 @@ export interface RecalculatedXpBreakdown {
 
 /// 再計算ウィンドウ内で取得した GitHub 側のカテゴリ別合計。
 /// `contributionsCollection` から取得できる範囲のみ。
+///
+/// `liveCurrentStreak` は再計算実行時点の "現在のストリーク" であり、
+/// 再計算ウィンドウ内のストリークではない点に注意。UI でも「現在のストリーク」
+/// として明示する。
 export interface RecalcContributionTotals {
   commits: number;
   pullRequests: number;
   issues: number;
   reviews: number;
-  currentStreak: number;
+  liveCurrentStreak: number;
 }
 
 /// `recalculate_xp_history` コマンドの返却値。

--- a/src/types/gamification.ts
+++ b/src/types/gamification.ts
@@ -139,6 +139,10 @@ export interface XpHistoryEntry {
   githubEventId: string | null;
   breakdown: XpBreakdown | null;
   createdAt: string;
+  /// "live" は user_stats.total_xp に反映される通常エントリ。
+  /// "recalculated" は Issue #194 の再計算コマンドが書き込んだ監査用エントリで、
+  /// user_stats.total_xp には加算されない。
+  source: string;
 }
 
 /// XP獲得時のブレークダウン
@@ -435,6 +439,62 @@ export interface LanguageBreakdownResponse {
   since: string;
   /// 走査したリポジトリ数
   repositoriesScanned: number;
+}
+
+// ============================================
+// 過去データの遡及 XP 再計算（Issue #194）
+// ============================================
+
+/// 再計算 XP の内訳。`SyncResult.xpBreakdown` (`XpBreakdownResult`) と同じ形を
+/// バックエンドが返すが、コマンド固有の型として明示する。
+export interface RecalculatedXpBreakdown {
+  commitsXp: number;
+  prsCreatedXp: number;
+  prsMergedXp: number;
+  issuesCreatedXp: number;
+  issuesClosedXp: number;
+  reviewsXp: number;
+  starsXp: number;
+  streakBonusXp: number;
+  totalXp: number;
+}
+
+/// 再計算ウィンドウ内で取得した GitHub 側のカテゴリ別合計。
+/// `contributionsCollection` から取得できる範囲のみ。
+export interface RecalcContributionTotals {
+  commits: number;
+  pullRequests: number;
+  issues: number;
+  reviews: number;
+  currentStreak: number;
+}
+
+/// `recalculate_xp_history` コマンドの返却値。
+///
+/// `xp_history` への書き込みは `source = 'recalculated'` で行われ、
+/// `user_stats.total_xp` は変更しない（DoD: 計算前後の値を比較表示できる）。
+export interface RecalculationResult {
+  /// ウィンドウの下限 (RFC3339)
+  since: string;
+  /// ウィンドウの上限 = 再計算実行時刻 (RFC3339)
+  until: string;
+  /// 再計算で得られた合計 XP
+  recalculatedTotalXp: number;
+  /// 再計算 XP の内訳
+  recalculatedBreakdown: RecalculatedXpBreakdown;
+  /// 同じウィンドウ内の `source = 'live'` 合計 XP（比較用）
+  previousLiveTotalXpInWindow: number;
+  /// recalculatedTotalXp - previousLiveTotalXpInWindow
+  xpDiff: number;
+  /// 挿入された `source = 'recalculated'` の xp_history.id
+  recalculationHistoryId: number;
+  /// ウィンドウの日数
+  windowDays: number;
+  /// `XpBreakdown::calculate` に渡したカテゴリ別合計
+  contributions: RecalcContributionTotals;
+  /// `contributionsCollection` から取得できないカテゴリ
+  /// (`prs_merged`, `issues_closed`, `stars`)
+  uncoveredCategories: string[];
 }
 
 /// 純増減行数を取得


### PR DESCRIPTION
## Summary

Implements a past-year XP recalculation feature that allows users to recompute their XP earnings from the past year based on GitHub's `contributionCalendar` data using the current XP ruleset. The recalculation results are stored as audit-only entries in `xp_history` with `source = 'recalculated'`, leaving the live XP total untouched while enabling before/after comparison.

## Key Changes

### Backend (Rust/Tauri)

- **New command `recalculate_xp_history`** in `src-tauri/src/commands/gamification.rs`:
  - Fetches contribution calendar data for a configurable window (up to 1 year)
  - Recalculates XP using current `XpBreakdown::calculate` rules
  - Enforces 1-hour rate limiting per user
  - Returns detailed `RecalculationResult` with before/after comparison
  - Surfaces uncovered categories (`prs_merged`, `issues_closed`, `stars`) that require separate API calls

- **Database layer enhancements** in `src-tauri/src/database/repository/xp_history.rs`:
  - Added `source` column to `xp_history` table (migration 15) to distinguish live vs. recalculated entries
  - New methods: `record_xp_gain_with_source`, `record_xp_recalculation`, `get_xp_total_in_range`, `get_last_recalculation_at`
  - Refactored `record_xp_gain` to default to `source = 'live'` for backward compatibility
  - RFC3339 timestamp normalization for deterministic range queries

- **GitHub API enhancement** in `src-tauri/src/github/client.rs`:
  - Extended `get_contribution_calendar` with optional `from`/`to` window parameters
  - New method `get_contribution_calendar_window` for scoped queries

- **Comprehensive test coverage** in `src-tauri/src/database/repository/tests.rs`:
  - Tests for source column separation (live vs. recalculated)
  - Range query filtering by source and time window
  - Rate-limit guard validation

### Frontend (TypeScript/React)

- **New `XpRecalculation` component** in `src/components/features/settings/XpRecalculation.tsx`:
  - Two-modal UX: confirmation modal with risk/limitation disclosure, then results modal
  - Displays before/after XP comparison with color-coded diff
  - Shows per-category breakdown (commits, PRs, issues, reviews, streak bonus)
  - Surfaces uncovered categories and audit entry ID for traceability
  - Handles rate-limit errors gracefully

- **Type definitions** in `src/types/gamification.ts`:
  - `RecalculationResult` interface with all comparison data
  - `RecalculatedXpBreakdown` and `RecalcContributionTotals` types
  - Updated `XpHistoryEntry` to include `source` field

- **Integration** in `src/pages/Settings/Settings.tsx`:
  - Added XP Recalculation section to Settings page under Data Management

- **Command binding** in `src/lib/tauri/commands.ts`:
  - Exposed `gamification.recalculateXpHistory()` to frontend

## Notable Implementation Details

- **Audit-only design**: Recalculated entries never modify `user_stats.total_xp`, preserving the original live XP record for audit purposes
- **Rate limiting**: 1-hour minimum interval between recalculations per user, enforced before API calls to minimize GitHub API usage
- **Sync lock integration**: Recalculation holds `AppState::sync_lock` to prevent races with scheduler-driven `run_github_sync`
- **Deterministic timestamps**: All `xp_history` entries now use RFC3339 format with microseconds for consistent range queries
- **Transparent limitations**: UI explicitly discloses the 1-year window cap and uncovered categories (PR merges, closed issues,

https://claude.ai/code/session_01U8eDBJrzu5VEq4abneQ1Vx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 設定に「XP再計算」を追加。過去最大1年のGitHub貢献を基に再計算し、再計算前後の合計・カテゴリ別内訳・差分を結果モーダルで表示。確認モーダル・実行中の無効化・実行間隔制限あり。未対応カテゴリは注意表示。

* **Chores**
  * 再計算結果は監査用として記録され、既存の合計値は直接上書きされません。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otomatty/development-tools/pull/217)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->