### PR TITLE
deps: consolidate Dependabot Rust and CI updates (sqlx 0.9, codecov-action 7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
             --ignore-tests
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v7
         with:
           files: ./cobertura.xml
           fail_ci_if_error: false

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -34,7 +34,7 @@ chrono = { version = "0.4", features = ["serde"] }
 dirs = "6"
 
 # Database
-sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite"] }
+sqlx = { version = "0.9", features = ["runtime-tokio", "sqlite"] }
 tokio = { version = "1", features = ["full"] }
 
 # HTTP Client for GitHub API


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Status: merged to `main`

Changes were integrated directly to `main`:

- `0eb6470` — sqlx 0.9 + codecov-action 7
- `cefd17a` — npm consolidation (included in subsequent main commit)

This PR can be closed.

## Summary

Consolidates two open Dependabot PRs:

- **sqlx** 0.8 → 0.9
- **codecov/codecov-action** 6 → 7

## Supersedes

#230, #232

## Not merged (close separately)

#227 (keyring v4 — pinned to v3 per #223)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-330123e0-ce17-483d-abd9-584f89dec3b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-330123e0-ce17-483d-abd9-584f89dec3b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

