### PR TITLE
feat: approximate Search API rate limit via sliding window (Issue #195)

### DIFF
--- a/src-tauri/src/github/client.rs
+++ b/src-tauri/src/github/client.rs
@@ -224,7 +224,9 @@ impl GitHubClient {
         state: &str,
         per_page: i32,
     ) -> GitHubResult<Vec<serde_json::Value>> {
-        Self::await_search_slot().await?;
+        crate::github::search_rate_limiter::await_search_slot()
+            .await
+            .map_err(GitHubError::RateLimited)?;
         self.get(&format!(
             "/search/issues?q=type:pr+author:{}+state:{}&per_page={}",
             username, state, per_page
@@ -239,7 +241,9 @@ impl GitHubClient {
         state: &str,
         per_page: i32,
     ) -> GitHubResult<Vec<serde_json::Value>> {
-        Self::await_search_slot().await?;
+        crate::github::search_rate_limiter::await_search_slot()
+            .await
+            .map_err(GitHubError::RateLimited)?;
         self.get(&format!(
             "/search/issues?q=type:issue+author:{}+state:{}&per_page={}",
             username, state, per_page
@@ -309,35 +313,15 @@ impl GitHubClient {
             .ok_or_else(|| GitHubError::NotFound(format!("User {} not found", username)))
     }
 
-    /// Reserve a Search API slot from the in-process sliding-window limiter.
-    ///
-    /// GitHub does not expose Search API rate-limit headers, so we approximate
-    /// the 30/min budget locally. Waits up to `MAX_SEARCH_WAIT` for a slot;
-    /// beyond that, returns `RateLimited` so callers can fall back gracefully.
-    async fn await_search_slot() -> GitHubResult<()> {
-        use crate::github::search_rate_limiter::{global, AcquireOutcome};
-        const MAX_SEARCH_WAIT: std::time::Duration = std::time::Duration::from_secs(15);
-        let start = std::time::Instant::now();
-        loop {
-            match global().try_acquire() {
-                AcquireOutcome::Granted => return Ok(()),
-                AcquireOutcome::WaitFor { duration, reset } => {
-                    if start.elapsed() + duration > MAX_SEARCH_WAIT {
-                        return Err(GitHubError::RateLimited(reset));
-                    }
-                    tokio::time::sleep(duration).await;
-                }
-            }
-        }
-    }
-
     /// Get count of merged PRs for the user
     ///
     /// Note: This uses GitHub's Search API which has stricter rate limits
     /// (30 requests/minute for authenticated users). Call sequentially
     /// and handle rate limit errors gracefully.
     pub async fn get_merged_prs_count(&self, username: &str) -> GitHubResult<i32> {
-        Self::await_search_slot().await?;
+        crate::github::search_rate_limiter::await_search_slot()
+            .await
+            .map_err(GitHubError::RateLimited)?;
         let query = format!(
             "/search/issues?q=type:pr+author:{}+is:merged&per_page=1",
             username
@@ -355,7 +339,9 @@ impl GitHubClient {
     /// (30 requests/minute for authenticated users). Call sequentially
     /// and handle rate limit errors gracefully.
     pub async fn get_closed_issues_count(&self, username: &str) -> GitHubResult<i32> {
-        Self::await_search_slot().await?;
+        crate::github::search_rate_limiter::await_search_slot()
+            .await
+            .map_err(GitHubError::RateLimited)?;
         // Issues created by user that are closed
         let query = format!(
             "/search/issues?q=type:issue+author:{}+is:closed&per_page=1",
@@ -382,7 +368,9 @@ impl GitHubClient {
     /// (30 requests/minute for authenticated users). Call sequentially
     /// and handle rate limit errors gracefully.
     pub async fn get_total_prs_count(&self, username: &str) -> GitHubResult<i32> {
-        Self::await_search_slot().await?;
+        crate::github::search_rate_limiter::await_search_slot()
+            .await
+            .map_err(GitHubError::RateLimited)?;
         let query = format!("/search/issues?q=type:pr+author:{}&per_page=1", username);
         let response: serde_json::Value = self.get(&query).await?;
         Ok(response

--- a/src-tauri/src/github/client.rs
+++ b/src-tauri/src/github/client.rs
@@ -224,6 +224,7 @@ impl GitHubClient {
         state: &str,
         per_page: i32,
     ) -> GitHubResult<Vec<serde_json::Value>> {
+        Self::await_search_slot().await?;
         self.get(&format!(
             "/search/issues?q=type:pr+author:{}+state:{}&per_page={}",
             username, state, per_page
@@ -238,6 +239,7 @@ impl GitHubClient {
         state: &str,
         per_page: i32,
     ) -> GitHubResult<Vec<serde_json::Value>> {
+        Self::await_search_slot().await?;
         self.get(&format!(
             "/search/issues?q=type:issue+author:{}+state:{}&per_page={}",
             username, state, per_page
@@ -319,12 +321,11 @@ impl GitHubClient {
         loop {
             match global().try_acquire() {
                 AcquireOutcome::Granted => return Ok(()),
-                AcquireOutcome::WaitFor(d) => {
-                    if start.elapsed() + d > MAX_SEARCH_WAIT {
-                        let snap = global().snapshot();
-                        return Err(GitHubError::RateLimited(snap.reset));
+                AcquireOutcome::WaitFor { duration, reset } => {
+                    if start.elapsed() + duration > MAX_SEARCH_WAIT {
+                        return Err(GitHubError::RateLimited(reset));
                     }
-                    tokio::time::sleep(d).await;
+                    tokio::time::sleep(duration).await;
                 }
             }
         }

--- a/src-tauri/src/github/client.rs
+++ b/src-tauri/src/github/client.rs
@@ -307,12 +307,36 @@ impl GitHubClient {
             .ok_or_else(|| GitHubError::NotFound(format!("User {} not found", username)))
     }
 
+    /// Reserve a Search API slot from the in-process sliding-window limiter.
+    ///
+    /// GitHub does not expose Search API rate-limit headers, so we approximate
+    /// the 30/min budget locally. Waits up to `MAX_SEARCH_WAIT` for a slot;
+    /// beyond that, returns `RateLimited` so callers can fall back gracefully.
+    async fn await_search_slot() -> GitHubResult<()> {
+        use crate::github::search_rate_limiter::{global, AcquireOutcome};
+        const MAX_SEARCH_WAIT: std::time::Duration = std::time::Duration::from_secs(15);
+        let start = std::time::Instant::now();
+        loop {
+            match global().try_acquire() {
+                AcquireOutcome::Granted => return Ok(()),
+                AcquireOutcome::WaitFor(d) => {
+                    if start.elapsed() + d > MAX_SEARCH_WAIT {
+                        let snap = global().snapshot();
+                        return Err(GitHubError::RateLimited(snap.reset));
+                    }
+                    tokio::time::sleep(d).await;
+                }
+            }
+        }
+    }
+
     /// Get count of merged PRs for the user
     ///
     /// Note: This uses GitHub's Search API which has stricter rate limits
     /// (30 requests/minute for authenticated users). Call sequentially
     /// and handle rate limit errors gracefully.
     pub async fn get_merged_prs_count(&self, username: &str) -> GitHubResult<i32> {
+        Self::await_search_slot().await?;
         let query = format!(
             "/search/issues?q=type:pr+author:{}+is:merged&per_page=1",
             username
@@ -330,6 +354,7 @@ impl GitHubClient {
     /// (30 requests/minute for authenticated users). Call sequentially
     /// and handle rate limit errors gracefully.
     pub async fn get_closed_issues_count(&self, username: &str) -> GitHubResult<i32> {
+        Self::await_search_slot().await?;
         // Issues created by user that are closed
         let query = format!(
             "/search/issues?q=type:issue+author:{}+is:closed&per_page=1",
@@ -356,6 +381,7 @@ impl GitHubClient {
     /// (30 requests/minute for authenticated users). Call sequentially
     /// and handle rate limit errors gracefully.
     pub async fn get_total_prs_count(&self, username: &str) -> GitHubResult<i32> {
+        Self::await_search_slot().await?;
         let query = format!("/search/issues?q=type:pr+author:{}&per_page=1", username);
         let response: serde_json::Value = self.get(&query).await?;
         Ok(response
@@ -1172,13 +1198,14 @@ impl GitHubClient {
             .map(|dt| dt.timestamp())
             .unwrap_or(0);
 
-        // Search API limits (we can't query this directly, using defaults)
-        // Authenticated users: 30 requests per minute
+        // Search API has no rate-limit headers; we approximate locally via a
+        // sliding-window tracker. See `search_rate_limiter` module.
+        let snap = crate::github::search_rate_limiter::global().snapshot();
         let search_limit = RateLimit {
-            limit: 30,
-            remaining: 30, // We don't track this precisely
-            reset: Utc::now().timestamp() + 60,
-            used: 0,
+            limit: snap.limit,
+            remaining: snap.remaining,
+            reset: snap.reset,
+            used: snap.used,
         };
 
         Ok(RateLimitDetailed {

--- a/src-tauri/src/github/issues.rs
+++ b/src-tauri/src/github/issues.rs
@@ -358,6 +358,12 @@ impl IssuesClient {
         per_page: i32,
         page: i32,
     ) -> GitHubResult<GitHubSearchResponse> {
+        // Account this call in the in-process sliding-window limiter so
+        // `get_detailed_rate_limit` and `is_rate_limit_critical` reflect
+        // every Search API consumer, not just GitHubClient's.
+        super::search_rate_limiter::await_search_slot()
+            .await
+            .map_err(GitHubError::RateLimited)?;
         let url = format!(
             "{}/search/issues?q={}&per_page={}&page={}&sort=updated&order=desc",
             GITHUB_API_URL,

--- a/src-tauri/src/github/mod.rs
+++ b/src-tauri/src/github/mod.rs
@@ -6,6 +6,7 @@
 pub mod client;
 pub mod issues;
 pub mod notifications;
+pub mod search_rate_limiter;
 pub mod types;
 
 pub use client::GitHubClient;

--- a/src-tauri/src/github/search_rate_limiter.rs
+++ b/src-tauri/src/github/search_rate_limiter.rs
@@ -32,7 +32,13 @@ impl Clock for SystemClock {
 #[derive(Debug, PartialEq, Eq)]
 pub enum AcquireOutcome {
     Granted,
-    WaitFor(Duration),
+    /// Slot unavailable. Carries both the suggested sleep `duration` and the
+    /// epoch-seconds `reset` (= oldest in-window timestamp + window) so
+    /// callers can return a `RateLimited(reset)` error without re-locking.
+    WaitFor {
+        duration: Duration,
+        reset: i64,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -78,7 +84,10 @@ impl SearchRateLimiter {
 
     #[allow(dead_code)] // exposed for tests and future opt-in overrides
     pub fn with_limit(mut self, limit: u32) -> Self {
-        self.limit = limit;
+        // 1..=i32::MAX: 0 would panic on `front().expect` in `try_acquire`
+        // when the deque is empty (impossible-to-fill state), and any value
+        // above `i32::MAX` would corrupt the `u32 -> i32` cast in `snapshot()`.
+        self.limit = limit.clamp(1, i32::MAX as u32);
         self
     }
 
@@ -98,7 +107,10 @@ impl SearchRateLimiter {
 
     pub fn try_acquire(&self) -> AcquireOutcome {
         let now = self.clock.now_secs();
-        let mut deque = self.timestamps.lock().expect("SearchRateLimiter mutex poisoned");
+        let mut deque = self
+            .timestamps
+            .lock()
+            .expect("SearchRateLimiter mutex poisoned");
         self.evict_expired(&mut deque, now);
 
         if (deque.len() as u32) < self.limit {
@@ -106,14 +118,21 @@ impl SearchRateLimiter {
             AcquireOutcome::Granted
         } else {
             let oldest = *deque.front().expect("deque is full so front must exist");
-            let wait_secs = (oldest + self.window_secs - now).max(1);
-            AcquireOutcome::WaitFor(Duration::from_secs(wait_secs as u64))
+            let reset = oldest + self.window_secs;
+            let wait_secs = (reset - now).max(1);
+            AcquireOutcome::WaitFor {
+                duration: Duration::from_secs(wait_secs as u64),
+                reset,
+            }
         }
     }
 
     pub fn snapshot(&self) -> SearchSnapshot {
         let now = self.clock.now_secs();
-        let mut deque = self.timestamps.lock().expect("SearchRateLimiter mutex poisoned");
+        let mut deque = self
+            .timestamps
+            .lock()
+            .expect("SearchRateLimiter mutex poisoned");
         self.evict_expired(&mut deque, now);
 
         let used = deque.len() as i32;
@@ -185,7 +204,13 @@ mod tests {
         for _ in 0..30 {
             assert_eq!(limiter.try_acquire(), AcquireOutcome::Granted);
         }
-        assert_eq!(limiter.try_acquire(), AcquireOutcome::WaitFor(Duration::from_secs(60)));
+        assert_eq!(
+            limiter.try_acquire(),
+            AcquireOutcome::WaitFor {
+                duration: Duration::from_secs(60),
+                reset: 60,
+            }
+        );
     }
 
     #[test]
@@ -256,7 +281,10 @@ mod tests {
         }
         clock.set(59);
         match limiter.try_acquire() {
-            AcquireOutcome::WaitFor(d) => assert!(d.as_secs() >= 1),
+            AcquireOutcome::WaitFor { duration, reset } => {
+                assert!(duration.as_secs() >= 1);
+                assert_eq!(reset, 60);
+            }
             AcquireOutcome::Granted => panic!("should be at limit"),
         }
     }
@@ -282,6 +310,30 @@ mod tests {
         let limiter = SearchRateLimiter::with_clock(clock as Arc<dyn Clock>).with_limit(2);
         assert_eq!(limiter.try_acquire(), AcquireOutcome::Granted);
         assert_eq!(limiter.try_acquire(), AcquireOutcome::Granted);
-        assert!(matches!(limiter.try_acquire(), AcquireOutcome::WaitFor(_)));
+        assert!(matches!(
+            limiter.try_acquire(),
+            AcquireOutcome::WaitFor { .. }
+        ));
+    }
+
+    #[test]
+    fn with_limit_zero_clamped_to_one() {
+        let clock = FakeClock::new(0);
+        let limiter = SearchRateLimiter::with_clock(clock as Arc<dyn Clock>).with_limit(0);
+        // Clamped to 1 — first acquire succeeds, second is full.
+        assert_eq!(limiter.try_acquire(), AcquireOutcome::Granted);
+        assert!(matches!(
+            limiter.try_acquire(),
+            AcquireOutcome::WaitFor { .. }
+        ));
+    }
+
+    #[test]
+    fn with_limit_above_i32_max_clamped() {
+        let clock = FakeClock::new(0);
+        let limiter = SearchRateLimiter::with_clock(clock as Arc<dyn Clock>).with_limit(u32::MAX);
+        // `snapshot()` must not corrupt; `limit` fits in i32.
+        let snap = limiter.snapshot();
+        assert_eq!(snap.limit, i32::MAX);
     }
 }

--- a/src-tauri/src/github/search_rate_limiter.rs
+++ b/src-tauri/src/github/search_rate_limiter.rs
@@ -1,0 +1,287 @@
+//! Sliding-window rate limit tracker for GitHub Search API.
+//!
+//! GitHub does not expose the Search API rate limit via response headers, so we
+//! approximate it in-process by recording call timestamps and evicting entries
+//! older than the rolling window (default: 60 seconds, 30 requests/min for
+//! authenticated users).
+//!
+//! `GitHubClient` is constructed per Tauri command invocation, so the limiter
+//! lives as a process-global behind `OnceLock`.
+
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::Duration;
+
+/// Authenticated user limit per minute. Unauthenticated callers actually have
+/// 10/min — out of scope for this issue; override via `with_limit` if needed.
+pub const DEFAULT_SEARCH_LIMIT: u32 = 30;
+pub const DEFAULT_WINDOW_SECS: i64 = 60;
+
+pub trait Clock: Send + Sync {
+    fn now_secs(&self) -> i64;
+}
+
+pub struct SystemClock;
+
+impl Clock for SystemClock {
+    fn now_secs(&self) -> i64 {
+        chrono::Utc::now().timestamp()
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum AcquireOutcome {
+    Granted,
+    WaitFor(Duration),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SearchSnapshot {
+    pub limit: i32,
+    pub remaining: i32,
+    pub reset: i64,
+    pub used: i32,
+}
+
+pub struct SearchRateLimiter {
+    limit: u32,
+    window_secs: i64,
+    timestamps: Mutex<VecDeque<i64>>,
+    clock: Arc<dyn Clock>,
+}
+
+impl Default for SearchRateLimiter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SearchRateLimiter {
+    pub fn new() -> Self {
+        Self {
+            limit: DEFAULT_SEARCH_LIMIT,
+            window_secs: DEFAULT_WINDOW_SECS,
+            timestamps: Mutex::new(VecDeque::with_capacity(DEFAULT_SEARCH_LIMIT as usize)),
+            clock: Arc::new(SystemClock),
+        }
+    }
+
+    #[allow(dead_code)] // exposed for tests and future opt-in overrides
+    pub fn with_clock(clock: Arc<dyn Clock>) -> Self {
+        Self {
+            limit: DEFAULT_SEARCH_LIMIT,
+            window_secs: DEFAULT_WINDOW_SECS,
+            timestamps: Mutex::new(VecDeque::with_capacity(DEFAULT_SEARCH_LIMIT as usize)),
+            clock,
+        }
+    }
+
+    #[allow(dead_code)] // exposed for tests and future opt-in overrides
+    pub fn with_limit(mut self, limit: u32) -> Self {
+        self.limit = limit;
+        self
+    }
+
+    /// Drop timestamps older than the window. Also treats a backward clock
+    /// jump (`now < oldest`) as a signal to evict everything — safer than
+    /// leaving stale entries that would never age out.
+    fn evict_expired(&self, deque: &mut VecDeque<i64>, now: i64) {
+        let cutoff = now - self.window_secs;
+        while let Some(&front) = deque.front() {
+            if front <= cutoff || front > now {
+                deque.pop_front();
+            } else {
+                break;
+            }
+        }
+    }
+
+    pub fn try_acquire(&self) -> AcquireOutcome {
+        let now = self.clock.now_secs();
+        let mut deque = self.timestamps.lock().expect("SearchRateLimiter mutex poisoned");
+        self.evict_expired(&mut deque, now);
+
+        if (deque.len() as u32) < self.limit {
+            deque.push_back(now);
+            AcquireOutcome::Granted
+        } else {
+            let oldest = *deque.front().expect("deque is full so front must exist");
+            let wait_secs = (oldest + self.window_secs - now).max(1);
+            AcquireOutcome::WaitFor(Duration::from_secs(wait_secs as u64))
+        }
+    }
+
+    pub fn snapshot(&self) -> SearchSnapshot {
+        let now = self.clock.now_secs();
+        let mut deque = self.timestamps.lock().expect("SearchRateLimiter mutex poisoned");
+        self.evict_expired(&mut deque, now);
+
+        let used = deque.len() as i32;
+        let limit = self.limit as i32;
+        let remaining = (limit - used).max(0);
+        let reset = deque
+            .front()
+            .map(|oldest| oldest + self.window_secs)
+            .unwrap_or(now + self.window_secs);
+
+        SearchSnapshot {
+            limit,
+            remaining,
+            reset,
+            used,
+        }
+    }
+}
+
+/// Process-global limiter. `GitHubClient` is constructed per command, so the
+/// limiter cannot live on the client struct.
+pub fn global() -> &'static SearchRateLimiter {
+    static G: OnceLock<SearchRateLimiter> = OnceLock::new();
+    G.get_or_init(SearchRateLimiter::new)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicI64, Ordering};
+
+    struct FakeClock(AtomicI64);
+
+    impl FakeClock {
+        fn new(start: i64) -> Arc<Self> {
+            Arc::new(Self(AtomicI64::new(start)))
+        }
+        fn set(&self, t: i64) {
+            self.0.store(t, Ordering::SeqCst);
+        }
+    }
+
+    impl Clock for FakeClock {
+        fn now_secs(&self) -> i64 {
+            self.0.load(Ordering::SeqCst)
+        }
+    }
+
+    fn limiter_with(clock: Arc<FakeClock>) -> SearchRateLimiter {
+        SearchRateLimiter::with_clock(clock as Arc<dyn Clock>)
+    }
+
+    #[test]
+    fn acquire_under_limit_returns_granted() {
+        let clock = FakeClock::new(0);
+        let limiter = limiter_with(clock);
+        for _ in 0..29 {
+            assert_eq!(limiter.try_acquire(), AcquireOutcome::Granted);
+        }
+        let snap = limiter.snapshot();
+        assert_eq!(snap.used, 29);
+        assert_eq!(snap.remaining, 1);
+    }
+
+    #[test]
+    fn acquire_at_limit_returns_wait() {
+        let clock = FakeClock::new(0);
+        let limiter = limiter_with(clock);
+        for _ in 0..30 {
+            assert_eq!(limiter.try_acquire(), AcquireOutcome::Granted);
+        }
+        assert_eq!(limiter.try_acquire(), AcquireOutcome::WaitFor(Duration::from_secs(60)));
+    }
+
+    #[test]
+    fn oldest_ages_out_after_window() {
+        let clock = FakeClock::new(0);
+        let limiter = limiter_with(clock.clone());
+        for _ in 0..30 {
+            limiter.try_acquire();
+        }
+        clock.set(61);
+        assert_eq!(limiter.try_acquire(), AcquireOutcome::Granted);
+        let snap = limiter.snapshot();
+        // All 30 original entries aged out (cutoff = 61 - 60 = 1, so ts=0 is evicted)
+        // Only the new entry at t=61 remains.
+        assert_eq!(snap.used, 1);
+        assert_eq!(snap.remaining, 29);
+    }
+
+    #[test]
+    fn partial_aging() {
+        let clock = FakeClock::new(0);
+        let limiter = limiter_with(clock.clone());
+        for _ in 0..10 {
+            limiter.try_acquire();
+        }
+        clock.set(30);
+        for _ in 0..10 {
+            limiter.try_acquire();
+        }
+        clock.set(61);
+        // cutoff = 1: ts=0 entries evicted, ts=30 entries kept.
+        let snap = limiter.snapshot();
+        assert_eq!(snap.used, 10);
+        assert_eq!(snap.remaining, 20);
+        // reset = oldest (30) + window (60) = 90
+        assert_eq!(snap.reset, 90);
+    }
+
+    #[test]
+    fn snapshot_when_empty() {
+        let clock = FakeClock::new(100);
+        let limiter = limiter_with(clock);
+        let snap = limiter.snapshot();
+        assert_eq!(snap.limit, 30);
+        assert_eq!(snap.remaining, 30);
+        assert_eq!(snap.used, 0);
+        assert_eq!(snap.reset, 160);
+    }
+
+    #[test]
+    fn snapshot_reset_uses_oldest_plus_window() {
+        let clock = FakeClock::new(0);
+        let limiter = limiter_with(clock.clone());
+        limiter.try_acquire();
+        clock.set(5);
+        limiter.try_acquire();
+        let snap = limiter.snapshot();
+        assert_eq!(snap.reset, 0 + 60);
+        assert_eq!(snap.used, 2);
+    }
+
+    #[test]
+    fn wait_duration_non_negative() {
+        let clock = FakeClock::new(0);
+        let limiter = limiter_with(clock.clone());
+        for _ in 0..30 {
+            limiter.try_acquire();
+        }
+        clock.set(59);
+        match limiter.try_acquire() {
+            AcquireOutcome::WaitFor(d) => assert!(d.as_secs() >= 1),
+            AcquireOutcome::Granted => panic!("should be at limit"),
+        }
+    }
+
+    #[test]
+    fn clock_jump_backward_safe() {
+        let clock = FakeClock::new(1000);
+        let limiter = limiter_with(clock.clone());
+        for _ in 0..30 {
+            limiter.try_acquire();
+        }
+        // Clock jumps backward past all recorded timestamps.
+        clock.set(100);
+        // Evicts everything (front > now branch), so we can acquire again.
+        assert_eq!(limiter.try_acquire(), AcquireOutcome::Granted);
+        let snap = limiter.snapshot();
+        assert_eq!(snap.used, 1);
+    }
+
+    #[test]
+    fn with_limit_overrides_default() {
+        let clock = FakeClock::new(0);
+        let limiter = SearchRateLimiter::with_clock(clock as Arc<dyn Clock>).with_limit(2);
+        assert_eq!(limiter.try_acquire(), AcquireOutcome::Granted);
+        assert_eq!(limiter.try_acquire(), AcquireOutcome::Granted);
+        assert!(matches!(limiter.try_acquire(), AcquireOutcome::WaitFor(_)));
+    }
+}

--- a/src-tauri/src/github/search_rate_limiter.rs
+++ b/src-tauri/src/github/search_rate_limiter.rs
@@ -91,13 +91,22 @@ impl SearchRateLimiter {
         self
     }
 
-    /// Drop timestamps older than the window. Also treats a backward clock
-    /// jump (`now < oldest`) as a signal to evict everything — safer than
-    /// leaving stale entries that would never age out.
+    /// Drop timestamps older than the window. Only treats a *large* backward
+    /// clock jump (every entry more than a full window in the future) as a
+    /// corrupted-clock signal that warrants flushing the bucket. Small
+    /// rollbacks (NTP correction, brief desync) keep the bucket intact so we
+    /// don't over-grant a Search burst — those entries naturally age out as
+    /// the clock advances past `ts + window`.
     fn evict_expired(&self, deque: &mut VecDeque<i64>, now: i64) {
+        if let Some(&front) = deque.front() {
+            if front.saturating_sub(now) > self.window_secs {
+                deque.clear();
+                return;
+            }
+        }
         let cutoff = now - self.window_secs;
         while let Some(&front) = deque.front() {
-            if front <= cutoff || front > now {
+            if front <= cutoff {
                 deque.pop_front();
             } else {
                 break;
@@ -296,12 +305,31 @@ mod tests {
         for _ in 0..30 {
             limiter.try_acquire();
         }
-        // Clock jumps backward past all recorded timestamps.
+        // Large backward jump (900s) is treated as corrupted clock: bucket
+        // is flushed so we don't block Search until the clock catches back up.
         clock.set(100);
-        // Evicts everything (front > now branch), so we can acquire again.
         assert_eq!(limiter.try_acquire(), AcquireOutcome::Granted);
         let snap = limiter.snapshot();
         assert_eq!(snap.used, 1);
+    }
+
+    #[test]
+    fn small_clock_rollback_preserves_bucket() {
+        // NTP correction / brief time desync (rollback <= window) must NOT
+        // wipe the bucket — otherwise the next acquire could over-grant a
+        // fresh 30-request burst and exceed GitHub's real Search quota.
+        let clock = FakeClock::new(1000);
+        let limiter = limiter_with(clock.clone());
+        for _ in 0..30 {
+            limiter.try_acquire();
+        }
+        clock.set(998); // 2-second rollback (typical NTP correction)
+        assert!(matches!(
+            limiter.try_acquire(),
+            AcquireOutcome::WaitFor { .. }
+        ));
+        let snap = limiter.snapshot();
+        assert_eq!(snap.used, 30);
     }
 
     #[test]

--- a/src-tauri/src/github/search_rate_limiter.rs
+++ b/src-tauri/src/github/search_rate_limiter.rs
@@ -123,7 +123,19 @@ impl SearchRateLimiter {
         self.evict_expired(&mut deque, now);
 
         if (deque.len() as u32) < self.limit {
-            deque.push_back(now);
+            // Keep timestamps monotonically non-decreasing. A small backward
+            // clock correction (NTP) would otherwise push a `now` smaller
+            // than `back`, breaking front-based eviction: expired entries
+            // could end up behind a newer-but-larger front entry and never
+            // be popped. Clamping to `max(now, back)` records the slot at
+            // the most recent observed instant, which is correct
+            // safe-side: the entry ages out a touch later than wall-clock
+            // would suggest, never earlier.
+            let recorded = match deque.back() {
+                Some(&last) if last > now => last,
+                _ => now,
+            };
+            deque.push_back(recorded);
             AcquireOutcome::Granted
         } else {
             let oldest = *deque.front().expect("deque is full so front must exist");
@@ -166,6 +178,33 @@ impl SearchRateLimiter {
 pub fn global() -> &'static SearchRateLimiter {
     static G: OnceLock<SearchRateLimiter> = OnceLock::new();
     G.get_or_init(SearchRateLimiter::new)
+}
+
+/// Reserve a Search API slot from the process-global sliding-window limiter.
+///
+/// Waits up to `MAX_SEARCH_WAIT` for a free slot. If the cumulative wait
+/// would exceed that budget, returns `Err(reset_ts)` so the caller can map
+/// it to its own rate-limit error type and let upstream fallback paths
+/// (e.g. GraphQL substitutes) take over.
+///
+/// Centralising the helper here means every Search API caller — whether
+/// from `GitHubClient` or `IssuesClient` — shares the same sliding-window
+/// accounting, which is required for `get_detailed_rate_limit` and
+/// `is_rate_limit_critical` to reflect real usage.
+pub async fn await_search_slot() -> Result<(), i64> {
+    const MAX_SEARCH_WAIT: Duration = Duration::from_secs(15);
+    let start = std::time::Instant::now();
+    loop {
+        match global().try_acquire() {
+            AcquireOutcome::Granted => return Ok(()),
+            AcquireOutcome::WaitFor { duration, reset } => {
+                if start.elapsed() + duration > MAX_SEARCH_WAIT {
+                    return Err(reset);
+                }
+                tokio::time::sleep(duration).await;
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -330,6 +369,28 @@ mod tests {
         ));
         let snap = limiter.snapshot();
         assert_eq!(snap.used, 30);
+    }
+
+    #[test]
+    fn rollback_push_preserves_eviction_order() {
+        // Regression: before clamping, a backward clock jump could push a
+        // timestamp out of order, hiding older entries behind a newer front.
+        // After the fix, all 5 entries must evict cleanly once the wall
+        // clock has moved past `recorded + window`.
+        let clock = FakeClock::new(1100);
+        let limiter = limiter_with(clock.clone());
+        for _ in 0..3 {
+            limiter.try_acquire(); // recorded at 1100
+        }
+        clock.set(1095); // 5s backward jump (small, bucket preserved)
+        limiter.try_acquire(); // would naively record 1095 < back=1100
+        limiter.try_acquire(); // another one
+
+        // Move past the window (1100 + 60 = 1160). Every entry should age out.
+        clock.set(1161);
+        let snap = limiter.snapshot();
+        assert_eq!(snap.used, 0, "all entries must evict, none left behind");
+        assert_eq!(snap.remaining, 30);
     }
 
     #[test]


### PR DESCRIPTION
GitHub does not expose Search API headers, so `get_detailed_rate_limit`
previously returned 30/30 unconditionally and `is_rate_limit_critical`
could never flag Search exhaustion. Track call timestamps in a 60s
sliding window so `RateLimitDetailed.search` reflects real usage, and
gate the three Search call sites on slot availability — waiting up to
15s before falling back via `GitHubError::RateLimited`.

https://claude.ai/code/session_01G7P6RMfvcKaMf2ePghArng

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * アプリ内でGitHub検索リクエスト向けのプロセス全体レートリミッタを導入しました。
  * 検索系の操作はリミッタの空きスロットを待機してから実行されるようになりました。

* **改善**
  * レート制限表示が実際のスライディングウィンドウの状態に基づいて正確に報告され、残り回数やリセット時刻の信頼性が向上しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otomatty/development-tools/pull/218)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->