### PR TITLE
fix(deps): repair Dependabot major-bump breakage on main

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -63,9 +63,10 @@ base64 = "0.22"
 # Pinned to ^3: keyring v4 was an architectural rewrite where the main
 # crate became a re-export shell and platform backends moved to separate
 # `keyring-core` + per-platform credential-store crates. The v4 README
-# explicitly tells v3 users not to upgrade in place — the migration
-# requires a full rewrite of the `OsKeyStore` impl. Reassess once v4
-# stabilises a drop-in replacement path.
+# explicitly tells v3 users not to upgrade in place — no drop-in path
+# is planned. Migrating requires a full rewrite of the `OsKeyStore`
+# impl against the new trait/registration API; track as a future task
+# and reassess when that work can be prioritised.
 keyring = { version = "3", features = [
     "apple-native",
     "windows-native",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -59,7 +59,14 @@ base64 = "0.22"
 # fail at `TokenManager::new`; only unit tests inject `MemoryKeyStore`
 # manually via `TokenManager::with_keystore`. See `auth::keystore` for
 # the full security model.
-keyring = { version = "4", features = [
+#
+# Pinned to ^3: keyring v4 was an architectural rewrite where the main
+# crate became a re-export shell and platform backends moved to separate
+# `keyring-core` + per-platform credential-store crates. The v4 README
+# explicitly tells v3 users not to upgrade in place — the migration
+# requires a full rewrite of the `OsKeyStore` impl. Reassess once v4
+# stabilises a drop-in replacement path.
+keyring = { version = "3", features = [
     "apple-native",
     "windows-native",
     "sync-secret-service",

--- a/src/components/icons/Icon.tsx
+++ b/src/components/icons/Icon.tsx
@@ -73,6 +73,8 @@ const iconNameMap: Record<string, keyof typeof LucideIcons> = {
   'clock': 'Clock',
   // lucide-react v1 dropped brand icons (incl. `Github`). `GitGraph` is the
   // closest neutral substitute for the ActivityTimeline default-event fallback.
+  // TODO: integrate a dedicated brand-icon library (e.g. simple-icons) once a
+  // GitHub mark is needed for a user-facing affordance like a login button.
   'github': 'GitGraph',
   'link': 'Link',
   'refresh': 'RefreshCw',

--- a/src/components/icons/Icon.tsx
+++ b/src/components/icons/Icon.tsx
@@ -71,7 +71,9 @@ const iconNameMap: Record<string, keyof typeof LucideIcons> = {
   'git-pull-request-closed': 'GitPullRequestClosed',
   'git-pull-request-draft': 'GitPullRequestDraft',
   'clock': 'Clock',
-  'github': 'Github',
+  // lucide-react v1 dropped brand icons (incl. `Github`). `GitGraph` is the
+  // closest neutral substitute for the ActivityTimeline default-event fallback.
+  'github': 'GitGraph',
   'link': 'Link',
   'refresh': 'RefreshCw',
   'circle': 'Circle',

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,8 +13,7 @@
     "noEmit": true,
     "paths": {
       "@/*": ["./src/*"]
-    },
-    "baseUrl": "."
+    }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
   "exclude": ["node_modules", "src/**/*.rs", "src-tauri"]


### PR DESCRIPTION
## Summary
Three of the four Dependabot PRs merged into `main` earlier today (`#222` keyring, `#221` lucide-react, `#204` typescript) shipped with failing CI. This PR repairs `main` by handling the breaking changes individually.

- **keyring `^4` → `^3`** (`src-tauri/Cargo.toml`) — v4 is an architectural rewrite (functionality moved to `keyring-core` + per-platform credential-store crates; all v3 feature flags removed). The v4 README explicitly tells v3 users not to upgrade in place. A real migration requires rewriting `OsKeyStore` against the new trait API; revert until upstream offers a drop-in path.
- **`'Github'` → `'GitGraph'`** (`src/components/icons/Icon.tsx`) — lucide-react v1 dropped all brand icons, leaving the icon map's `'github' → 'Github'` entry as a type error. The only caller is `ActivityTimeline`'s default-event fallback, where a generic repo-activity glyph reads fine.
- **Drop deprecated `baseUrl`** (`tsconfig.json`) — silences TS5101 under typescript 6. With `moduleResolution: "bundler"` the `@/*` paths mapping resolves relative to the tsconfig file, so `baseUrl: "."` was only a TS<6 shim.
- **Add `vite/client` ambient types** (`src/vite-env.d.ts`) — gives the side-effect `import '/styles.css'` in `main.tsx` a declaration under TS6's stricter unresolved-module check (TS2882).

## Local verification
- `cargo check --workspace`  ✅
- `cargo fmt --all -- --check`  ✅
- `tsc --noEmit`  ✅
- `vite build` (after `build:css`)  ✅
- `cargo clippy --all-targets` / `cargo test` — not runnable locally (sandbox lacks GTK3 dev libs); CI installs `libwebkit2gtk-4.1-dev libgtk-3-dev …` before these jobs, and the keyring v3 code path was previously green on `#219`.

## Test plan
- [ ] Format Check, Clippy, Test, Build Tauri (Ubuntu), Build Frontend (Solid.js/Vite), Build Frontend (Leptos/WASM), Code Coverage, Security Audit, License Check all green
- [ ] Consider adding `ignore: dependency-name: keyring, update-types: ["version-update:semver-major"]` to `.github/dependabot.yml` so Dependabot doesn't re-propose the v4 bump (out of scope for this PR — open as a follow-up if desired)

https://claude.ai/code/session_01H1FLu1j7HtWgkYD33HgGpf

---
_Generated by [Claude Code](https://claude.ai/code/session_01H1FLu1j7HtWgkYD33HgGpf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * GitHubアイコンの表示を改善しました（代替アイコンへの切替を含む）。
* **Chores**
  * セキュリティ関連ライブラリを一時的に旧バージョンへ差し戻しました。
  * TypeScript 開発環境を調整しました（Vite 型定義を追加、パス解決設定を簡素化）。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otomatty/development-tools/pull/223)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->